### PR TITLE
Fix the registerIDFCommand by returning the closure's result (VSC-382)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,7 +139,7 @@ export async function activate(context: vscode.ExtensionContext) {
     name: string,
     callback: (...args: any[]) => any
   ): number => {
-    const telemetryCallback = (...args: any[]) => {
+    const telemetryCallback = (...args: any[]): any => {
       const startTime = Date.now();
       Logger.info(`Command::${name}::Executed`);
       const cbResult = callback.apply(this, args);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,9 +142,10 @@ export async function activate(context: vscode.ExtensionContext) {
     const telemetryCallback = (...args: any[]) => {
       const startTime = Date.now();
       Logger.info(`Command::${name}::Executed`);
-      callback.apply(this, args);
+      const cbResult = callback.apply(this, args);
       const timeSpent = Date.now() - startTime;
       Telemetry.sendEvent("command", { commandName: name }, { timeSpent });
+      return cbResult;
     };
     return context.subscriptions.push(
       vscode.commands.registerCommand(name, telemetryCallback)


### PR DESCRIPTION
`registerIDFCommand` was not returning the value from the callback function which make tasks.json and launch.json command executions (which expected a return value) fails.

Fix #141 