### PR TITLE
Add new project compiler path

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,4 +35,12 @@ export namespace ESP {
       export const GrantType = "authorization_code";
     }
   }
+
+  export namespace URL {
+    export const GithubRepository =
+      "https://github.com/espressif/vscode-esp-idf-extension";
+    export namespace Docs {
+      export const README = ESP.URL.GithubRepository + "/blob/master/README.md";
+    }
+  }
 }

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -92,7 +92,6 @@ export class ExamplesPlanel {
               canSelectMany: false,
             });
             if (!selectedFolder) {
-              vscode.window.showInformationMessage("No folder selected");
               return;
             }
             try {

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -101,7 +101,10 @@ export class ExamplesPlanel {
                 message.name
               );
               await ensureDir(resultFolder);
-              utils.copyFromSrcProject(message.project_path, resultFolder);
+              await utils.copyFromSrcProject(
+                message.project_path,
+                resultFolder
+              );
               const settingsJsonPath = path.join(
                 resultFolder,
                 ".vscode",

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -137,7 +137,6 @@ export class ExamplesPlanel {
               if (opt === "Show Docs") {
                 vscode.env.openExternal(vscode.Uri.parse(ESP.URL.Docs.README));
               }
-              return;
             }
           }
           break;

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -20,6 +20,7 @@ import { Logger } from "../logger/logger";
 import * as utils from "../utils";
 import { createExamplesHtml } from "./createExamplesHtml";
 import marked from "marked";
+import { ESP } from "../config";
 
 const locDic = new LocDictionary("ExamplesPanel");
 
@@ -126,7 +127,17 @@ export class ExamplesPlanel {
               const projectPath = vscode.Uri.file(resultFolder);
               vscode.commands.executeCommand("vscode.openFolder", projectPath);
             } catch (error) {
-              Logger.errorNotify("Error copying ESP-IDF example", error);
+              const msg = `Error copying ESP-IDF example.`;
+              Logger.error(msg, error);
+              const opt = await vscode.window.showErrorMessage(
+                msg,
+                "Show Docs",
+                "Ok"
+              );
+              if (opt === "Show Docs") {
+                vscode.env.openExternal(vscode.Uri.parse(ESP.URL.Docs.README));
+              }
+              return;
             }
           }
           break;

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ensureDir, readFile } from "fs-extra";
+import { ensureDir, readFile, readJSON, writeJSON } from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
 import { LocDictionary } from "../localizationDictionary";
@@ -110,15 +110,20 @@ export class ExamplesPlanel {
                 ".vscode",
                 "settings.json"
               );
-              const settingsJson = await utils.readJson(settingsJsonPath);
+              const settingsJson = await readJSON(settingsJsonPath);
               const modifiedEnv = utils.appendIdfAndToolsToPath();
+              const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
               const compilerPath = await utils.isBinInPath(
-                "xtensa-esp32-elf-gdb",
+                `xtensa-${idfTarget}-elf-gdb`,
                 resultFolder,
                 modifiedEnv
               );
               settingsJson["C_Cpp.default.compilerPath"] = compilerPath;
-              await utils.writeJson(settingsJsonPath, settingsJson);
+              await writeJSON(settingsJsonPath, settingsJson, {
+                spaces:
+                  vscode.workspace.getConfiguration().get("editor.tabSize") ||
+                  2,
+              });
               const projectPath = vscode.Uri.file(resultFolder);
               vscode.commands.executeCommand("vscode.openFolder", projectPath);
             } catch (error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -767,7 +767,7 @@ export async function activate(context: vscode.ExtensionContext) {
       try {
         return await utils.isBinInPath(
           "xtensa-esp32-elf-gdb",
-          this.workspaceRoot.fsPath,
+          workspaceRoot.fsPath,
           modifiedEnv
         );
       } catch (error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@
 import * as childProcess from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
-import { copy, pathExists } from "fs-extra";
+import { copy, pathExists, readJSON, writeJSON } from "fs-extra";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import { EOL } from "os";
 import * as path from "path";
@@ -196,6 +196,19 @@ export function fileExists(filePath) {
 
 export function readFileSync(filePath) {
   return fs.readFileSync(filePath, "utf-8");
+}
+
+export function doesPathExists(inputPath: string) {
+  return pathExists(inputPath);
+}
+export function readJson(jsonPath: string) {
+  return readJSON(jsonPath);
+}
+
+export function writeJson(jsonPath: string, object: any) {
+  return writeJSON(jsonPath, object, {
+    spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+  });
 }
 
 export function readComponentsDirs(filePath): IdfComponent[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@
 import * as childProcess from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
-import { copy, pathExists, readJSON, writeJSON } from "fs-extra";
+import { copy, pathExists } from "fs-extra";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import { EOL } from "os";
 import * as path from "path";
@@ -196,19 +196,6 @@ export function fileExists(filePath) {
 
 export function readFileSync(filePath) {
   return fs.readFileSync(filePath, "utf-8");
-}
-
-export function doesPathExists(inputPath: string) {
-  return pathExists(inputPath);
-}
-export function readJson(jsonPath: string) {
-  return readJSON(jsonPath);
-}
-
-export function writeJson(jsonPath: string, object: any) {
-  return writeJSON(jsonPath, object, {
-    spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
-  });
 }
 
 export function readComponentsDirs(filePath): IdfComponent[] {

--- a/templates/.vscode/c_cpp_properties.json
+++ b/templates/.vscode/c_cpp_properties.json
@@ -1,8 +1,8 @@
 {
   "configurations": [
     {
-      "name": "Linux",
-      "compilerPath": "${command:espIdf.getXtensaGdb}",
+      "name": "ESP-IDF",
+      "compilerPath": "${default}",
       "cStandard": "c11",
       "cppStandard": "c++17",
       "includePath": [

--- a/templates/.vscode/c_cpp_properties.json
+++ b/templates/.vscode/c_cpp_properties.json
@@ -2,6 +2,7 @@
   "configurations": [
     {
       "name": "Linux",
+      "compilerPath": "${command:espIdf.getXtensaGdb}",
       "cStandard": "c11",
       "cppStandard": "c++17",
       "includePath": [

--- a/templates/.vscode/settings.json
+++ b/templates/.vscode/settings.json
@@ -7,6 +7,5 @@
   "[c]": {
     "editor.quickSuggestions": true
   },
-  "C_Cpp.intelliSenseEngineFallback": "Enabled",
   "C_Cpp.intelliSenseEngine": "Tag Parser",
 }

--- a/templates/.vscode/settings.json
+++ b/templates/.vscode/settings.json
@@ -7,5 +7,6 @@
   "[c]": {
     "editor.quickSuggestions": true
   },
-  "C_Cpp.intelliSenseEngineFallback": "Enabled"
+  "C_Cpp.intelliSenseEngineFallback": "Enabled",
+  "C_Cpp.intelliSenseEngine": "Tag Parser",
 }


### PR DESCRIPTION
Add `compilerPath` to settings.json `C_Cpp.default.compilerPath` for `c_cpp_properties.json` default compiler path on Create project from example.

Fix #191 