### PR TITLE
:bug: Fix python venv install wheel issue in Linux (VSC-348)

### DIFF
--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -134,7 +134,7 @@ export function updateConfParameter(
     .showInputBox({ placeHolder: confParamDescription, value: currentValue })
     .then((newValue) => {
       return new Promise(async (resolve, reject) => {
-        if (newValue) {
+        if (newValue && newValue.indexOf("~") !== -1) {
           const typeOfConfig = checkTypeOfConfiguration(confParamName);
           let valueToWrite;
           if (typeOfConfig === "array") {

--- a/src/onboarding/OnboardingPanel.ts
+++ b/src/onboarding/OnboardingPanel.ts
@@ -218,6 +218,15 @@ export class OnBoardingPanel {
                     this.selectedWorkspaceFolder
                   );
                 }
+                if (!utils.canAccessFile(message.py_bin_path)) {
+                  const notAccessMsg = `${message.py_bin_path} is not accesible.`;
+                  vscode.window.showErrorMessage(notAccessMsg);
+                  this.panel.webview.postMessage({
+                    command: "response_py_req_check",
+                    py_req_log: notAccessMsg,
+                  });
+                  return;
+                }
                 checkPythonRequirements(
                   this.extensionPath,
                   this.selectedWorkspaceFolder,
@@ -253,6 +262,12 @@ export class OnBoardingPanel {
                     this.selectedWorkspaceFolder
                   );
                 } else {
+                  if (message.tools_path.indexOf("~") > -1) {
+                    vscode.window.showInformationMessage(
+                      "Given path can't contain ~, please use absolute path."
+                    );
+                    return;
+                  }
                   const selected = await vscode.window.showErrorMessage(
                     "Specified Directory doesn't exists. Create?",
                     { modal: true },
@@ -371,10 +386,17 @@ export class OnBoardingPanel {
           break;
         case "savePythonBinary":
           if (message.selectedPyBin) {
+            if (!utils.fileExists(message.selectedPyBin)) {
+              vscode.window.showInformationMessage("Python path doesn't exist");
+              return;
+            }
             const msg = `Saving ${message.selectedPyBin} to create python virtual environment.`;
             Logger.info(msg);
             OutputChannel.appendLine(msg);
             this.pythonSystemBinPath = message.selectedPyBin;
+            this.panel.webview.postMessage({
+              command: "set_py_sys_path_is_valid",
+            });
           }
           break;
         case "saveShowOnboarding":

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -128,6 +128,17 @@ export async function installPythonEnv(
     channel.appendLine(createVirtualEnvResult + "\n");
   }
   pyTracker.Log = installPyPkgsMsg;
+  // Install wheel and other required packages
+  const systemReqs = await utils.execChildProcess(
+    `"${virtualEnvPython}" -m pip install wheel`,
+    pyEnvPath,
+    channel
+  );
+  pyTracker.Log = systemReqs;
+  pyTracker.Log = "\n";
+  if (channel) {
+    channel.appendLine(systemReqs + "\n");
+  }
   // ESP-IDF Python Requirements
   const espIdfReqInstallResult = await utils.execChildProcess(
     `"${virtualEnvPython}" -m pip install -r "${requirements}"`,

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -140,10 +140,13 @@ export async function installPythonEnv(
     channel.appendLine(systemReqs + "\n");
   }
   // ESP-IDF Python Requirements
+  const modifiedEnv = Object.assign({}, process.env);
+  modifiedEnv.IDF_PATH = espDir;
   const espIdfReqInstallResult = await utils.execChildProcess(
     `"${virtualEnvPython}" -m pip install -r "${requirements}"`,
     pyEnvPath,
-    channel
+    channel,
+    { env: modifiedEnv }
   );
   pyTracker.Log = espIdfReqInstallResult;
   pyTracker.Log = "\n";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -292,17 +292,17 @@ export function execChildProcess(
         }
         if (stderr && stderr.length > 2) {
           Logger.error(stderr, new Error(stderr));
-          if (stderr.indexOf("Licensed under GNU GPL v2") !== -1) {
-            resolve(stderr);
-          }
-          if (stderr.indexOf("DEPRECATION") !== -1) {
-            resolve(stdout.concat(stderr));
-          }
-          if (stderr.indexOf("WARNING") !== -1) {
-            resolve(stdout.concat(stderr));
-          }
-          if (stderr.indexOf("Cache entry deserialization failed") !== -1) {
-            resolve(stdout.concat(stderr));
+          const ignoredMessages = [
+            "Licensed under GNU GPL v2",
+            "DEPRECATION",
+            "WARNING",
+            "Cache entry deserialization failed",
+            `Ignoring pywin32: markers 'platform_system == "Windows"' don't match your environment`,
+          ];
+          for (const msg of ignoredMessages) {
+            if (stderr.indexOf(msg) !== -1) {
+              resolve(stdout.concat(stderr));
+            }
           }
           if (stderr.trim().endsWith("pip install --upgrade pip' command.")) {
             resolve(stdout.concat(stderr));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -298,6 +298,7 @@ export function execChildProcess(
             "WARNING",
             "Cache entry deserialization failed",
             `Ignoring pywin32: markers 'platform_system == "Windows"' don't match your environment`,
+            `Ignoring None: markers 'sys_platform == "win32"' don't match your environment`,
           ];
           for (const msg of ignoredMessages) {
             if (stderr.indexOf(msg) !== -1) {

--- a/src/views/onboarding/GitPyCheck.vue
+++ b/src/views/onboarding/GitPyCheck.vue
@@ -1,6 +1,10 @@
 <template>
   <div id="git-py-check">
-    <router-link to="/" class="arrow go-back right"></router-link>
+    <router-link
+      to="/"
+      class="arrow go-back right"
+      @click.native="setPythonSysIsValid(false)"
+    ></router-link>
     <h4>Select Git and Python version to use</h4>
     <label>Git version: {{ gitVersion }}</label>
     <p v-if="gitVersion === 'Not found'">
@@ -9,7 +13,11 @@
     </p>
     <br /><br />
     <label for="python-version-select">Python version:</label>
-    <select v-model="selectedPythonVersion" id="python-version-select">
+    <select
+      v-model="selectedPythonVersion"
+      id="python-version-select"
+      @change="setPythonSysIsValid(false)"
+    >
       <option v-for="ver in pyVersionList" :key="ver" :value="ver">
         {{ ver }}
       </option>
@@ -41,11 +49,18 @@
     <br />
     <br />
     <router-link
-      v-on:click.native="savePyBin"
+      v-if="pythonPathIsValid"
       to="/download"
       class="onboarding-button"
       >Configure ESP-IDF</router-link
     >
+    <button
+      v-if="!pythonPathIsValid"
+      v-on:click="savePyBin"
+      class="onboarding-button"
+    >
+      Check Python path exists
+    </button>
   </div>
 </template>
 
@@ -58,8 +73,10 @@ import { Action, Mutation, State } from "vuex-class";
 export default class GitPyCheck extends Vue {
   @State("gitVersion") private storeGitVersionList;
   @State("pyVersionList") private storePythonVersionList;
+  @State("pythonSysPathIsValid") private pythonPathIsValid;
   @State("selectedPythonVersion") private storeSelectedPythonVersion;
   @Mutation private setSelectedPythonVersion;
+  @Mutation private setPythonSysIsValid;
   private manualPythonPath;
   @Action private savePythonToUse;
 

--- a/src/views/onboarding/main.ts
+++ b/src/views/onboarding/main.ts
@@ -236,6 +236,9 @@ window.addEventListener("message", (event) => {
         store.commit("setPythonBinPath", message.pythonBinPath);
       }
       break;
+    case "set_py_sys_path_is_valid":
+      store.commit("setPythonSysIsValid", true);
+      break;
     default:
       break;
   }

--- a/src/views/onboarding/store/mutations.ts
+++ b/src/views/onboarding/store/mutations.ts
@@ -78,6 +78,11 @@ export const mutations: MutationTree<IState> = {
     newState.pyBinPath = pythonBinPath;
     Object.assign(state, newState);
   },
+  setPythonSysIsValid(state, isValid: boolean) {
+    const newState = state;
+    newState.pythonSysPathIsValid = isValid;
+    Object.assign(state, newState);
+  },
   setPyLog(state, pyLog: string) {
     const newState = state;
     newState.pyLog = pyLog;

--- a/src/views/onboarding/store/onboarding.ts
+++ b/src/views/onboarding/store/onboarding.ts
@@ -40,6 +40,7 @@ export const onboardState: IState = {
   pyBinPath: "",
   pyLog: "",
   pyVersionList: [],
+  pythonSysPathIsValid: false,
   requiredToolsVersions: [],
   selectedConfTarget: CONF_TARGET_GLOBAL,
   selectedIdfVersion: undefined,

--- a/src/views/onboarding/store/types.ts
+++ b/src/views/onboarding/store/types.ts
@@ -62,6 +62,7 @@ export interface IState {
   pyBinPath: string;
   pyLog: string;
   pyVersionList: string[];
+  pythonSysPathIsValid: boolean;
   requiredToolsVersions: IToolStatus[];
   selectedConfTarget: number;
   selectedIdfVersion: IEspIdfLink;


### PR DESCRIPTION
For Python > 3.3, we use `venv` since it the official Python virtual environments module. The thing is, for Linux users it seems to not include `wheel` from the system wide Python within the virtual environment. 

We added an step to install wheel in the virtualenv before installing requirements.txt

Should fix #105 