### PR TITLE
Add interface cfg-file into the default `idf.openOcdConfigs`config (VSC-420)

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
           "idf.openOcdConfigs": {
             "type": "array",
             "default": [
+              "interface/ftdi/esp32_devkitj_v1.cfg",
               "board/esp32-wrover.cfg"
             ],
             "description": "%param.openOcdConfigFilesList%",


### PR DESCRIPTION
Probably related to https://github.com/espressif/openocd-esp32/issues/118