### PR TITLE
Fix dispose sdkconfig editor on confserver exit error

### DIFF
--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -352,8 +352,11 @@ export class ConfserverProcess {
     });
     this.confServerProcess.on("exit", (code, signal) => {
       if (code !== 0) {
-        this.printError(`Received signal: ${signal} with code: ${code}`);
+        this.printError(
+          `SDK Configuration editor confserver process exited with code: ${code}`
+        );
       }
+      ConfserverProcess.dispose();
     });
   }
 


### PR DESCRIPTION
Close SDK Configuration editor on `idf.py confserver` process exit.
Fix #199 