### PR TITLE
add arguments to debug adapter manager (VSC-379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,14 @@ jobs:
           name: esp-idf-extension.vsix
           path: esp-idf-extension.vsix
 
+      - name: xvfb
+        run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
       - name: Extension Test
-        uses: GabrielBB/xvfb-action@v1.2
-        with:
-          run: yarn test --VERBOSE | tee testing.results.log
+        run: yarn test --VERBOSE 2>&1 | tee testing.results.log
         env:
           CODE_VERSION: "1.41.1"
+          DISPLAY: ":99.0"
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.5
+          python-version: 3.6
 
       - name: Install Node Dependencies
         run: yarn
@@ -49,7 +49,7 @@ jobs:
         run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Extension Test
-        run: yarn test --VERBOSE 2>&1 | tee testing.results.log
+        run: yarn test --VERBOSE 2>&1 >> testing.results.log
         env:
           CODE_VERSION: "1.41.1"
           DISPLAY: ":99.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,12 @@ jobs:
           name: esp-idf-extension.vsix
           path: esp-idf-extension.vsix
 
-      - name: xvfb
-        run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-
       - name: Extension Test
-        run: yarn test --VERBOSE 2>&1 | tee testing.results.log
+        uses: GabrielBB/xvfb-action@v1.2
+        with:
+          run: yarn test --VERBOSE 2>&1 >> testing.results.log
         env:
           CODE_VERSION: "1.41.1"
-          DISPLAY: ":99.0"
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Extension Test
         uses: GabrielBB/xvfb-action@v1.2
         with:
-          run: yarn test --VERBOSE
+          run: yarn test --VERBOSE | tee testing.results.log
+          env:
+            CODE_VERSION: "1.41.1"
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.2
         with:
           run: yarn test --VERBOSE | tee testing.results.log
-          env:
-            CODE_VERSION: "1.41.1"
+        env:
+          CODE_VERSION: "1.41.1"
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,7 @@ jobs:
       - name: Extension Test
         uses: GabrielBB/xvfb-action@v1.2
         with:
-          run: yarn test --VERBOSE 2>&1 >> testing.results.log
-        env:
-          CODE_VERSION: "1.41.1"
+          run: yarn test
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,10 @@ jobs:
           name: esp-idf-extension.vsix
           path: esp-idf-extension.vsix
 
-      - name: xvfb
-        run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-
       - name: Extension Test
-        run: yarn test --VERBOSE >> testing.results.log
-        env:
-          CODE_VERSION: "1.41.1"
-          DISPLAY: ":99.0"
+        uses: GabrielBB/xvfb-action@v1.2
+        with:
+          run: yarn test --VERBOSE
 
       - name: Upload testing.results.log
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Extension Test
-        run: yarn test --VERBOSE 2>&1 >> testing.results.log
+        run: yarn test --VERBOSE 2>&1 | tee testing.results.log
         env:
           CODE_VERSION: "1.41.1"
           DISPLAY: ":99.0"

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -69,5 +69,8 @@
   "esp.rainmaker.backend.remove_node.title": "Remove this node",
   "esp.rainmaker.backend.update_node_param.title": "Update param for device",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
-  "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub"
+  "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
+  "esp_idf.setupCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
+  "esp_idf.debuggers.text.description": "The command to execute",
+  "esp_idf.debuggers.description.description": "Optional command description"
 }

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -70,7 +70,6 @@
   "esp.rainmaker.backend.update_node_param.title": "Update param for device",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
-  "esp_idf.setupCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
-  "esp_idf.debuggers.text.description": "The command to execute",
-  "esp_idf.debuggers.description.description": "Optional command description"
+  "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.debuggers.text.description": "The command to execute"
 }

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -71,5 +71,6 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
   "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -71,5 +71,6 @@
   "param.esp.rainmaker.oauth.url": "URL del servidor ESP-Rainmaker OAuth",
   "idf.wssPort.description": "Puerto del servidor Web Socket para Core-Dump o GDB-Stub",
   "esp_idf.initGdbCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.gdbinitFile.description": "ruta del archivo gdbinit para el ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "Comando a ejecutar"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -70,7 +70,6 @@
   "esp.rainmaker.backend.update_node_param.title": "Actualizar parámetros para dispositivos",
   "param.esp.rainmaker.oauth.url": "URL del servidor ESP-Rainmaker OAuth",
   "idf.wssPort.description": "Puerto del servidor Web Socket para Core-Dump o GDB-Stub",
-  "esp_idf.setupCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Conectar GDB al ESP en el puerto serial /dev/ttyUSB0\" }].",
-  "esp_idf.debuggers.text.description": "Comando a ejecutar",
-  "esp_idf.debuggers.description.description": "Descripcion del comando a ejecutar"
+  "esp_idf.initGdbCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.debuggers.text.description": "Comando a ejecutar"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -69,5 +69,8 @@
   "esp.rainmaker.backend.remove_node.title": "Eliminar este nodo",
   "esp.rainmaker.backend.update_node_param.title": "Actualizar parámetros para dispositivos",
   "param.esp.rainmaker.oauth.url": "URL del servidor ESP-Rainmaker OAuth",
-  "idf.wssPort.description": "Puerto del servidor Web Socket para Core-Dump o GDB-Stub"
+  "idf.wssPort.description": "Puerto del servidor Web Socket para Core-Dump o GDB-Stub",
+  "esp_idf.setupCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Conectar GDB al ESP en el puerto serial /dev/ttyUSB0\" }].",
+  "esp_idf.debuggers.text.description": "Comando a ejecutar",
+  "esp_idf.debuggers.description.description": "Descripcion del comando a ejecutar"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -69,5 +69,8 @@
   "esp.rainmaker.backend.remove_node.title": "删除该节点",
   "esp.rainmaker.backend.update_node_param.title": "更新设备的参数",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth服务器网址",
-  "idf.wssPort.description": "用于核心转储或GDB存根的Web套接字服务器端口"
+  "idf.wssPort.description": "用于核心转储或GDB存根的Web套接字服务器端口",
+  "esp_idf.setupCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
+  "esp_idf.debuggers.text.description": "要执行的命令",
+  "esp_idf.debuggers.description.description": "可选命令说明"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -70,7 +70,6 @@
   "esp.rainmaker.backend.update_node_param.title": "更新设备的参数",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth服务器网址",
   "idf.wssPort.description": "用于核心转储或GDB存根的Web套接字服务器端口",
-  "esp_idf.setupCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
-  "esp_idf.debuggers.text.description": "要执行的命令",
-  "esp_idf.debuggers.description.description": "可选命令说明"
+  "esp_idf.initGdbCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
+  "esp_idf.debuggers.text.description": "要执行的命令"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -71,5 +71,6 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth服务器网址",
   "idf.wssPort.description": "用于核心转储或GDB存根的Web套接字服务器端口",
   "esp_idf.initGdbCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
+  "esp_idf.gdbinitFile.description": "ESP-IDF调试适配器的gdbinit文件路径",
   "esp_idf.debuggers.text.description": "要执行的命令"
 }

--- a/package.json
+++ b/package.json
@@ -736,24 +736,13 @@
                 "description": "Environments variables override in Visual Studio Code launched ESP-IDF Debug Adapter",
                 "default": null
               },
-              "setupCommands": {
+              "initGdbCommands": {
                 "type": "array",
-                "description": "%esp_idf.setupCommands.description%",
+                "description": "%esp_idf.initGdbCommands.description%",
                 "items": {
-                  "type": "object",
-                  "default": {},
-                  "properties": {
-                    "text": {
-                      "type": "string",
-                      "description": "%esp_idf.debuggers.text.description%",
-                      "default": ""
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "%esp_idf.debuggers.description.description%",
-                      "default": ""
-                    }
-                  }
+                  "type": "string",
+                  "description": "%esp_idf.debuggers.text.description%",
+                  "default": ""
                 },
                 "default": []
               }

--- a/package.json
+++ b/package.json
@@ -735,6 +735,27 @@
                 "type": "object",
                 "description": "Environments variables override in Visual Studio Code launched ESP-IDF Debug Adapter",
                 "default": null
+              },
+              "setupCommands": {
+                "type": "array",
+                "description": "%esp_idf.setupCommands.description%",
+                "items": {
+                  "type": "object",
+                  "default": {},
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "description": "%esp_idf.debuggers.text.description%",
+                      "default": ""
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "%esp_idf.debuggers.description.description%",
+                      "default": ""
+                    }
+                  }
+                },
+                "default": []
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -821,7 +821,7 @@
     "debugPreTask": "webpack --mode development",
     "compile": "tsc -p ./",
     "watch": "webpack --watch --mode development",
-    "test": "yarn run compile && node ./out/test/runTest.js",
+    "test": "tsc -p ./ && node ./out/test/runTest.js --VERBOSE 2>&1 >> testing.results.log",
     "package": "vsce package --yarn -o esp-idf-extension.vsix",
     "release": "vsce publish --yarn -p ${VS_MARKETPLACE_TOKEN}",
     "gulp_clean": "gulp clean",

--- a/package.json
+++ b/package.json
@@ -745,6 +745,11 @@
                   "default": ""
                 },
                 "default": []
+              },
+              "gdbinitFile": {
+                "type": "string",
+                "description": "%esp_idf.gdbinitFile.description%",
+                "default": ""
               }
             }
           }

--- a/package.nls.json
+++ b/package.nls.json
@@ -69,5 +69,8 @@
   "esp.rainmaker.backend.remove_node.title": "Remove this node",
   "esp.rainmaker.backend.update_node_param.title": "Update param for device",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
-  "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub"
+  "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
+  "esp_idf.setupCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
+  "esp_idf.debuggers.text.description": "The command to execute",
+  "esp_idf.debuggers.description.description": "Optional command description"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -70,7 +70,6 @@
   "esp.rainmaker.backend.update_node_param.title": "Update param for device",
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
-  "esp_idf.setupCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"target remote /dev/ttyUSB0\", \"description\": \"Connect GDB to ESP on serial port/dev/ttyUSB0\" }].",
-  "esp_idf.debuggers.text.description": "The command to execute",
-  "esp_idf.debuggers.description.description": "Optional command description"
+  "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.debuggers.text.description": "The command to execute"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -71,5 +71,6 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
   "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gcovr
+websocket_client

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -140,6 +140,7 @@
     "param.esp.rainmaker.oauth.url",
     "idf.wssPort.description",
     "esp_idf.initGdbCommands.description",
-    "esp_idf.debuggers.text.description"
+    "esp_idf.debuggers.text.description",
+    "esp_idf.gdbinitFile.description"
   ]
 }

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -138,6 +138,8 @@
     "esp.rainmaker.backend.remove_node.title",
     "esp.rainmaker.backend.update_node_param.title",
     "param.esp.rainmaker.oauth.url",
-    "idf.wssPort.description"
+    "idf.wssPort.description",
+    "esp_idf.initGdbCommands.description",
+    "esp_idf.debuggers.text.description"
   ]
 }

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -123,6 +123,7 @@ export class DebugAdapterManager extends EventEmitter {
       }
       if (this.coreDumpFile) {
         adapterArgs.push("-c", this.coreDumpFile);
+        adapterArgs.push("-om", "without_oocd");
       }
       const resultGdbInitFile = this.gdbinitFilePath
         ? this.gdbinitFilePath

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -239,11 +239,14 @@ export class DebugAdapterManager extends EventEmitter {
       "debug_adapter"
     );
     this.initGdbCommands = [];
-    this.elfFile = `${path.join(
-      this.currentWorkspace.fsPath,
-      "build",
-      "project-name"
-    )}.elf`;
+    this.elfFile = "";
+    if (this.currentWorkspace) {
+      this.elfFile = `${path.join(
+        this.currentWorkspace.fsPath,
+        "build",
+        "project-name"
+      )}.elf`;
+    }
   }
 
   private sendToOutputChannel(data: Buffer) {

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -118,9 +118,6 @@ export class DebugAdapterManager extends EventEmitter {
         "-dn",
         this.target,
       ];
-      this.isPostMortemDebugMode
-        ? adapterArgs.push("-om", "without_oocd")
-        : adapterArgs.push("-om", "connect_to_instance");
       if (this.isPostMortemDebugMode) {
         adapterArgs.push("-pm");
       }

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -37,11 +37,11 @@ export interface IDebugAdapterConfig {
   debugAdapterPort?: number;
   elfFile?: string;
   env?: NodeJS.ProcessEnv;
-  logLevel?: number;
-  isPostMortemDebugMode: boolean;
-  target?: string;
-  initGdbCommands?: string[];
   gdbinitFilePath?: string;
+  initGdbCommands?: string[];
+  isPostMortemDebugMode: boolean;
+  logLevel?: number;
+  target?: string;
 }
 
 export class DebugAdapterManager extends EventEmitter {
@@ -61,11 +61,11 @@ export class DebugAdapterManager extends EventEmitter {
   private displayChan: vscode.OutputChannel;
   private elfFile: string;
   private env;
+  private gdbinitFilePath: string;
+  private initGdbCommands: string[];
+  private isPostMortemDebugMode: boolean;
   private logLevel: number;
   private port: number;
-  private isPostMortemDebugMode: boolean;
-  private initGdbCommands: string[];
-  private gdbinitFilePath: string;
   private target: string;
 
   private constructor(context: vscode.ExtensionContext) {
@@ -198,20 +198,18 @@ export class DebugAdapterManager extends EventEmitter {
         this.env[envVar] = config.env[envVar];
       }
     }
-    if (config.logLevel) {
-      this.logLevel = config.logLevel;
-    }
-    if (typeof config.isPostMortemDebugMode !== "undefined") {
-      this.isPostMortemDebugMode = config.isPostMortemDebugMode;
-    }
-    if (config.target) {
-      this.target = config.target;
+    if (config.gdbinitFilePath) {
+      this.gdbinitFilePath = config.gdbinitFilePath;
     }
     if (config.initGdbCommands) {
       this.initGdbCommands = config.initGdbCommands;
     }
-    if (config.gdbinitFilePath) {
-      this.gdbinitFilePath = config.gdbinitFilePath;
+    this.isPostMortemDebugMode = config.isPostMortemDebugMode;
+    if (config.logLevel) {
+      this.logLevel = config.logLevel;
+    }
+    if (config.target) {
+      this.target = config.target;
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -685,8 +685,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (
           launchMode === "auto" &&
           !openOCDManager.isRunning() &&
-          session.name !== "Core Dump Debug" &&
-          session.name !== "GDB Stub Debug"
+          session.name !== "Core Dump Debug"
         ) {
           isOpenOCDLaunchedByDebug = true;
           await openOCDManager.start();
@@ -1411,7 +1410,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const coreDumpFile = "my-core-dump.elf";
         const debugAdapterConfig = {
           coreDumpFile: coreDumpFile,
-          isPostMortemDebugMode: false,
+          isPostMortemDebugMode: true,
         } as IDebugAdapterConfig;
         debugAdapterManager.configureAdapter(debugAdapterConfig);
         await vscode.debug.startDebugging(undefined, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,6 @@ import { srcOp, UpdateCmakeLists } from "./cmake/srcsWatcher";
 import {
   DebugAdapterManager,
   IDebugAdapterConfig,
-  ISetupCmd,
 } from "./espIdf/debugAdapter/debugAdapterManager";
 import { ConfserverProcess } from "./espIdf/menuconfig/confServerProcess";
 import {
@@ -1399,14 +1398,10 @@ export async function activate(context: vscode.ExtensionContext) {
         wsServer.done();
       })
       .on("gdb-stub-detected", (resp) => {
-        //
         const port = idfConf.readParameter("idf.port");
-        const setupCmd = {
-          text: `target remote ${port}`,
-          description: "Start GDB on serial port",
-        } as ISetupCmd;
+        const setupCmd = [`target remote ${port}`];
         const debugAdapterConfig = {
-          setupCommands: [setupCmd],
+          initGdbCommands: setupCmd,
           isPostMortemDebugMode: true,
         } as IDebugAdapterConfig;
         debugAdapterManager.configureAdapter(debugAdapterConfig);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -689,6 +689,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const debugAdapterConfig = {
           debugAdapterPort: portToUse,
           env: session.configuration.env,
+          initGdbCommands: session.configuration.initGdbCommands || [],
           isPostMortemDebugMode: false,
           logLevel: session.configuration.logLevel,
         } as IDebugAdapterConfig;

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -47,7 +47,7 @@ export class FlashTask {
   }
 
   private verifyArgs() {
-    if (!canAccessFile(this.flashScriptPath)) {
+    if (!canAccessFile(this.flashScriptPath, constants.R_OK)) {
       throw new Error("SCRIPT_PERMISSION_ERROR");
     }
     for (const flashFile of this.model.flashSections) {

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -68,6 +68,10 @@ export async function installPythonEnv(
       : ["bin", "python"];
   const virtualEnvPython = path.join(pyEnvPath, ...pyDir);
   const requirements = path.join(espDir, "requirements.txt");
+  const extensionRequirements = path.join(
+    utils.extensionContext.extensionPath,
+    "requirements.txt"
+  );
   const debugAdapterRequirements = path.join(
     utils.extensionContext.extensionPath,
     "esp_debug_adapter",
@@ -152,6 +156,17 @@ export async function installPythonEnv(
   pyTracker.Log = "\n";
   if (channel) {
     channel.appendLine(espIdfReqInstallResult + "\n");
+  }
+  // Extension Python requirements
+  const extensionInstallResult = await utils.execChildProcess(
+    `"${virtualEnvPython}" -m pip install -r "${extensionRequirements}"`,
+    pyEnvPath,
+    channel
+  );
+  pyTracker.Log = extensionInstallResult;
+  pyTracker.Log = "\n";
+  if (channel) {
+    channel.appendLine(extensionInstallResult + "\n");
   }
   // Debug Adapter Python Requirements
   pyTracker.Log = installDAPyPkgsMsg;


### PR DESCRIPTION
Move elf file to debug adapter bag of options (`IDebugAdapterConfig `) and added extra arguments for debug adapter manager

* Add setupCommands for launch.json configuration to pass multiple `--setup-cmd cmd1` for 

launch.json
```
setupCommands: [
   {
      text: "cmd1",
      description: "some description"
   },
   {
      text: "cmd2",
      description: "some description"
   }
]
```
added some `--postmortem` as debug adapter argument for post mortem debug initialization.