### PR TITLE
:bug: Fix the target name (VSC-334)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -612,16 +612,8 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window
         .showQuickPick(
           [
-            {
-              description: "ESP32",
-              label: "ESP32",
-              target: "esp32",
-            },
-            {
-              description: "ESP32 S2 (Beta)",
-              label: "ESP32S2BETA",
-              target: "esp32s2beta",
-            },
+            { description: "ESP32", label: "ESP32", target: "esp32" },
+            { description: "ESP32-S2", label: "ESP32-S2", target: "esp32s2" },
           ],
           { placeHolder: enterDeviceTargetMsg }
         )


### PR DESCRIPTION
Due to merge conflict fix error, old target name is retained, this should fix this