### PR TITLE
add fallback value for int and hex (VSC-387)

### DIFF
--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -102,8 +102,21 @@ export class ConfserverProcess {
         newValueRequest = `{"version": 2, "set": { "${updatedValue.value}": true }}\n`;
         break;
       case menuType.string:
-      case menuType.hex:
         newValueRequest = `{"version": 2, "set": { "${updatedValue.id}": "${updatedValue.value}" }}\n`;
+        break;
+      case menuType.hex:
+        newValueRequest = `{"version": 2, "set": { "${updatedValue.id}": "${
+          updatedValue.value || "0"
+        }" }}\n`;
+        break;
+      case menuType.int:
+        if (updatedValue.value === "") {
+          updatedValue.value =
+            updatedValue.range && updatedValue.range.length > 0
+              ? updatedValue.range[0]
+              : 0;
+        }
+        newValueRequest = `{"version": 2, "set": { "${updatedValue.id}": ${updatedValue.value} }}\n`;
         break;
       default:
         newValueRequest = `{"version": 2, "set": { "${updatedValue.id}": ${updatedValue.value} }}\n`;


### PR DESCRIPTION
Fix #147 by adding fallback values on empty input for int and hex config elements in gui menuconfig webview.