### PR TITLE
fix python env bin update after re onboarding (VSC-247)

### DIFF
--- a/src/onboarding/pythonReqsManager.ts
+++ b/src/onboarding/pythonReqsManager.ts
@@ -72,7 +72,7 @@ export async function installPythonRequirements(workingDir: string) {
     const idfToolsPath = idfConf.readParameter("idf.toolsPath") as string;
     const logTracker = new PyReqLog(sendPyReqLog);
     process.env.IDF_PATH = espIdfPath || process.env.IDF_PATH;
-    await pythonManager.installPythonEnv(
+    return await pythonManager.installPythonEnv(
         espIdfPath, idfToolsPath, logTracker, pythonBinPath, OutputChannel.init())
         .then((virtualEnvPythonBin) => {
             if (virtualEnvPythonBin) {
@@ -81,6 +81,7 @@ export async function installPythonRequirements(workingDir: string) {
                 if (logTracker.Log.indexOf("Exception") < 0) {
                     OnBoardingPanel.postMessage({ command: "set_py_setup_finish" });
                 }
+                return virtualEnvPythonBin;
             } else {
                 OutputChannel.appendLine("Python requirements has not been installed.");
             }

--- a/src/onboarding/toolsInstall.ts
+++ b/src/onboarding/toolsInstall.ts
@@ -76,13 +76,13 @@ export async function downloadToolsInIdfToolsPath(workingDir: string,
         });
         OutputChannel.appendLine("Installing python virtualenv and ESP-IDF python requirements...");
         Logger.info("Installing python virtualenv and ESP-IDF python requirements...");
-        await installPythonRequirements(workingDir).catch((reason) => {
+        const pyEnvResult = await installPythonRequirements(workingDir).catch((reason) => {
             OutputChannel.appendLine(reason);
             Logger.info(reason);
         });
         let exportPaths = await idfToolsManager.exportPaths(path.join(installDir, "tools"));
         const pythonSystemBinPath = idfConf.readParameter("idf.pythonSystemBinPath") as string;
-        const pythonBinPath = idfConf.readParameter("idf.pythonBinPath") as string;
+        const pythonBinPath =  pyEnvResult || idfConf.readParameter("idf.pythonBinPath") as string;
         // Append System Python and Virtual Env Python to PATH
         exportPaths = path.dirname(pythonBinPath) + path.delimiter +
             path.dirname(pythonSystemBinPath) + path.delimiter + exportPaths;


### PR DESCRIPTION
Fix Python env binary path in idf.customExtraPaths after running onboarding a second time.

VSC-232

