### PR TITLE
add idf task definition (VSC-374)

### DIFF
--- a/package.json
+++ b/package.json
@@ -710,6 +710,17 @@
         "language": "kconfig",
         "path": "./snippets/kconfig.code-snippets"
       }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "esp-idf",
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "Command to be executed"
+          }
+        }
+      }
     ]
   },
   "extensionDependencies": [

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -74,7 +74,7 @@ export class BuildTask {
       options
     );
     TaskManager.addTask(
-      { type: "shell" },
+      { type: "esp-idf", command: compileExecution.commandLine },
       vscode.TaskScope.Workspace,
       "ESP-IDF Compile",
       compileExecution,
@@ -82,7 +82,7 @@ export class BuildTask {
     );
     const buildExecution = this.getShellExecution(["--build", "."], options);
     TaskManager.addTask(
-      { type: "shell" },
+      { type: "esp-idf", command: buildExecution.commandLine },
       vscode.TaskScope.Workspace,
       "ESP-IDF Build",
       buildExecution,

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -69,7 +69,7 @@ export class FlashTask {
     this.verifyArgs();
     const flashExecution = this._flashExecution();
     TaskManager.addTask(
-      { type: "shell" },
+      { type: "esp-idf", command: flashExecution.commandLine },
       vscode.TaskScope.Workspace,
       "ESP-IDF Flash",
       flashExecution,

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -18,6 +18,10 @@
 
 import * as vscode from "vscode";
 
+export interface IdfTaskDefinition extends vscode.TaskDefinition {
+  command?: string;
+}
+
 export class TaskManager {
   private static tasks: vscode.Task[] = [];
   private static disposables: vscode.Disposable[] = [];


### PR DESCRIPTION
Not really an error but was using predefined shell task definition which required some additional fields and had some output in output tasks.

Instead, defined our esp-idf task definition.

Fix #131 