### PR TITLE
Bugfix/idf tools not available (VSC-360)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -607,15 +607,19 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         vscode.window.withProgress(
           {
-            cancellable: false,
+            cancellable: true,
             location: vscode.ProgressLocation.Notification,
             title: "ESP-IDF: Menuconfig",
           },
           async (
-            progress: vscode.Progress<{ message: string; increment: number }>
+            progress: vscode.Progress<{ message: string; increment: number }>,
+            cancelToken: vscode.CancellationToken
           ) => {
             try {
               ConfserverProcess.registerProgress(progress);
+              cancelToken.onCancellationRequested(() => {
+                ConfserverProcess.dispose();
+              });
               await ConfserverProcess.init(
                 workspaceRoot,
                 context.extensionPath

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -113,6 +113,11 @@ export class IdfToolsManager {
         ) > -1
       );
     });
+    if (!versions || versions.length === 0) {
+      throw new Error(
+        `${pkg.name} doesn't have a compatible version for ${this.platformInfo.platformToUse}`
+      );
+    }
     const linkInfo =
       versions.length > 0
         ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
@@ -131,6 +136,11 @@ export class IdfToolsManager {
         ) > -1
       );
     });
+    if (!versions || versions.length === 0) {
+      throw new Error(
+        `${pkg.name} doesn't have a compatible version for ${this.platformInfo.platformToUse}`
+      );
+    }
     return versions.length > 0 ? versions[0].name : undefined;
   }
 

--- a/src/onboarding/toolsInstall.ts
+++ b/src/onboarding/toolsInstall.ts
@@ -46,7 +46,7 @@ export async function downloadToolsInIdfToolsPath(
   }
   const downloadManager = new DownloadManager(installDir);
   const installManager = new InstallManager(installDir);
-  return vscode.window.withProgress(
+  await vscode.window.withProgress(
     {
       cancellable: false,
       location: vscode.ProgressLocation.Notification,
@@ -70,23 +70,15 @@ export async function downloadToolsInIdfToolsPath(
         });
       OutputChannel.appendLine("");
       Logger.info("");
-      await downloadManager
-        .downloadPackages(idfToolsManager, progress, packagesProgress)
-        .catch((reason) => {
-          OutputChannel.appendLine(reason);
-          Logger.info(reason);
-        });
+      await downloadManager.downloadPackages(
+        idfToolsManager,
+        progress,
+        packagesProgress
+      );
       OutputChannel.appendLine("");
       Logger.info("");
-      await installManager
-        .installPackages(idfToolsManager, progress)
-        .then(() => {
-          OnBoardingPanel.postMessage({ command: "set_tools_setup_finish" });
-        })
-        .catch((reason) => {
-          OutputChannel.appendLine(reason);
-          Logger.info(reason);
-        });
+      await installManager.installPackages(idfToolsManager, progress);
+      OnBoardingPanel.postMessage({ command: "set_tools_setup_finish" });
       progress.report({
         message: `Installing python virtualenv and ESP-IDF python requirements...`,
       });
@@ -102,10 +94,7 @@ export async function downloadToolsInIdfToolsPath(
         confTarget,
         selectedWorkspaceFolder,
         systemPythonPath
-      ).catch((reason) => {
-        OutputChannel.appendLine(reason);
-        Logger.info(reason);
-      });
+      );
       let exportPaths = await idfToolsManager.exportPaths(
         path.join(installDir, "tools")
       );


### PR DESCRIPTION
throw error for IDF Tools when a version is not found. Capture errors on `downloadToolsInIdfToolsPath` caller.

Add cancellable gui menuconfig loading.

Should block IDF Tools download to fix #114 fo example.