### PR TITLE
find xtensa toolchain full path fix getProjectName (VSC-272)

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -36,7 +36,7 @@ If you prefer using Microsoft C/C++ Extension to debug, the user community have 
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "miDebuggerPath": "xtensa-esp32-elf-gdb",
+      "miDebuggerPath": "${command:espIdf.getXtensaGdb}",
       "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
       "windows": {
         "program": "${workspaceFolder}\\build\\${command:espIdf.getProjectName}.elf"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -531,6 +531,13 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerIDFCommand("espIdf.getXtensaGdb", () => {
+    return PreCheck.perform([openFolderCheck], async () => {
+      const extraPaths = idfConf.readParameter("idf.customExtraPaths");
+      return await utils.findBinaryFullPath("xtensa-esp32-elf-gdb", extraPaths);
+    });
+  });
+
   registerIDFCommand("espIdf.createVsCodeFolder", () => {
     PreCheck.perform([openFolderCheck], () => {
       utils.createVscodeFolder(workspaceRoot.fsPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -534,7 +534,17 @@ export async function activate(context: vscode.ExtensionContext) {
   registerIDFCommand("espIdf.getXtensaGdb", () => {
     return PreCheck.perform([openFolderCheck], async () => {
       const extraPaths = idfConf.readParameter("idf.customExtraPaths");
-      return await utils.findBinaryFullPath("xtensa-esp32-elf-gdb", extraPaths);
+      try {
+        return await utils.findBinaryFullPath(
+          "xtensa-esp32-elf-gdb",
+          extraPaths
+        );
+      } catch (error) {
+        Logger.errorNotify(
+          "xtensa-esp32-elf-gdb is not found in idf.customExtraPaths",
+          error
+        );
+      }
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -544,6 +544,7 @@ export async function activate(context: vscode.ExtensionContext) {
           "xtensa-esp32-elf-gdb is not found in idf.customExtraPaths",
           error
         );
+        return;
       }
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -611,15 +611,10 @@ export async function findBinaryFullPath(
 ) {
   const locCmd = process.platform === "win32" ? "where" : "which";
   const pathModified = pathsToVerify + path.delimiter + process.env.PATH;
-  const result = await execChildProcess(
+  return await execChildProcess(
     `${locCmd} ${binName}`,
     process.cwd(),
     this.toolsManagerChannel,
     { cwd: process.cwd(), env: { PATH: pathModified } }
-  ).catch((reason) => {
-    this.toolsManagerChannel.appendLine(reason);
-    Logger.error(reason, new Error(reason));
-    return "Error";
-  });
-  return result.trim();
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -604,3 +604,22 @@ export async function isBinInPath(
   }
   return "";
 }
+
+export async function findBinaryFullPath(
+  binName: string,
+  pathsToVerify: string
+) {
+  const locCmd = process.platform === "win32" ? "where" : "which";
+  const pathModified = pathsToVerify + path.delimiter + process.env.PATH;
+  const result = await execChildProcess(
+    `${locCmd} ${binName}`,
+    process.cwd(),
+    this.toolsManagerChannel,
+    { cwd: process.cwd(), env: { PATH: pathModified } }
+  ).catch((reason) => {
+    this.toolsManagerChannel.appendLine(reason);
+    Logger.error(reason, new Error(reason));
+    return "Error";
+  });
+  return result.trim();
+}


### PR DESCRIPTION
Fix #61 by adding a command to resolve xtensa toolchain gdb full path and fix getProjectName command. Updated the previous launch.json template.

Tested on MacOS 