### PR TITLE
Arduino as an ESP32 component (VSC-354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The ESP-IDF extension makes it easy to develop, build, flash, monitor and debug 
 - [GUI Menuconfig tool](#ESP-IDF-GUI-Menuconfig-tool) within the extension with enabled search.
 - Easily Build, Flash and Monitor your code for the ESP-32 chip.
 - Syntax highlighting for [KConfig](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/kconfig.html) and ESP-IDF Kconfig style syntax validation if enabled.
-- Localization (English, Chinese, Spanish)of commands which you can also [add a language contribution](https://github.com/espressif/vscode-esp-idf-extension/blob/master/docs/LANG_CONTRIBUTE.md).
+- Localization (English, Chinese, Spanish) of commands which you can also [add a language contribution](https://github.com/espressif/vscode-esp-idf-extension/blob/master/docs/LANG_CONTRIBUTE.md).
 - OpenOCD server within Visual Studio Code.
+- [Code Coverage](./docs/COVERAGE.md) for editor source highlighting and generate HTML reports.
 
 ## Demo
 
@@ -35,7 +36,6 @@ There are a few dependencies which needs to be downloaded and installed before y
 - Support Rainmaker
 - Support GDB Stub
 - Support Core Dump
-- Support code coverage inside text editor & `gcovr` HTML report integration
 
 ## Quick Installation Guide
 
@@ -100,6 +100,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Configure ESP-IDF extension                     |                                        |                                           |
 | Create ESP-IDF project                          | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
 | Add vscode configuration folder                 |                                        |                                           |
+| Add Arduino ESP32 as ESP-IDF Component          |                                        |                                           |
 | Configure Paths                                 |                                        |                                           |
 | Set Espressif device target                     |                                        |                                           |
 | Device configuration                            |                                        |                                           |
@@ -110,12 +111,15 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Flash your project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
 | Monitor your device                             | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>M</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>M</kbd> |
 | Build, Flash and start a monitor on your device | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
+| Open ESP-IDF Terminal                           | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>T</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>T</kbd> |
 | Pick a workspace folder                         |                                        |                                           |
 | Size analysis of the binaries                   | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>S</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>S</kbd> |
 | Show ESP-IDF Examples Projects                  |                                        |                                           |
 | Add Editor coverage                             |                                        |                                           |
 | Remove Editor coverage                          |                                        |                                           |
 | Get HTML Coverage Report for project            |                                        |                                           |
+
+The **Add Arduino ESP32 as ESP-IDF Component** command will just add [Arduino ESP32](https://github.com/espressif/arduino-esp32) at your current folder with in `${CURRENT_FOLDER}/components/arduino`. You can also use **Create ESP-IDF project** with the `arduino-as-component` template to create a new project folder that includes arduino as ESP-IDF component.
 
 ## ESP-IDF Configure extension
 
@@ -124,23 +128,23 @@ Initial configuration is done easily by executing **ESP-IDF: Configure ESP-IDF e
 This windows helps you setup key Visual Studio Code configurations for this extension to perform included features correctly. This is how the extension uses them:
 
 1. `idf.pythonBinPath` is used to executed python scripts within the extension. In **ESP-IDF: Configure ESP-IDF extension** we first select a system-wide python executable from which to create a python virtual environment and we save the executable from this virtual environment in `idf.pythonBinPath`. All required python packages by ESP-IDF are installed in this virtual environment, if using **ESP-IDF: Configure ESP-IDF extension**
-2. `idf.customExtraPaths` is pre-appended to your system environment variable PATH within visual studio code **(not modifying your system environment)** before executing any of our extension commands such as openocd or cmake (build your current project) else extension commands will try to use what is already in your system PATH. In **ESP-IDF: Configure ESP-IDF extension** you can download ESP-IDF Tools or skip download and manually enter all required ESP-IDF Tools as explain in [ONBOARDING](./docs/ONBOARDING.md) which will be saved in `idf.customExtraPaths`.
-3. `idf.customExtraVars` stores any custom environment variable we use such as OPENOCD_SCRIPTS, which is the openOCD scripts directory used in openocd server startup. We add these variables to visual studio code process environment variables, choosing the extension variable if available, else extension commands will try to use what is already in your system PATH. **This doesn't modify your system environment outside visual studio code.**
+2. `idf.customExtraPaths` is pre-appended to your system environment variable PATH within Visual Studio Code **(not modifying your system environment)** before executing any of our extension commands such as `openocd` or `cmake` (i.e. build your current project) else extension commands will try to use what is already in your system PATH. In **ESP-IDF: Configure ESP-IDF extension** you can download ESP-IDF Tools or skip IDF Tools download and manually enter all required ESP-IDF Tools as explain in [ONBOARDING](./docs/ONBOARDING.md) which will be saved in `idf.customExtraPaths`.
+3. `idf.customExtraVars` stores any custom environment variable we use such as OPENOCD_SCRIPTS, which is the openOCD scripts directory used in openocd server startup. We add these variables to visual studio code process environment variables, choosing the extension variable if available, else extension commands will try to use what is already in your system PATH. **This doesn't modify your system environment outside Visual Studio Code.**
 4. `idf.adapterTargetName` is used to select the chipset (esp32, esp32 s2, etc.) on which to run our extension commands.
 5. `idf.openOcdConfigs` is used to store an array of openOCD scripts directory relative path config files to use with OpenOCD server. (Example: ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"]).
-6. `idf.espIdfPath` is used to store ESP-IDF directory path within our extension. We override visual studio code process IDF_PATH if this value is available. **This doesn't modify your system environment outside visual studio code.**
+6. `idf.espIdfPath` is used to store ESP-IDF directory path within our extension. We override Visual Studio Code process IDF_PATH if this value is available. **This doesn't modify your system environment outside Visual Studio Code.**
 
-Note: From Visual Studio Code extension context, we can't modify your system PATH or any other environment variable. We do override the current Visual Studio Code process environment variables which might collide with other extension you might have installed. Please review the content of `idf.customExtraPaths` and `idf.customExtraVars` in case you have issues with other extensions.
+**Note**: From Visual Studio Code extension context, we can't modify your system PATH or any other environment variable. We do override the current Visual Studio Code process environment variables which might collide with other extension you might have installed. Please review the content of `idf.customExtraPaths` and `idf.customExtraVars` in case you have issues with other extensions.
 
 ## ESP IDF Settings
 
 This extension contributes the following settings that can be later updated in settings.json or from VSCode Settings Preference menu (F1 -> Preferences: Open Settings (UI)).
 
-### IDF Specific Settings
+### ESP-IDF Specific Settings
 
-These are project IDF Project specific settings
+These are the configuration settings that ESP-IDF extension contributes to your Visual Studio Code editor settings.
 
-| Setting                    | Description                                                                   |
+| Setting ID                 | Description                                                                   |
 | -------------------------- | ----------------------------------------------------------------------------- |
 | `idf.espIdfPath`           | Path to locate ESP-IDF framework (IDF_PATH)                                   |
 | `idf.toolsPath`            | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                 |
@@ -188,7 +192,7 @@ These settings are specific to the Log Tracing
 
 Environment (env) variables and other ESP-IDF settings (config) current values strings can be used in other ESP-IDF setting as `${env:VARNAME}` and `${config:ESPIDFSETTING}`, respectively.
 
-Example : `idf.espIdfPath` = `"${env:HOME}/esp/esp-idf"` would be translated to `"~/esp/esp-idf"`.
+Example : If you want to use `"~/esp/esp-idf"` you can set the value of `idf.espIdfPath` to `"${env:HOME}/esp/esp-idf"`.
 
 ## Available Tasks in tasks.json
 

--- a/i18n/en/out/extension.i18n.json
+++ b/i18n/en/out/extension.i18n.json
@@ -1,5 +1,5 @@
 {
-  "extension.defaultFoldersGeneratedMessage": "Default folders were generated.",
+  "extension.defaultFoldersGeneratedMessage": "Template folders were generated.",
   "extension.openFolderFirst": "Open a folder first.",
   "espIdf.pickAWorkspaceFolder.text": "Select your current folder",
   "extension.noFolderMessage": "No workspace selected.",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -1,5 +1,6 @@
 {
   "espIdf.createFiles.title": "ESP-IDF: Create project",
+  "espIdf.addArduinoAsComponentToCurFolder.title": "ESP-IDF: Add Arduino ESP32 as ESP-IDF Component",
   "espIdf.createIdfTerminal.title": "ESP-IDF: Open ESP-IDF Terminal",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Add vscode configuration folder",
   "espIdf.setPath.title": "ESP-IDF: Configure Paths",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -1,5 +1,6 @@
 {
   "espIdf.createFiles.title": "ESP-IDF: Crear proyecto",
+  "espIdf.addArduinoAsComponentToCurFolder.title": "ESP-IDF: Agregar Arduino ESP32 como componente ESP-IDF",
   "espIdf.createIdfTerminal.title": "ESP-IDF: Abrir terminal ESP-IDF",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Agregar carpeta de configuración vscode",
   "espIdf.setPath.title": "ESP-IDF: Configurar rutas ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -1,5 +1,6 @@
 {
   "espIdf.createFiles.title": "ESP-IDF: 新建项目",
+  "espIdf.addArduinoAsComponentToCurFolder.title": "ESP-IDF: 添加ArduinoESP32作为ESP-IDF组件",
   "espIdf.createIdfTerminal.title": "ESP-IDF: 打开ESP-IDF终端",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: 添加 vscode 配置文件夹",
   "espIdf.setPath.title": "ESP-IDF：配置路径",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "activationEvents": [
     "onCommand:espIdf.createFiles",
+    "onCommand:espIdf.addArduinoAsComponentToCurFolder",
     "onCommand:espIdf.createIdfTerminal",
     "onCommand:espIdf.createVsCodeFolder",
     "onCommand:espIdf.setPath",
@@ -213,6 +214,11 @@
         "command": "espIdf.monitorDevice",
         "key": "ctrl+e m",
         "mac": "cmd+e m"
+      },
+      {
+        "command": "espIdf.createIdfTerminal",
+        "key": "ctrl+e t",
+        "mac": "cmd+e t"
       },
       {
         "command": "espIdf.selectPort",
@@ -451,6 +457,10 @@
       {
         "command": "espIdf.createFiles",
         "title": "%espIdf.createFiles.title%"
+      },
+      {
+        "command": "espIdf.addArduinoAsComponentToCurFolder",
+        "title": "%espIdf.addArduinoAsComponentToCurFolder.title%"
       },
       {
         "command": "espIdf.createVsCodeFolder",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,6 @@
 {
   "espIdf.createFiles.title": "ESP-IDF: Create project",
+  "espIdf.addArduinoAsComponentToCurFolder.title": "ESP-IDF: Add Arduino ESP32 as ESP-IDF Component",
   "espIdf.createIdfTerminal.title": "ESP-IDF: Open ESP-IDF Terminal",
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Add vscode configuration folder",
   "espIdf.setPath.title": "ESP-IDF: Configure Paths",

--- a/src/espIdf/arduino/addArduinoComponent.ts
+++ b/src/espIdf/arduino/addArduinoComponent.ts
@@ -1,0 +1,90 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Thursday, 2nd June 2020 10:57:18 am
+ * Copyright 2020 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getEspIdfVersion } from "../../utils";
+import { spawn } from "child_process";
+import * as idfConf from "../../idfConfiguration";
+import { join } from "path";
+import { ensureDir } from "fs-extra";
+import { OutputChannel } from "../../logger/outputChannel";
+import { Logger } from "../../logger/logger";
+
+export async function cloneArduinoInComponentsFolder(
+  projectDir: string,
+  branchToUse: string
+) {
+  const ARDUINO_ESP32_URL = "https://github.com/espressif/arduino-esp32.git";
+  const componentsDir = join(projectDir, "components");
+  await ensureDir(componentsDir);
+  return new Promise((resolve, reject) => {
+    const arduinoCloneProcess = spawn(
+      `git`,
+      [
+        "clone",
+        "--recursive",
+        "--progress",
+        "-b",
+        branchToUse,
+        ARDUINO_ESP32_URL,
+        "arduino",
+      ],
+      { cwd: componentsDir }
+    );
+    arduinoCloneProcess.stderr.on("data", (data) => {
+      OutputChannel.appendLine(data.toString());
+    });
+
+    arduinoCloneProcess.stdout.on("data", (data) => {
+      OutputChannel.appendLine(data.toString());
+    });
+    arduinoCloneProcess.on("exit", (code, signal) => {
+      if (!signal && code !== 0) {
+        OutputChannel.appendLine(`Arduino ESP32 cloning has exit with ${code}`);
+        reject(`Arduino ESP32 cloning has exit with ${code}`);
+      }
+      resolve();
+    });
+  });
+}
+
+export async function checkIdfVersion(espIdfPath?: string) {
+  if (typeof espIdfPath === "undefined" || espIdfPath === "") {
+    espIdfPath =
+      idfConf.readParameter("idf.espIdfPath") || process.env.IDF_PATH;
+  }
+  const idfVersion = await getEspIdfVersion(espIdfPath);
+  const results = {
+    "4.0": "idf-release/v4.0",
+    "3.3": "idf-release/v3.3",
+  };
+  return results[idfVersion] || undefined;
+}
+
+export async function addArduinoAsComponent(
+  projectDir: string,
+  espIdfPath?: string
+) {
+  const branchToUse = await checkIdfVersion(espIdfPath);
+  if (!branchToUse) {
+    Logger.infoNotify(
+      "ESP-IDF version 4.0 or 3.3 is required for Arduino ESP32"
+    );
+    return;
+  }
+  await ensureDir(projectDir);
+  await cloneArduinoInComponentsFolder(projectDir, branchToUse);
+}

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -86,17 +86,21 @@ export class ExamplesPlanel {
                     selectedFolder[0].fsPath,
                     message.name
                   );
-                  ensureDir(resultFolder).then(() => {
-                    utils.copyFromSrcProject(
-                      message.project_path,
-                      resultFolder
-                    );
-                    const projectPath = vscode.Uri.file(resultFolder);
-                    vscode.commands.executeCommand(
-                      "vscode.openFolder",
-                      projectPath
-                    );
-                  });
+                  ensureDir(resultFolder)
+                    .then(() => {
+                      utils.copyFromSrcProject(
+                        message.project_path,
+                        resultFolder
+                      );
+                      const projectPath = vscode.Uri.file(resultFolder);
+                      vscode.commands.executeCommand(
+                        "vscode.openFolder",
+                        projectPath
+                      );
+                    })
+                    .catch((err) => {
+                      Logger.errorNotify("Error copying ESP-IDF example", err);
+                    });
                 } else {
                   vscode.window.showInformationMessage("No folder selected");
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,7 +277,7 @@ export async function activate(context: vscode.ExtensionContext) {
           {
             cancellable: true,
             location: vscode.ProgressLocation.Notification,
-            title: "ESP-IDF:",
+            title: "Creating ESP-IDF Project...",
           },
           async (
             progress: vscode.Progress<{
@@ -338,7 +338,7 @@ export async function activate(context: vscode.ExtensionContext) {
               cancelToken.onCancellationRequested(() => {
                 arduinoComponentManager.cancel();
               });
-              await arduinoComponentManager.addArduinoAsComponent(progress);
+              await arduinoComponentManager.addArduinoAsComponent();
             }
             const projectPath = vscode.Uri.file(resultFolder);
             vscode.commands.executeCommand(
@@ -365,7 +365,7 @@ export async function activate(context: vscode.ExtensionContext) {
         {
           cancellable: true,
           location: vscode.ProgressLocation.Notification,
-          title: "ESP-IDF:",
+          title: "Arduino ESP32 as ESP-IDF Component",
         },
         async (
           progress: vscode.Progress<{
@@ -374,13 +374,17 @@ export async function activate(context: vscode.ExtensionContext) {
           }>,
           cancelToken: vscode.CancellationToken
         ) => {
-          const arduinoComponentManager = new ArduinoComponentInstaller(
-            workspaceRoot.fsPath
-          );
-          cancelToken.onCancellationRequested(() => {
-            arduinoComponentManager.cancel();
-          });
-          await arduinoComponentManager.addArduinoAsComponent(progress);
+          try {
+            const arduinoComponentManager = new ArduinoComponentInstaller(
+              workspaceRoot.fsPath
+            );
+            cancelToken.onCancellationRequested(() => {
+              arduinoComponentManager.cancel();
+            });
+            await arduinoComponentManager.addArduinoAsComponent();
+          } catch (error) {
+            Logger.errorNotify(error.message, error);
+          }
         }
       );
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { previewReport } from "./coverage/coverageService";
 import { BuildTask } from "./build/buildTask";
 import { FlashTask } from "./flash/flashTask";
 import { TaskManager } from "./taskManager";
+import { addArduinoAsComponent } from "./espIdf/arduino/addArduinoComponent";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -273,7 +274,7 @@ export async function activate(context: vscode.ExtensionContext) {
       utils.chooseTemplateDir(),
       { placeHolder: "Select a template to use" }
     );
-    PreCheck.perform([openFolderCheck], () => {
+    PreCheck.perform([openFolderCheck], async () => {
       if (option) {
         utils.createSkeleton(workspaceRoot.fsPath, option.target);
         const defaultFoldersMsg = locDic.localize(
@@ -281,6 +282,13 @@ export async function activate(context: vscode.ExtensionContext) {
           "Default folders were generated."
         );
         Logger.infoNotify(defaultFoldersMsg);
+        if (option.label === "arduino-as-component") {
+          try {
+            await addArduinoAsComponent(workspaceRoot.fsPath);
+          } catch (error) {
+            Logger.errorNotify(error.message, error);
+          }
+        }
       }
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,10 +143,10 @@ export function updateStatus(
   }
 }
 
-export function createVscodeFolder(curWorkspaceFsPath: string) {
+export async function createVscodeFolder(curWorkspaceFsPath: string) {
   const settingsDir = path.join(curWorkspaceFsPath, ".vscode");
   const vscodeTemplateFolder = path.join(templateDir, ".vscode");
-  copy(vscodeTemplateFolder, settingsDir);
+  await copy(vscodeTemplateFolder, settingsDir);
 }
 
 export function chooseTemplateDir() {
@@ -169,19 +169,20 @@ export function getDirectories(dirPath) {
   });
 }
 
-export function createSkeleton(
+export async function createSkeleton(
   curWorkspacePath: string,
   chosenTemplateDir: string
 ) {
   const templateDirToUse = path.join(templateDir, chosenTemplateDir);
-  copyFromSrcProject(templateDirToUse, curWorkspacePath);
+  await copyFromSrcProject(templateDirToUse, curWorkspacePath);
 }
 
-export function copyFromSrcProject(srcDirPath: string, destinationDir: string) {
-  createVscodeFolder(destinationDir);
-  copy(srcDirPath, destinationDir).catch((err) => {
-    Logger.errorNotify(err, err);
-  });
+export async function copyFromSrcProject(
+  srcDirPath: string,
+  destinationDir: string
+) {
+  await createVscodeFolder(destinationDir);
+  await copy(srcDirPath, destinationDir);
 }
 
 export function delConfigFile(workspaceRoot: vscode.Uri) {

--- a/templates/arduino-as-component/.gitignore
+++ b/templates/arduino-as-component/.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old

--- a/templates/arduino-as-component/CMakeLists.txt
+++ b/templates/arduino-as-component/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(template-app)

--- a/templates/arduino-as-component/CMakeLists.txt
+++ b/templates/arduino-as-component/CMakeLists.txt
@@ -3,4 +3,4 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(template-app)
+project(arduino-as-component)

--- a/templates/arduino-as-component/main/CMakeLists.txt
+++ b/templates/arduino-as-component/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "main.cpp"
+    INCLUDE_DIRS ""
+)

--- a/templates/arduino-as-component/main/main.cpp
+++ b/templates/arduino-as-component/main/main.cpp
@@ -1,0 +1,9 @@
+#include "Arduino.h"
+
+extern "C" void app_main()
+{
+    initArduino();
+    pinMode(4, OUTPUT);
+    digitalWrite(4, HIGH);
+    // Do your own thing
+}

--- a/templates/fibonacci-app/.gitignore
+++ b/templates/fibonacci-app/.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old


### PR DESCRIPTION
Introduce cloning [Arduino ESP32](https://github.com/espressif/arduino-esp32) as ESP-IDF component in two ways:

1) **Create ESP-IDF project** with the `arduino-as-component` will create a new project with Arduino as component and define a template `main.cpp`
2) Will just clone Arduino ESP32 as component for the currently selected workspace folder.

Added choosing directory for **Create ESP-IDF project** with validations.