### PR TITLE
update connection-check key (VSC-424)

### DIFF
--- a/src/test/adapter.test.ts
+++ b/src/test/adapter.test.ts
@@ -35,7 +35,7 @@ suite("Debug Adapter Tests", () => {
   setup((done) => {
     debugClient = new EspIdfDebugClient(
       "python",
-      ["-u", DEBUG_ADAPTER, "-cc"],
+      ["-u", DEBUG_ADAPTER, "--developer-mode", "connection-check"],
       "espidf",
       { cwd: __dirname },
       true


### PR DESCRIPTION
This MR adds small fix actualizing debug adapter test mode keys with future release of the Adapter. 

Should be merged AFTER we move to a new adapter released on github as a separated repo