### PR TITLE
Codicons in sdkconfig editor (VSC-467)

### DIFF
--- a/package.json
+++ b/package.json
@@ -835,6 +835,7 @@
     "typescript": "^3.9.5",
     "typescript-tslint-plugin": "^0.3.1",
     "vsce": "^1.52.0",
+    "vscode-codicons": "^0.0.12",
     "vscode-nls-dev": "^3.3.1",
     "vscode-test": "^1.0.0",
     "vue-class-component": "^7.1.0",

--- a/src/espIdf/menuconfig/MenuconfigPanel.ts
+++ b/src/espIdf/menuconfig/MenuconfigPanel.ts
@@ -71,6 +71,9 @@ export class MenuConfigPanel {
         retainContextWhenHidden: true,
         localResourceRoots: [
           vscode.Uri.file(path.join(extensionPath, "dist", "views")),
+          vscode.Uri.file(
+            path.join(extensionPath, "node_modules", "vscode-codicons", "dist")
+          ),
         ],
       }
     );
@@ -79,8 +82,22 @@ export class MenuConfigPanel {
         path.join(extensionPath, "dist", "views", "menuconfig-bundle.js")
       )
     );
+    const codiconsUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(
+        path.join(
+          extensionPath,
+          "node_modules",
+          "vscode-codicons",
+          "dist",
+          "codicon.css"
+        )
+      )
+    );
     this.panel.iconPath = getWebViewFavicon(extensionPath);
-    this.panel.webview.html = this.createMenuconfigHtml(scriptPath);
+    this.panel.webview.html = this.createMenuconfigHtml(
+      scriptPath,
+      codiconsUri
+    );
 
     ConfserverProcess.registerListener(this.updateConfigValues);
 
@@ -231,13 +248,17 @@ export class MenuConfigPanel {
     });
   }
 
-  private createMenuconfigHtml(scriptPath: vscode.Uri): string {
+  private createMenuconfigHtml(
+    scriptPath: vscode.Uri,
+    codiconsUri: vscode.Uri
+  ): string {
     return `<!DOCTYPE html>
         <html lang="en">
         <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Menuconfig</title>
+            <title>SDK Configuration Editor</title>
+            <link href="${codiconsUri}" rel="stylesheet" />
             </head>
             <body>
                 <div id="menuconfig"></div>

--- a/src/views/menuconfig/components/SideNavItem.vue
+++ b/src/views/menuconfig/components/SideNavItem.vue
@@ -4,20 +4,15 @@
     :href="'#' + menu.id"
   >
     <div class="menu-line">
-      <font-awesome-icon
-        v-if="menu.isCollapsed"
-        v-show="menuSubItems.length > 0"
-        icon="caret-right"
-        class="info-icon"
-        @click="collapse"
-      />
-      <font-awesome-icon
-        v-else
-        v-show="menuSubItems.length > 0"
-        icon="caret-down"
-        class="info-icon"
-        @click="collapse"
-      />
+      <div class="info-icon" @click="collapse" v-show="menuSubItems.length > 0">
+        <i
+          :class="
+            menu.isCollapsed
+              ? 'codicon codicon-chevron-right'
+              : 'codicon codicon-chevron-down'
+          "
+        ></i>
+      </div>
       <p @click="setAsSelectedMenu" v-text="menu.title" />
     </div>
     <ul

--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -1,15 +1,13 @@
 <template>
-  <div v-if="config.isVisible">
+  <div v-if="config.isVisible" :class="{ 'config-el': config.type !== 'menu' }">
     <div v-if="config.type === 'choice'" class="form-group">
       <div class="field">
         <div class="field has-addons">
           <label v-text="config.title" />
           <div class="control">
-            <font-awesome-icon
-              icon="info-circle"
-              class="info-icon"
-              @click="toggleHelp"
-            />
+            <div class="info-icon" @click="toggleHelp">
+              <i class="codicon codicon-info"></i>
+            </div>
           </div>
         </div>
         <div class="field">
@@ -39,11 +37,9 @@
         <div class="field has-addons">
           <label :for="config.id" v-text="config.title" />
           <div class="control">
-            <font-awesome-icon
-              icon="info-circle"
-              class="info-icon"
-              @click="toggleHelp"
-            />
+            <div class="info-icon" @click="toggleHelp">
+              <i class="codicon codicon-info"></i>
+            </div>
           </div>
         </div>
       </div>
@@ -52,11 +48,9 @@
       <div class="field has-addons">
         <label v-text="config.title" />
         <div class="control">
-          <font-awesome-icon
-            icon="info-circle"
-            class="info-icon"
-            @click="toggleHelp"
-          />
+          <div class="info-icon" @click="toggleHelp">
+            <i class="codicon codicon-info"></i>
+          </div>
         </div>
       </div>
       <div class="field is-grouped">
@@ -74,11 +68,9 @@
     <div v-if="config.type === 'string'" class="form-group">
       <div class="field has-addons">
         <label v-text="config.title" />
-        <font-awesome-icon
-          icon="info-circle"
-          class="info-icon"
-          @click="toggleHelp"
-        />
+        <div class="info-icon" @click="toggleHelp">
+          <i class="codicon codicon-info"></i>
+        </div>
       </div>
       <div class="field is-grouped">
         <div class="control">
@@ -95,11 +87,9 @@
       <div class="field has-addons">
         <label v-text="config.title" />
         <div class="control">
-          <font-awesome-icon
-            icon="info-circle"
-            class="info-icon"
-            @click="toggleHelp"
-          />
+          <div class="info-icon" @click="toggleHelp">
+            <i class="codicon codicon-info"></i>
+          </div>
         </div>
       </div>
       <div class="field is-grouped">
@@ -139,11 +129,9 @@
         <div class="field has-addons">
           <label :for="config.id" v-text="config.title" />
           <div class="control">
-            <font-awesome-icon
-              icon="info-circle"
-              class="info-icon"
-              @click="toggleHelp"
-            />
+            <div class="info-icon" @click="toggleHelp">
+              <i class="codicon codicon-info"></i>
+            </div>
           </div>
         </div>
       </div>
@@ -194,6 +182,9 @@ export default class ConfigElement extends Vue {
   overflow: hidden;
   margin-bottom: 0.5em;
 }
+.config-el:hover {
+  background-color: var(--vscode-notifications-background);
+}
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
@@ -205,6 +196,10 @@ input[type="number"]::-webkit-inner-spin-button {
   overflow: hidden;
   transition: max-height 0.2s ease-out;
   margin: 10px;
+}
+.input,
+.select {
+  border-color: var(--vscode-input-background);
 }
 .switch_box {
   display: -webkit-box;

--- a/src/views/menuconfig/main.ts
+++ b/src/views/menuconfig/main.ts
@@ -11,25 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-  faCaretDown,
-  faCaretRight,
-  faInfoCircle,
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import Vue from "vue";
 import vuescroll from "vue-scroll";
 import VueTheMask from "vue-the-mask";
+// @ts-ignore
 import ConfigElement from "./components/configElement.vue";
+// @ts-ignore
 import SearchBar from "./components/SearchBar.vue";
+// @ts-ignore
 import SideNavItem from "./components/SideNavItem.vue";
+// @ts-ignore
 import Menuconfig from "./Menuconfig.vue";
 import { store } from "./store";
-
-library.add(faInfoCircle, faCaretDown, faCaretRight);
-Vue.component("font-awesome-icon", FontAwesomeIcon);
 Vue.component("config-el", ConfigElement);
 Vue.component("sidenav-el", SideNavItem);
 Vue.component("search-bar", SearchBar);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6291,6 +6291,11 @@ vsce@^1.52.0:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
+vscode-codicons@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-codicons/-/vscode-codicons-0.0.12.tgz#94b867156f3e3a6a4cf7661e9bf2bd0060042390"
+  integrity sha512-CyGFDf3OmQhtBql/BFheUAlvEZ1MKAgvyCrGktGXEsqYvK5m9456kckDTNvnEAGG8gYjE2ds5O1cle82sMgmAg==
+
 vscode-debugadapter-testsupport@^1.34.0:
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.41.0.tgz#db2b6c743ef07b1f57828168bdc5f7a5e50ae21a"


### PR DESCRIPTION
Replace font awesome icons to prefer vscode codicons in SDKConfig Editor.

Current onboarding still depends on font-awesome and should be replace after #159 is merged.