### PR TITLE
configuration save destination (VSC-255)

### DIFF
--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -3,6 +3,7 @@
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Add vscode configuration folder",
   "espIdf.setPath.title": "ESP-IDF: Configure Paths",
   "espIdf.setTarget.title": "ESP-IDF: Set Espressif device target",
+  "espIdf.selectConfTarget.title": "ESP-IDF: Select where to save configuration settings",
   "espIdf.configDevice.title": "ESP-IDF:Device configuration",
   "menuconfig.start.title": "ESP-IDF: Launch gui configuration tool",
   "espIdf.setDefaultConfig.title": "ESP-IDF: Set default sdkconfig file in project",
@@ -41,5 +42,6 @@
   "trace.stop_tmo.description": "stop_tmo will be set for the apptrace",
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
-  "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways"
+  "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways",
+  "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -2,6 +2,7 @@
   "espIdf.createFiles.title": "ESP-IDF: Crear proyecto",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Agregar carpeta de configuración vscode",
   "espIdf.setPath.title": "ESP-IDF: Configurar rutas ESP-IDF",
+  "espIdf.selectConfTarget.title": "ESP-IDF: Selecciona donde almacenar tu configuración",
   "espIdf.setTarget.title": "ESP-IDF: Selecciona el dispositivo Espressif a utilizar",
   "espIdf.configDevice.title": "ESP-IDF: Configuración del dispositivo",
   "menuconfig.start.title": "ESP-IDF: Abrir herramienta de configuración ESP-IDF GUI",
@@ -41,5 +42,6 @@
   "trace.stop_tmo.description": "stop_tmo will be set for the apptrace",
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
-  "param.saveBeforeBuildDescription": "Guarde todos los archivos editados en el espacio de trabajo antes de continuar con la compilación, aunque si no guarda los archivos, se compilará de todos modos"
+  "param.saveBeforeBuildDescription": "Guarde todos los archivos editados en el espacio de trabajo antes de continuar con la compilación, aunque si no guarda los archivos, se compilará de todos modos",
+  "param.saveScope": "Dónde se almacena las configuraciones para comandos ESP-IDF usando enum vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -2,6 +2,7 @@
   "espIdf.createFiles.title": "ESP-IDF: 新建项目",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: 添加 vscode 配置文件夹",
   "espIdf.setPath.title": "ESP-IDF：配置路径",
+  "espIdf.selectConfTarget.title": "ESP-IDF：选择保存配置设置的位置",
   "espIdf.setTarget.title": "ESP-IDF: 设置espressif设备目标",
   "espIdf.configDevice.title": "ESP-IDF：配置设备",
   "menuconfig.start.title": "ESP-IDF：启动 GUI 配置工具",
@@ -41,5 +42,6 @@
   "trace.stop_tmo.description": "apptrace：设置 stop_tmo",
   "trace.wait4halt.description": "apptrace：设置 wait4halt",
   "trace.skip_size.description": "apptrace：设置 skip_size",
-  "param.saveBeforeBuildDescription": "在继续进行构建之前，将所有编辑的文件保存在工作区中，尽管如果无法保存文件，无论如何都会进行构建"
+  "param.saveBeforeBuildDescription": "在继续进行构建之前，将所有编辑的文件保存在工作区中，尽管如果无法保存文件，无论如何都会进行构建",
+  "param.saveScope": "使用编号为vscode.ConfigurationTarget的ESP-IDF命令将配置保存到何处. Global = 1, Workspace= 2, WorkspaceFolder=3"
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "onCommand:espIdf.createFiles",
     "onCommand:espIdf.createVsCodeFolder",
     "onCommand:espIdf.setPath",
+    "onCommand:espIdf.selectConfTarget",
     "onCommand:espIdf.configDevice",
     "onCommand:menuconfig.start",
     "onCommand:espIdf.setDefaultConfig",
@@ -298,6 +299,22 @@
             "default": true,
             "scope": "resource",
             "description": "%param.saveBeforeBuildDescription%"
+          },
+          "idf.saveScope": {
+            "type": "number",
+            "default": "1",
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "enumDescriptions": [
+              "Global",
+              "Workspace",
+              "WorkspaceFolder"
+            ],
+            "scope": "resource",
+            "description": "%param.saveScope%"
           }
         }
       }
@@ -314,6 +331,10 @@
       {
         "command": "espIdf.setPath",
         "title": "%espIdf.setPath.title%"
+      },
+      {
+        "command": "espIdf.selectConfTarget",
+        "title": "%espIdf.selectConfTarget.title%"
       },
       {
         "command": "espIdf.setTarget",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
   "espIdf.createFiles.title": "ESP-IDF: Create project",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Add vscode configuration folder",
   "espIdf.setPath.title": "ESP-IDF: Configure Paths",
+  "espIdf.selectConfTarget.title": "ESP-IDF: Select where to save configuration settings",
   "espIdf.setTarget.title": "ESP-IDF: Set Espressif device target",
   "espIdf.configDevice.title": "ESP-IDF: Device configuration",
   "menuconfig.start.title": "ESP-IDF: Launch gui configuration tool",
@@ -41,5 +42,6 @@
   "trace.stop_tmo.description": "stop_tmo will be set for the apptrace",
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
-  "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways"
+  "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways",
+  "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3"
 }

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -71,6 +71,7 @@
     "espIdf.createFiles.title",
     "espIdf.createVsCodeFolder.title",
     "espIdf.setPath.title",
+    "espIdf.selectConfTarget.title",
     "espIdf.setTarget.title",
     "espIdf.configDevice.title",
     "menuconfig.start.title",
@@ -110,6 +111,7 @@
     "trace.stop_tmo.description",
     "trace.wait4halt.description",
     "trace.skip_size.description",
-    "param.saveBeforeBuildDescription"
+    "param.saveBeforeBuildDescription",
+    "param.saveScope"
   ]
 }

--- a/src/espIdf/apptrace/appTraceManager.ts
+++ b/src/espIdf/apptrace/appTraceManager.ts
@@ -109,7 +109,7 @@ export class AppTraceManager extends EventEmitter {
       validateInput: validatorFunction,
     });
     if (userInput) {
-      const target = await idfConf.chooseConfigurationTarget();
+      const target = idfConf.readParameter("idf.saveScope");
       await idfConf.writeParameter(paramName, userInput, target);
     }
   }

--- a/src/espIdf/apptrace/appTraceManager.ts
+++ b/src/espIdf/apptrace/appTraceManager.ts
@@ -109,7 +109,8 @@ export class AppTraceManager extends EventEmitter {
       validateInput: validatorFunction,
     });
     if (userInput) {
-      await idfConf.writeParameter(paramName, userInput);
+      const target = await idfConf.chooseConfigurationTarget();
+      await idfConf.writeParameter(paramName, userInput, target);
     }
   }
 

--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -20,7 +20,7 @@ import * as vscode from "vscode";
 import * as idfConf from "../../idfConfiguration";
 import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
-import { PreCheck, spawn } from "../../utils";
+import { spawn } from "../../utils";
 import { SerialPortDetails } from "./serialPortDetails";
 
 export class SerialPort {
@@ -71,12 +71,14 @@ export class SerialPort {
   }
 
   private async updatePortListStatus(l: string) {
-    await idfConf.writeParameter("idf.port", l);
-    const portHasBeenSelectedMsg = this.locDic.localize(
-      "serial.portHasBeenSelectedMessage",
-      "Port has been updated to "
-    );
-    Logger.infoNotify(portHasBeenSelectedMsg + l);
+    await idfConf.chooseConfigurationTarget().then(async (target) => {
+      await idfConf.writeParameter("idf.port", l, target);
+      const portHasBeenSelectedMsg = this.locDic.localize(
+        "serial.portHasBeenSelectedMessage",
+        "Port has been updated to "
+      );
+      Logger.infoNotify(portHasBeenSelectedMsg + l);
+    });
   }
 
   private list(): Thenable<SerialPortDetails[]> {

--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -71,14 +71,13 @@ export class SerialPort {
   }
 
   private async updatePortListStatus(l: string) {
-    await idfConf.chooseConfigurationTarget().then(async (target) => {
-      await idfConf.writeParameter("idf.port", l, target);
-      const portHasBeenSelectedMsg = this.locDic.localize(
-        "serial.portHasBeenSelectedMessage",
-        "Port has been updated to "
-      );
-      Logger.infoNotify(portHasBeenSelectedMsg + l);
-    });
+    const target = idfConf.readParameter("idf.saveScope");
+    await idfConf.writeParameter("idf.port", l, target);
+    const portHasBeenSelectedMsg = this.locDic.localize(
+      "serial.portHasBeenSelectedMessage",
+      "Port has been updated to "
+    );
+    Logger.infoNotify(portHasBeenSelectedMsg + l);
   }
 
   private list(): Thenable<SerialPortDetails[]> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -590,7 +590,7 @@ export async function activate(context: vscode.ExtensionContext) {
             configurationTarget
           );
           if (selected.target === "esp32") {
-            idfConf.writeParameter(
+            await idfConf.writeParameter(
               "idf.openOcdConfigs",
               ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"],
               configurationTarget

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -585,21 +585,25 @@ export async function activate(context: vscode.ExtensionContext) {
           if (typeof selected === "undefined") {
             return;
           }
+          const configurationTarget = await idfConf.chooseConfigurationTarget();
           await idfConf.writeParameter(
             "idf.adapterTargetName",
-            selected.target
+            selected.target,
+            configurationTarget
           );
           if (selected.target === "esp32") {
-            idfConf.writeParameter("idf.openOcdConfigs", [
-              "interface/ftdi/esp32_devkitj_v1.cfg",
-              "board/esp32-wrover.cfg",
-            ]);
+            idfConf.writeParameter(
+              "idf.openOcdConfigs",
+              ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"],
+              configurationTarget
+            );
           }
           if (selected.target === "esp32s2") {
-            await idfConf.writeParameter("idf.openOcdConfigs", [
-              "interface/ftdi/esp32_devkitj_v1.cfg",
-              "target/esp32s2.cfg",
-            ]);
+            await idfConf.writeParameter(
+              "idf.openOcdConfigs",
+              ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s2.cfg"],
+              configurationTarget
+            );
           }
           const idfPathDir = idfConf.readParameter("idf.espIdfPath");
           const idfPy = path.join(idfPathDir, "tools", "idf.py");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,6 +291,10 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerIDFCommand("espIdf.selectConfTarget", () => {
+    idfConf.chooseConfigurationTarget();
+  });
+
   registerIDFCommand("espIdf.setPath", () => {
     PreCheck.perform([webIdeCheck], () => {
       const selectFrameworkMsg = locDic.localize(
@@ -583,7 +587,7 @@ export async function activate(context: vscode.ExtensionContext) {
           if (typeof selected === "undefined") {
             return;
           }
-          const configurationTarget = await idfConf.chooseConfigurationTarget();
+          const configurationTarget = idfConf.readParameter("idf.saveScope");
           await idfConf.writeParameter(
             "idf.adapterTargetName",
             selected.target,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,7 +292,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.setPath", () => {
-    PreCheck.perform([webIdeCheck, openFolderCheck], () => {
+    PreCheck.perform([webIdeCheck], () => {
       const selectFrameworkMsg = locDic.localize(
         "selectFrameworkMessage",
         "Select framework to define its path:"
@@ -370,101 +370,99 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.configDevice", () => {
-    PreCheck.perform([openFolderCheck], () => {
-      const selectConfigMsg = locDic.localize(
-        "extension.selectConfigMessage",
-        "Select option to define its path :"
-      );
-      vscode.window
-        .showQuickPick(
-          [
-            {
-              description: "Device target (esp32, esp32s2)",
-              label: "Device Target",
-              target: "deviceTarget",
-            },
-            {
-              description: "Device port path",
-              label: "Device Port",
-              target: "devicePort",
-            },
-            {
-              description: "Baud rate of device",
-              label: "Baud Rate",
-              target: "baudRate",
-            },
-            {
-              description:
-                "Relative paths to OpenOCD Scripts directory separated by comma(,)",
-              label: "OpenOcd Config Files",
-              target: "openOcdConfig",
-            },
-          ],
-          { placeHolder: selectConfigMsg }
-        )
-        .then((option) => {
-          if (typeof option === "undefined") {
-            const noOptionMsg = locDic.localize(
-              "extension.noOptionMessage",
-              "No option selected."
+    const selectConfigMsg = locDic.localize(
+      "extension.selectConfigMessage",
+      "Select option to define its path :"
+    );
+    vscode.window
+      .showQuickPick(
+        [
+          {
+            description: "Device target (esp32, esp32s2)",
+            label: "Device Target",
+            target: "deviceTarget",
+          },
+          {
+            description: "Device port path",
+            label: "Device Port",
+            target: "devicePort",
+          },
+          {
+            description: "Baud rate of device",
+            label: "Baud Rate",
+            target: "baudRate",
+          },
+          {
+            description:
+              "Relative paths to OpenOCD Scripts directory separated by comma(,)",
+            label: "OpenOcd Config Files",
+            target: "openOcdConfig",
+          },
+        ],
+        { placeHolder: selectConfigMsg }
+      )
+      .then((option) => {
+        if (typeof option === "undefined") {
+          const noOptionMsg = locDic.localize(
+            "extension.noOptionMessage",
+            "No option selected."
+          );
+          Logger.infoNotify(noOptionMsg);
+          return;
+        }
+        let currentValue;
+        let msg: string;
+        let paramName: string;
+        switch (option.target) {
+          case "deviceTarget":
+            msg = locDic.localize(
+              "extension.enterDeviceTargetMessage",
+              "Enter device target name"
             );
-            Logger.infoNotify(noOptionMsg);
-            return;
-          }
-          let currentValue;
-          let msg: string;
-          let paramName: string;
-          switch (option.target) {
-            case "deviceTarget":
-              msg = locDic.localize(
-                "extension.enterDeviceTargetMessage",
-                "Enter device target name"
-              );
-              paramName = "idf.adapterTargetName";
-              break;
-            case "devicePort":
-              msg = locDic.localize(
-                "extension.enterDevicePortMessage",
-                "Enter device port Path"
-              );
-              paramName = "idf.port";
-              break;
-            case "baudRate":
-              msg = locDic.localize(
-                "extension.enterDeviceBaudRateMessage",
-                "Enter device baud rate"
-              );
-              paramName = "idf.baudRate";
-              break;
-            case "openOcdConfig":
-              msg = locDic.localize(
-                "extension.enterOpenOcdConfigMessage",
-                "Enter OpenOCD Configuration File Paths list"
-              );
-              paramName = "idf.openOcdConfigs";
-              break;
-            default:
-              const noParamUpdatedMsg = locDic.localize(
-                "extension.noParamUpdatedMessage",
-                "No device parameter has been updated"
-              );
-              Logger.infoNotify(noParamUpdatedMsg);
-              break;
-          }
-          if (msg && paramName) {
-            currentValue = idfConf.readParameter(paramName);
-            if (currentValue instanceof Array) {
-              currentValue = currentValue.join(",");
-            }
-            idfConf.updateConfParameter(
-              paramName,
-              msg,
-              currentValue,
-              option.label
+            paramName = "idf.adapterTargetName";
+            break;
+          case "devicePort":
+            msg = locDic.localize(
+              "extension.enterDevicePortMessage",
+              "Enter device port Path"
             );
+            paramName = "idf.port";
+            break;
+          case "baudRate":
+            msg = locDic.localize(
+              "extension.enterDeviceBaudRateMessage",
+              "Enter device baud rate"
+            );
+            paramName = "idf.baudRate";
+            break;
+          case "openOcdConfig":
+            msg = locDic.localize(
+              "extension.enterOpenOcdConfigMessage",
+              "Enter OpenOCD Configuration File Paths list"
+            );
+            paramName = "idf.openOcdConfigs";
+            break;
+          default:
+            const noParamUpdatedMsg = locDic.localize(
+              "extension.noParamUpdatedMessage",
+              "No device parameter has been updated"
+            );
+            Logger.infoNotify(noParamUpdatedMsg);
+            break;
+        }
+        if (msg && paramName) {
+          currentValue = idfConf.readParameter(paramName);
+          if (currentValue instanceof Array) {
+            currentValue = currentValue.join(",");
           }
-        });
-    });
+          idfConf.updateConfParameter(
+            paramName,
+            msg,
+            currentValue,
+            option.label
+          );
+        }
+      });
   });
 
   vscode.workspace.onDidChangeConfiguration((e) => {

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -57,6 +57,7 @@ export function readParameter(
 }
 
 export function chooseConfigurationTarget() {
+  const previousTarget = readParameter("idf.saveScope");
   return vscode.window
     .showQuickPick(
       [
@@ -78,11 +79,16 @@ export function chooseConfigurationTarget() {
       ],
       { placeHolder: "Where to save the configuration?" }
     )
-    .then((option) => {
+    .then(async (option) => {
       if (option) {
+        await writeParameter(
+          "idf.saveScope",
+          option.target,
+          vscode.ConfigurationTarget.Global
+        );
         return option.target;
       } else {
-        return vscode.ConfigurationTarget.Global;
+        return previousTarget || vscode.ConfigurationTarget.Global;
       }
     });
 }
@@ -137,7 +143,7 @@ export function updateConfParameter(
           } else {
             valueToWrite = newValue;
           }
-          const target = await chooseConfigurationTarget();
+          const target = readParameter("idf.saveScope");
           if (
             typeof vscode.workspace.workspaceFolders === "undefined" &&
             target !== vscode.ConfigurationTarget.Global

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -51,14 +51,60 @@ export function readParameter(param: string) {
   return paramValue;
 }
 
-export async function writeParameter(param: string, newValue) {
+export function chooseConfigurationTarget() {
+  return vscode.window
+    .showQuickPick(
+      [
+        {
+          description: "Global",
+          label: "Global",
+          target: vscode.ConfigurationTarget.Global,
+        },
+        {
+          description: "Workspace",
+          label: "Workspace",
+          target: vscode.ConfigurationTarget.Workspace,
+        },
+        {
+          description: "Workspace Folder",
+          label: "Workspace Folder",
+          target: vscode.ConfigurationTarget.WorkspaceFolder,
+        },
+      ],
+      { placeHolder: "Where to save the configuration?" }
+    )
+    .then((option) => {
+      if (option) {
+        return option.target;
+      } else {
+        return vscode.ConfigurationTarget.Global;
+      }
+    });
+}
+
+export function writeParameter(
+  param: string,
+  newValue,
+  target: vscode.ConfigurationTarget
+) {
   const paramValue = addWinIfRequired(param);
-  const configuration = vscode.workspace.getConfiguration();
-  await configuration.update(
-    paramValue,
-    newValue,
-    vscode.ConfigurationTarget.Global
-  );
+  if (target === vscode.ConfigurationTarget.WorkspaceFolder) {
+    return vscode.window
+      .showWorkspaceFolderPick({
+        placeHolder: `Pick Workspace Folder to which ${param} should be applied`,
+      })
+      .then(async (workspaceFolder) => {
+        if (workspaceFolder) {
+          return vscode.workspace
+            .getConfiguration("", workspaceFolder.uri)
+            .update(paramValue, newValue, target);
+        }
+      });
+  } else {
+    return vscode.workspace
+      .getConfiguration()
+      .update(paramValue, newValue, target);
+  }
 }
 
 export function updateConfParameter(
@@ -69,7 +115,7 @@ export function updateConfParameter(
 ) {
   return vscode.window
     .showInputBox({ placeHolder: confParamDescription, value: currentValue })
-    .then((newValue: string) => {
+    .then((newValue) => {
       return new Promise(async (resolve, reject) => {
         if (newValue) {
           const typeOfConfig = checkTypeOfConfiguration(confParamName);
@@ -79,7 +125,15 @@ export function updateConfParameter(
           } else {
             valueToWrite = newValue;
           }
-          await writeParameter(confParamName, valueToWrite);
+          const target = await chooseConfigurationTarget();
+          if (
+            typeof vscode.workspace.workspaceFolders === "undefined" &&
+            target !== vscode.ConfigurationTarget.Global
+          ) {
+            Logger.infoNotify("Open a workspace or folder first.");
+            reject(newValue);
+          }
+          await writeParameter(confParamName, valueToWrite, target);
           const updateMessage = locDic.localize(
             "idfConfiguration.hasBeenUpdated",
             " has been updated"
@@ -94,8 +148,9 @@ export function updateConfParameter(
 }
 
 export function checkTypeOfConfiguration(paramName: string) {
-  const conf = vscode.workspace.getConfiguration("");
-  const { defaultValue } = conf.inspect(paramName);
+  const { defaultValue } = vscode.workspace
+    .getConfiguration()
+    .inspect(paramName);
   if (typeof defaultValue === "object") {
     return Array.isArray(defaultValue) ? "array" : "object";
   } else {

--- a/src/onboarding/espIdfDownload.ts
+++ b/src/onboarding/espIdfDownload.ts
@@ -17,7 +17,7 @@ import * as fs from "fs";
 import { move } from "fs-extra";
 import { EOL, tmpdir } from "os";
 import * as path from "path";
-import { ConfigurationTarget } from "vscode";
+import { ConfigurationTarget, WorkspaceFolder } from "vscode";
 import { DownloadManager } from "../downloadManager";
 import * as idfConf from "../idfConfiguration";
 import { InstallManager } from "../installManager";
@@ -41,7 +41,8 @@ export interface IEspIdfLink {
 export async function downloadInstallIdfVersion(
   idfVersion: IEspIdfLink,
   destPath: string,
-  confTarget: ConfigurationTarget
+  confTarget: ConfigurationTarget,
+  selectedWorkspaceFolder: WorkspaceFolder
 ) {
   const downloadedZipPath = path.join(destPath, idfVersion.filename);
   const extractedDirectory = downloadedZipPath.replace(".zip", "");
@@ -107,7 +108,8 @@ export async function downloadInstallIdfVersion(
               await idfConf.writeParameter(
                 "idf.espIdfPath",
                 expectedDirectory,
-                confTarget
+                confTarget,
+                selectedWorkspaceFolder
               );
             })
             .catch((reason) => {
@@ -157,7 +159,8 @@ export async function downloadInstallIdfVersion(
                   await idfConf.writeParameter(
                     "idf.espIdfPath",
                     expectedDirectory,
-                    confTarget
+                    confTarget,
+                    selectedWorkspaceFolder
                   );
                 });
             })

--- a/src/onboarding/espIdfDownload.ts
+++ b/src/onboarding/espIdfDownload.ts
@@ -17,6 +17,7 @@ import * as fs from "fs";
 import { move } from "fs-extra";
 import { EOL, tmpdir } from "os";
 import * as path from "path";
+import { ConfigurationTarget } from "vscode";
 import { DownloadManager } from "../downloadManager";
 import * as idfConf from "../idfConfiguration";
 import { InstallManager } from "../installManager";
@@ -39,7 +40,8 @@ export interface IEspIdfLink {
 
 export async function downloadInstallIdfVersion(
   idfVersion: IEspIdfLink,
-  destPath: string
+  destPath: string,
+  confTarget: ConfigurationTarget
 ) {
   const downloadedZipPath = path.join(destPath, idfVersion.filename);
   const extractedDirectory = downloadedZipPath.replace(".zip", "");
@@ -102,7 +104,11 @@ export async function downloadInstallIdfVersion(
                 downloadedPath: "master",
               });
               OnBoardingPanel.postMessage({ command: "notify_idf_extracted" });
-              await idfConf.writeParameter("idf.espIdfPath", expectedDirectory);
+              await idfConf.writeParameter(
+                "idf.espIdfPath",
+                expectedDirectory,
+                confTarget
+              );
             })
             .catch((reason) => {
               OutputChannel.appendLine(reason);
@@ -150,7 +156,8 @@ export async function downloadInstallIdfVersion(
                   });
                   await idfConf.writeParameter(
                     "idf.espIdfPath",
-                    expectedDirectory
+                    expectedDirectory,
+                    confTarget
                   );
                 });
             })

--- a/src/onboarding/pythonReqsManager.ts
+++ b/src/onboarding/pythonReqsManager.ts
@@ -14,7 +14,7 @@
 
 import { pathExists } from "fs-extra";
 import * as path from "path";
-import { ConfigurationTarget } from "vscode";
+import { ConfigurationTarget, WorkspaceFolder } from "vscode";
 import * as idfConf from "../idfConfiguration";
 import { Logger } from "../logger/logger";
 import { OutputChannel } from "../logger/outputChannel";
@@ -23,11 +23,18 @@ import * as utils from "../utils";
 import { OnBoardingPanel } from "./OnboardingPanel";
 import { PyReqLog } from "./PyReqLog";
 
-export async function checkPythonRequirements(workingDir: string) {
+export async function checkPythonRequirements(
+  workingDir: string,
+  selectedWorkspaceFolder: WorkspaceFolder
+) {
   const pythonSystemBinPath = idfConf.readParameter(
-    "idf.pythonSystemBinPath"
+    "idf.pythonSystemBinPath",
+    selectedWorkspaceFolder
   ) as string;
-  const pythonBinPath = idfConf.readParameter("idf.pythonBinPath") as string;
+  const pythonBinPath = idfConf.readParameter(
+    "idf.pythonBinPath",
+    selectedWorkspaceFolder
+  ) as string;
   process.env.PATH =
     path.dirname(pythonSystemBinPath) + path.delimiter + process.env.PATH;
   const canCheck = await checkPythonPipExists(pythonBinPath, workingDir);
@@ -38,8 +45,14 @@ export async function checkPythonRequirements(workingDir: string) {
     });
     return;
   }
-  const espIdfPath = idfConf.readParameter("idf.espIdfPath") as string;
-  const idfToolsPath = idfConf.readParameter("idf.toolsPath") as string;
+  const espIdfPath = idfConf.readParameter(
+    "idf.espIdfPath",
+    selectedWorkspaceFolder
+  ) as string;
+  const idfToolsPath = idfConf.readParameter(
+    "idf.toolsPath",
+    selectedWorkspaceFolder
+  ) as string;
   const reqFilePath = path.join(
     espIdfPath,
     "tools",
@@ -111,10 +124,12 @@ export async function checkPythonRequirements(workingDir: string) {
 
 export async function installPythonRequirements(
   workingDir: string,
-  confTarget: ConfigurationTarget
+  confTarget: ConfigurationTarget,
+  selectedWorkspaceFolder: WorkspaceFolder
 ) {
   const pythonBinPath = idfConf.readParameter(
-    "idf.pythonSystemBinPath"
+    "idf.pythonSystemBinPath",
+    selectedWorkspaceFolder
   ) as string;
   process.env.PATH =
     path.dirname(pythonBinPath) + path.delimiter + process.env.PATH;
@@ -126,8 +141,14 @@ export async function installPythonRequirements(
     );
     return;
   }
-  const espIdfPath = idfConf.readParameter("idf.espIdfPath") as string;
-  const idfToolsPath = idfConf.readParameter("idf.toolsPath") as string;
+  const espIdfPath = idfConf.readParameter(
+    "idf.espIdfPath",
+    selectedWorkspaceFolder
+  ) as string;
+  const idfToolsPath = idfConf.readParameter(
+    "idf.toolsPath",
+    selectedWorkspaceFolder
+  ) as string;
   const logTracker = new PyReqLog(sendPyReqLog);
   process.env.IDF_PATH = espIdfPath || process.env.IDF_PATH;
   return await pythonManager
@@ -143,7 +164,8 @@ export async function installPythonRequirements(
         await idfConf.writeParameter(
           "idf.pythonBinPath",
           virtualEnvPythonBin,
-          confTarget
+          confTarget,
+          selectedWorkspaceFolder
         );
         OutputChannel.appendLine("Python requirements has been installed.");
         if (logTracker.Log.indexOf("Exception") < 0) {
@@ -184,11 +206,6 @@ export async function checkPythonPipExists(
 
 export async function getPythonList(workingDir: string) {
   const pyVersionList = await pythonManager.getPythonBinList(workingDir);
-  const idfToolsPath = idfConf.readParameter("idf.toolsPath") as string;
-  const pyEnvList = await pythonManager.getIdfToolsPythonList(idfToolsPath);
-  if (pyEnvList && pyEnvList.length > 0) {
-    pyVersionList.push(...pyEnvList);
-  }
   pyVersionList.push("Provide python executable path");
   return pyVersionList;
 }

--- a/src/onboarding/pythonReqsManager.ts
+++ b/src/onboarding/pythonReqsManager.ts
@@ -14,6 +14,7 @@
 
 import { pathExists } from "fs-extra";
 import * as path from "path";
+import { ConfigurationTarget } from "vscode";
 import * as idfConf from "../idfConfiguration";
 import { Logger } from "../logger/logger";
 import { OutputChannel } from "../logger/outputChannel";
@@ -108,7 +109,10 @@ export async function checkPythonRequirements(workingDir: string) {
     });
 }
 
-export async function installPythonRequirements(workingDir: string) {
+export async function installPythonRequirements(
+  workingDir: string,
+  confTarget: ConfigurationTarget
+) {
   const pythonBinPath = idfConf.readParameter(
     "idf.pythonSystemBinPath"
   ) as string;
@@ -136,7 +140,11 @@ export async function installPythonRequirements(workingDir: string) {
     )
     .then(async (virtualEnvPythonBin) => {
       if (virtualEnvPythonBin) {
-        await idfConf.writeParameter("idf.pythonBinPath", virtualEnvPythonBin);
+        await idfConf.writeParameter(
+          "idf.pythonBinPath",
+          virtualEnvPythonBin,
+          confTarget
+        );
         OutputChannel.appendLine("Python requirements has been installed.");
         if (logTracker.Log.indexOf("Exception") < 0) {
           OnBoardingPanel.postMessage({ command: "set_py_setup_finish" });

--- a/src/onboarding/toolsInstall.ts
+++ b/src/onboarding/toolsInstall.ts
@@ -33,7 +33,8 @@ import {
 export async function downloadToolsInIdfToolsPath(
   workingDir: string,
   idfToolsManager: IdfToolsManager,
-  installDir: string
+  installDir: string,
+  confTarget: vscode.ConfigurationTarget
 ) {
   // In case IDF tools path is of the form path1:path2, tell the user for single path
   const manyPathsInIdfTools = installDir.split(path.delimiter);
@@ -93,12 +94,13 @@ export async function downloadToolsInIdfToolsPath(
       Logger.info(
         "Installing python virtualenv and ESP-IDF python requirements..."
       );
-      const pyEnvResult = await installPythonRequirements(workingDir).catch(
-        (reason) => {
-          OutputChannel.appendLine(reason);
-          Logger.info(reason);
-        }
-      );
+      const pyEnvResult = await installPythonRequirements(
+        workingDir,
+        confTarget
+      ).catch((reason) => {
+        OutputChannel.appendLine(reason);
+        Logger.info(reason);
+      });
       let exportPaths = await idfToolsManager.exportPaths(
         path.join(installDir, "tools")
       );
@@ -127,8 +129,16 @@ export async function downloadToolsInIdfToolsPath(
       Logger.info(exportPaths);
       OutputChannel.appendLine("");
       Logger.info("");
-      await idfConf.writeParameter("idf.customExtraPaths", exportPaths);
-      await idfConf.writeParameter("idf.customExtraVars", exportVars);
+      await idfConf.writeParameter(
+        "idf.customExtraPaths",
+        exportPaths,
+        confTarget
+      );
+      await idfConf.writeParameter(
+        "idf.customExtraVars",
+        exportVars,
+        confTarget
+      );
       OnBoardingPanel.postMessage({
         command: "load_custom_paths",
         custom_vars: JSON.parse(exportVars),

--- a/src/onboarding/toolsInstall.ts
+++ b/src/onboarding/toolsInstall.ts
@@ -34,7 +34,8 @@ export async function downloadToolsInIdfToolsPath(
   workingDir: string,
   idfToolsManager: IdfToolsManager,
   installDir: string,
-  confTarget: vscode.ConfigurationTarget
+  confTarget: vscode.ConfigurationTarget,
+  selectedWorkspaceFolder: vscode.WorkspaceFolder
 ) {
   // In case IDF tools path is of the form path1:path2, tell the user for single path
   const manyPathsInIdfTools = installDir.split(path.delimiter);
@@ -96,7 +97,8 @@ export async function downloadToolsInIdfToolsPath(
       );
       const pyEnvResult = await installPythonRequirements(
         workingDir,
-        confTarget
+        confTarget,
+        selectedWorkspaceFolder
       ).catch((reason) => {
         OutputChannel.appendLine(reason);
         Logger.info(reason);
@@ -105,10 +107,15 @@ export async function downloadToolsInIdfToolsPath(
         path.join(installDir, "tools")
       );
       const pythonSystemBinPath = idfConf.readParameter(
-        "idf.pythonSystemBinPath"
+        "idf.pythonSystemBinPath",
+        selectedWorkspaceFolder
       ) as string;
       const pythonBinPath =
-        pyEnvResult || (idfConf.readParameter("idf.pythonBinPath") as string);
+        pyEnvResult ||
+        (idfConf.readParameter(
+          "idf.pythonBinPath",
+          selectedWorkspaceFolder
+        ) as string);
       // Append System Python and Virtual Env Python to PATH
       exportPaths =
         path.dirname(pythonBinPath) +
@@ -132,12 +139,14 @@ export async function downloadToolsInIdfToolsPath(
       await idfConf.writeParameter(
         "idf.customExtraPaths",
         exportPaths,
-        confTarget
+        confTarget,
+        selectedWorkspaceFolder
       );
       await idfConf.writeParameter(
         "idf.customExtraVars",
         exportVars,
-        confTarget
+        confTarget,
+        selectedWorkspaceFolder
       );
       OnBoardingPanel.postMessage({
         command: "load_custom_paths",

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -234,49 +234,6 @@ export async function getPythonBinList(workingDir: string) {
   }
 }
 
-export async function getIdfToolsPythonList(
-  idfToolsDir: string
-): Promise<string[]> {
-  return utils
-    .dirExistPromise(idfToolsDir)
-    .then(async (doesExist) => {
-      if (doesExist) {
-        const pyEnvDir = path.join(idfToolsDir, "python_env");
-        return await utils.dirExistPromise(pyEnvDir).then((doesPyEnvExist) => {
-          if (doesPyEnvExist) {
-            const results: string[] = [];
-            const pythonBinaries = utils.getDirectories(pyEnvDir);
-            if (!pythonBinaries || pythonBinaries.length < 1) {
-              return [] as string[];
-            }
-            const pyDir =
-              process.platform === "win32"
-                ? ["Scripts", "python.exe"]
-                : ["bin", "python"];
-            pythonBinaries.forEach((pythonEnv) => {
-              const pyBin = path.join(pyEnvDir, pythonEnv, ...pyDir);
-              if (utils.fileExists(pyBin)) {
-                results.push(pyBin);
-              }
-            });
-            return results;
-          } else {
-            return [] as string[];
-          }
-        });
-      } else {
-        return [] as string[];
-      }
-    })
-    .catch((err) => {
-      Logger.errorNotify(
-        "Error while checking ESP-IDF Tools directory exists.",
-        err
-      );
-      return [] as string[];
-    });
-}
-
 export async function getUnixPythonList(workingDir: string) {
   return await utils
     .execChildProcess("which -a python python3", workingDir)

--- a/src/views/onboarding/App.vue
+++ b/src/views/onboarding/App.vue
@@ -11,39 +11,38 @@
         </ul>
         <p>
           Before using this extension,
-          <a href="https://git-scm.com/downloads">Git</a> and
-          <a href="https://www.python.org/downloads">Python</a> are required.
+            <a href="https://git-scm.com/downloads">Git</a>
+          and <a href="https://www.python.org/downloads">Python</a> are required.
+          Please read
+          <a href="https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#step-1-install-prerequisites">
+            ESP-IDF Prerequisites.
+          </a>
         </p>
         <p v-if="isNotWinPlatform">
           <a href="https://cmake.org/download/">CMake</a> and
           <a href="https://github.com/ninja-build/ninja/releases">Ninja</a> are
           required in environment PATH.
         </p>
-        <p>
-          Please read
-          <a
-            href="https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#step-1-install-prerequisites"
-          >
-            ESP-IDF Prerequisites.</a
-          >
-        </p>
-        <router-link
-          v-on:click.native="initSetup"
-          to="/gitpycheck"
-          class="enter-button"
-          >START</router-link
-        >
-        <br /><br />
         <div>
           <input
             id="showOnboarding"
             v-model="showOnboardingOnInit"
             type="checkbox"
-            @change="updateShowOnboarding"
           />
           <label for="showOnboarding">
             Show Onboarding on Visual Studio Code start.
           </label>
+          <br><br>
+          <label for="configurationTarget">
+            Where to save configuration settings ?
+          </label>
+          <select v-model="selectedConfTarget">
+            <option value="1">User settings</option>
+            <option value="2">Workspace settings</option>
+            <option value="3">Workspace folder settings</option>
+          </select>
+          <br><br>
+          <router-link  v-on:click.native="initSetup" to='/gitpycheck' class="enter-button">START</router-link>
         </div>
       </div>
     </div>
@@ -64,7 +63,10 @@ import { Action, Mutation, State } from "vuex-class";
 export default class App extends Vue {
   public isNotWelcomePage: boolean = false;
   @State("showOnboardingOnInit") private storeShowOnboardingOnInit: boolean;
-  @Mutation("showOnboardingOnInit") private setShowOnboardingOnInit;
+  @State("selectedConfTarget") private storeSelectedConfTarget: number;
+  @Mutation private setShowOnboardingOnInit;
+  @Mutation("updateConfTarget") private modifyConfTarget;
+  @Action private updateConfTarget;
   @Action private updateShowOnboardingOnInit;
   @Action private requestInitValues;
 
@@ -76,13 +78,20 @@ export default class App extends Vue {
     return navigator.platform.indexOf("Win") < 0;
   }
 
+  get selectedConfTarget() {
+    return this.storeSelectedConfTarget;
+  }
+  set selectedConfTarget(val) {
+    this.updateConfTarget(val);
+    this.modifyConfTarget(val);
+  }
+
   get showOnboardingOnInit(): boolean {
     return this.storeShowOnboardingOnInit;
   }
-
-  public updateShowOnboarding(e) {
-    this.setShowOnboardingOnInit(e.target.checked);
-    this.updateShowOnboardingOnInit(e.target.checked);
+  set showOnboardingOnInit(val) {
+    this.setShowOnboardingOnInit(val);
+    this.updateShowOnboardingOnInit(val);
   }
 
   private mounted() {

--- a/src/views/onboarding/App.vue
+++ b/src/views/onboarding/App.vue
@@ -11,10 +11,14 @@
         </ul>
         <p>
           Before using this extension,
-            <a href="https://git-scm.com/downloads">Git</a>
-          and <a href="https://www.python.org/downloads">Python</a> are required.
+          <a href="https://git-scm.com/downloads">Git</a>
+          and <a href="https://www.python.org/downloads">Python</a> are
+          required.
+          <br />
           Please read
-          <a href="https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#step-1-install-prerequisites">
+          <a
+            href="https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#step-1-install-prerequisites"
+          >
             ESP-IDF Prerequisites.
           </a>
         </p>
@@ -32,17 +36,32 @@
           <label for="showOnboarding">
             Show Onboarding on Visual Studio Code start.
           </label>
-          <br><br>
+          <br /><br />
           <label for="configurationTarget">
             Where to save configuration settings ?
           </label>
+          <br />
+          <br />
           <select v-model="selectedConfTarget">
             <option value="1">User settings</option>
             <option value="2">Workspace settings</option>
             <option value="3">Workspace folder settings</option>
           </select>
-          <br><br>
-          <router-link  v-on:click.native="initSetup" to='/gitpycheck' class="enter-button">START</router-link>
+          <br /><br />
+          <div v-if="selectedConfTarget === '3'">
+            <select v-model="selectedWorkspaceFolder">
+              <option v-for="ws in workspaceFolders" :value="ws" :key="ws">
+                {{ ws }}
+              </option>
+            </select>
+            <br /><br />
+          </div>
+          <router-link
+            v-on:click.native="initSetup"
+            to="/gitpycheck"
+            class="enter-button"
+            >START</router-link
+          >
         </div>
       </div>
     </div>
@@ -64,8 +83,11 @@ export default class App extends Vue {
   public isNotWelcomePage: boolean = false;
   @State("showOnboardingOnInit") private storeShowOnboardingOnInit: boolean;
   @State("selectedConfTarget") private storeSelectedConfTarget: number;
+  @State("workspaceFolders") private storeWorkspaceFolders: string[];
+  @State("selectedWorkspaceFolder") private storeSelectedWorkspace: string;
   @Mutation private setShowOnboardingOnInit;
   @Mutation("updateConfTarget") private modifyConfTarget;
+  @Mutation private setSelectedWorkspaceFolder;
   @Action private updateConfTarget;
   @Action private updateShowOnboardingOnInit;
   @Action private requestInitValues;
@@ -82,6 +104,7 @@ export default class App extends Vue {
     return this.storeSelectedConfTarget;
   }
   set selectedConfTarget(val) {
+    console.log(val);
     this.updateConfTarget(val);
     this.modifyConfTarget(val);
   }
@@ -92,6 +115,17 @@ export default class App extends Vue {
   set showOnboardingOnInit(val) {
     this.setShowOnboardingOnInit(val);
     this.updateShowOnboardingOnInit(val);
+  }
+
+  get workspaceFolders() {
+    return this.storeWorkspaceFolders;
+  }
+
+  get selectedWorkspaceFolder() {
+    return this.storeSelectedWorkspace;
+  }
+  set selectedWorkspaceFolder(newFolder) {
+    this.setSelectedWorkspaceFolder(newFolder);
   }
 
   private mounted() {

--- a/src/views/onboarding/main.ts
+++ b/src/views/onboarding/main.ts
@@ -209,6 +209,7 @@ window.addEventListener("message", (event) => {
       if (message.selected_folder) {
         store.commit("setIdfPath", message.selected_folder);
         store.commit("setIdfDownloadPath", message.selected_folder);
+        store.commit("showIdfPathCheck", false);
       }
       break;
     case "load_show_onboarding":
@@ -222,6 +223,10 @@ window.addEventListener("message", (event) => {
     case "resetConfigurationTarget":
       if (message.confTarget) {
         store.commit("updateConfTarget", message.confTarget);
+      }
+    case "loadWorkspaceFolders":
+      if (message.folders) {
+        store.commit("setWorkspaceFolders", message.folders);
       }
     default:
       break;

--- a/src/views/onboarding/main.ts
+++ b/src/views/onboarding/main.ts
@@ -219,6 +219,10 @@ window.addEventListener("message", (event) => {
         );
       }
       break;
+    case "resetConfigurationTarget":
+      if (message.confTarget) {
+        store.commit("updateConfTarget", message.confTarget);
+      }
     default:
       break;
   }

--- a/src/views/onboarding/store/actions.ts
+++ b/src/views/onboarding/store/actions.ts
@@ -94,6 +94,7 @@ export const actions: ActionTree<IState, any> = {
     vscode.postMessage({
       command: "updateConfigurationTarget",
       confTarget: parseInt(value, 10),
+      workspaceFolder: context.state.selectedWorkspaceFolder,
     });
   },
 };

--- a/src/views/onboarding/store/actions.ts
+++ b/src/views/onboarding/store/actions.ts
@@ -90,4 +90,10 @@ export const actions: ActionTree<IState, any> = {
       showOnboarding: value,
     });
   },
+  updateConfTarget(context, value) {
+    vscode.postMessage({
+      command: "updateConfigurationTarget",
+      confTarget: parseInt(value, 10),
+    });
+  },
 };

--- a/src/views/onboarding/store/mutations.ts
+++ b/src/views/onboarding/store/mutations.ts
@@ -159,6 +159,17 @@ export const mutations: MutationTree<IState> = {
     newState.downloadedIdfZipPath = "";
     Object.assign(state, newState);
   },
+  setSelectedWorkspaceFolder(state, newWorkspaceFolder: string) {
+    const newState = state;
+    newState.selectedWorkspaceFolder = newWorkspaceFolder;
+    Object.assign(state, newState);
+  },
+  setWorkspaceFolders(state, workspaceFolders: string[]) {
+    const newState = state;
+    newState.workspaceFolders = workspaceFolders;
+    newState.selectedWorkspaceFolder = workspaceFolders[0];
+    Object.assign(state, newState);
+  },
   setDownloadedZipPath(state, downloadedIdfZipPath: string) {
     const newState = state;
     newState.downloadedIdfZipPath = downloadedIdfZipPath;

--- a/src/views/onboarding/store/mutations.ts
+++ b/src/views/onboarding/store/mutations.ts
@@ -239,6 +239,11 @@ export const mutations: MutationTree<IState> = {
     );
     Object.assign(state, newState);
   },
+  updateConfTarget(state, confTarget) {
+    const newState = state;
+    newState.selectedConfTarget = confTarget;
+    Object.assign(state, newState);
+  },
   updateIdfDownloadDetail(state, updatedIdfDownloadDetail: IEspIdfStatus) {
     const newState = state;
     newState.idfDownloadStatus = {

--- a/src/views/onboarding/store/onboarding.ts
+++ b/src/views/onboarding/store/onboarding.ts
@@ -43,11 +43,13 @@ export const onboardState: IState = {
   selectedConfTarget: CONF_TARGET_GLOBAL,
   selectedIdfVersion: undefined,
   selectedPythonVersion: "",
+  selectedWorkspaceFolder: "",
   showIdfPathCheck: false,
   showIdfToolsChecks: false,
   showOnboardingOnInit: true,
   toolsSelectedSetupMode: "empty",
   toolsCheckResults: [],
+  workspaceFolders: [],
 };
 
 export const onboarding: StoreOptions<IState> = {

--- a/src/views/onboarding/store/onboarding.ts
+++ b/src/views/onboarding/store/onboarding.ts
@@ -17,6 +17,8 @@ import { actions } from "./actions";
 import { mutations } from "./mutations";
 import { IState } from "./types";
 
+const CONF_TARGET_GLOBAL = 1;
+
 export const onboardState: IState = {
   customExtraPaths: "",
   downloadedIdfZipPath: "",
@@ -38,6 +40,7 @@ export const onboardState: IState = {
   pyLog: "",
   pyVersionList: [],
   requiredToolsVersions: [],
+  selectedConfTarget: CONF_TARGET_GLOBAL,
   selectedIdfVersion: undefined,
   selectedPythonVersion: "",
   showIdfPathCheck: false,

--- a/src/views/onboarding/store/types.ts
+++ b/src/views/onboarding/store/types.ts
@@ -62,6 +62,7 @@ export interface IState {
   pyLog: string;
   pyVersionList: string[];
   requiredToolsVersions: IToolStatus[];
+  selectedConfTarget: number;
   selectedIdfVersion: IEspIdfLink;
   selectedPythonVersion: string;
   showIdfPathCheck: boolean;

--- a/src/views/onboarding/store/types.ts
+++ b/src/views/onboarding/store/types.ts
@@ -65,9 +65,11 @@ export interface IState {
   selectedConfTarget: number;
   selectedIdfVersion: IEspIdfLink;
   selectedPythonVersion: string;
+  selectedWorkspaceFolder: string;
   showIdfPathCheck: boolean;
   showIdfToolsChecks: boolean;
   showOnboardingOnInit: boolean;
   toolsCheckResults: IToolVersionResult[];
   toolsSelectedSetupMode: string;
+  workspaceFolders: string[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,7 +1503,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1552,11 +1552,6 @@ deep-equal@^1.0.0:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-compare@^1.0.0:
   version "1.0.0"
@@ -1639,11 +1634,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 didyoumean@^1.2.1:
   version "1.2.1"
@@ -2302,13 +2292,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
@@ -2837,7 +2820,7 @@ husky@^2.5.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@^0.4.19, iconv-lite@^0.4.4:
+iconv-lite@^0.4.19:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2860,13 +2843,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^5.1.4:
   version "5.1.4"
@@ -2939,7 +2915,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -3772,21 +3748,6 @@ minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -3954,15 +3915,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -4055,22 +4007,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-sass@^4.13.0:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
@@ -4100,14 +4036,6 @@ node-sass@^4.13.0:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -4148,27 +4076,6 @@ now-and-later@^2.0.0:
   dependencies:
     once "^1.3.2"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -4183,7 +4090,7 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -4354,7 +4261,7 @@ os@0.1.1:
   resolved "https://registry.yarnpkg.com/os/-/os-0.1.1.tgz#208845e89e193ad4d971474b93947736a56d13f3"
   integrity sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=
 
-osenv@0, osenv@^0.1.3, osenv@^0.1.4:
+osenv@0, osenv@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -4909,16 +4816,6 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -5181,7 +5078,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5251,7 +5148,7 @@ sass-loader@^7.1.0:
     pify "^4.0.1"
     semver "^6.3.0"
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -5713,7 +5610,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -5794,19 +5691,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 terser-webpack-plugin@^1.4.3:
   version "1.4.3"
@@ -6719,7 +6603,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Fix #46 

Enable the user to select where to save configuration settings.

On vscode commands -> extra step to define where to save configuration settings.

On Onboarding -> dropdown on first window to select where to save configuration settings for the whole onboarding experience.