### PR TITLE
add regex to include config on search string (VSC-333)

### DIFF
--- a/src/views/menuconfig/Menuconfig.vue
+++ b/src/views/menuconfig/Menuconfig.vue
@@ -66,7 +66,12 @@ export default class Menuconfig extends Vue {
 
   get items() {
     if (this.searchString !== "") {
-      return filterItems(this.storeItems, this.searchString.toLowerCase());
+      let searchStrMatch = /^(?:CONFIG_)?(.+)/.exec(this.searchString);
+      let searchMatch =
+        searchStrMatch && searchStrMatch.length > 1
+          ? searchStrMatch[1].toLowerCase()
+          : this.searchString.toLowerCase();
+      return filterItems(this.storeItems, searchMatch);
     }
     return this.storeItems;
   }


### PR DESCRIPTION
Allow users to make search of sdkconfig configurations with optional **CONFIG_** prefix like:

`BT_ENABLED`
`CONFIG_BT_ENABLED`

will (should) return same result.
