### PR TITLE
Github Actions for Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags: 
+      - "v*"
+
+jobs:
+  build:
+    name: Upload .vxis in release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Install Dependencies
+        run: yarn
+      
+      - name: VSIX Package
+        run: yarn run package
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ESP IDF VSCode Extension Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./esp-idf-extension.vsix
+          asset_name: esp-idf-extension-${{ github.ref }}.vsix
+          asset_content_type: application/zip
+          
+      - name: Marketplace release
+        run: yarn run release
+        env:
+          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
Add workflow to create automated release when there are tagged commits pushed.
- Release to the VSCode Marketplace
- Release to the Github Releases and Upload the `.vsix` generated