### PR TITLE
Feature cmake editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,13 @@ We have provide a [system view tracing viewer](./docs/SYS_VIEW_TRACING_VIEWER.md
 
 When you open a `Kconfig`, `Kconfig.projbuild` or `Kconfig.in` file we provide syntax highlighting. If `idf.useIDFKconfigStyle` is enabled, we also provide ESP-IDF Kconfig style syntax validation such as indent validation and not closing blocks found (Example: menu-endmenu). Please review [Kconfig Formatting Rules](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/kconfig.html) and [Kconfig Language](https://github.com/espressif/esp-idf/blob/master/tools/kconfig/kconfig-language.txt) for further details about the ESP-IDF Kconfig formatting rules and Kconfig language in general.
 
+# CMake Editor
+
+On CMakeLists.txt file right click this extension provides a custom CMake Editor to fill our ESP-IDF Project and Component registration as specified in [ESP-IDF Project CMakeLists.txt](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#project-cmakelists-file) and [ESP-IDF Component CMakeLists.txt files](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files). You need to choose which kind of CMakeLists.txt file (project or component) to edit. There is 2 types of input, one is a simple string and another is an array of strings, such as Component Sources (SRCS). All inputs are described in the CMakeLists.txt Schema (\${this_repository}/src/cmake/cmakeListsSchema.json).
+
 ## ESP Rainmaker Support
 
-We support connecting, viewing and editing of ESP Rainmaker enabled devices out of the box, please [refer here](/docs/ESP_RAINMAKER.md) for more info
+We support connecting, viewing and editing of ESP Rainmaker enabled devices out of the box, please [refer here](/docs/ESP_RAINMAKER.md) for more info.
 
 ## Forum
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -8,6 +8,7 @@
   "espIdf.selectConfTarget.title": "ESP-IDF: Select where to save configuration settings",
   "espIdf.configDevice.title": "ESP-IDF:Device configuration",
   "menuconfig.start.title": "ESP-IDF: SDK Configuration editor",
+  "cmakeListsEditor.start.title": "ESP-IDF: CMakeLists.txt Editor",
   "espIdf.setDefaultConfig.title": "ESP-IDF: Set default sdkconfig file in project",
   "espIdf.selectPort.title": "ESP-IDF: Select port to use",
   "espIdf.buildDevice.title": "ESP-IDF: Build your project",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -8,6 +8,7 @@
   "espIdf.setTarget.title": "ESP-IDF: Selecciona el dispositivo Espressif a utilizar",
   "espIdf.configDevice.title": "ESP-IDF: Configuración del dispositivo",
   "menuconfig.start.title": "ESP-IDF: Editor de Configuración SDK",
+  "cmakeListsEditor.start.title": "ESP-IDF: Editor de CMakeLists.txt",
   "espIdf.setDefaultConfig.title": "ESP-IDF: Establecer archivo sdkconfig por defecto",
   "espIdf.selectPort.title": "ESP-IDF: Seleccionar puerto a utilizar",
   "espIdf.buildDevice.title": "ESP-IDF: Construir el proyecto",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -8,6 +8,7 @@
   "espIdf.setTarget.title": "ESP-IDF: 设置espressif设备目标",
   "espIdf.configDevice.title": "ESP-IDF：配置设备",
   "menuconfig.start.title": "ESP-IDF：SDK配置编辑器",
+  "cmakeListsEditor.start.title": "ESP-IDF：CMakeLists.txt文件编辑",
   "espIdf.setDefaultConfig.title": "ESP-IDF：设置项目默认的 sdkconfig 文件",
   "espIdf.selectPort.title": "ESP-IDF：选择要使用的烧录端口",
   "espIdf.buildDevice.title": "ESP-IDF：构建项目",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:espIdf.selectConfTarget",
     "onCommand:espIdf.configDevice",
     "onCommand:menuconfig.start",
+    "onCommand:cmakeListsEditor.start",
     "onCommand:espIdf.setDefaultConfig",
     "onCommand:espIdf.selectPort",
     "onCommand:espIdf.setTarget",
@@ -200,6 +201,11 @@
         {
           "when": "resourceFilename == sdkconfig",
           "command": "menuconfig.start",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceFilename == CMakeLists.txt",
+          "command": "cmakeListsEditor.start",
           "group": "navigation"
         }
       ]
@@ -545,6 +551,10 @@
       {
         "command": "examples.start",
         "title": "%espIdf.examples.title%"
+      },
+      {
+        "command": "cmakeListsEditor.start",
+        "title": "%cmakeListsEditor.start.title%"
       },
       {
         "command": "espIdf.setDefaultConfig",

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
   "espIdf.setTarget.title": "ESP-IDF: Set Espressif device target",
   "espIdf.configDevice.title": "ESP-IDF: Device configuration",
   "menuconfig.start.title": "ESP-IDF: SDK Configuration editor",
+  "cmakeListsEditor.start.title": "ESP-IDF: CMakeLists.txt Editor",
   "espIdf.setDefaultConfig.title": "ESP-IDF: Set default sdkconfig file in project",
   "espIdf.selectPort.title": "ESP-IDF: Select port to use",
   "espIdf.buildDevice.title": "ESP-IDF: Build your project",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -76,6 +76,7 @@
     "espIdf.setTarget.title",
     "espIdf.configDevice.title",
     "menuconfig.start.title",
+    "cmakeListsEditor.start.title",
     "espIdf.setDefaultConfig.title",
     "espIdf.selectPort.title",
     "espIdf.buildDevice.title",

--- a/src/cmake/cmakeEditorPanel.ts
+++ b/src/cmake/cmakeEditorPanel.ts
@@ -77,9 +77,6 @@ export class CmakeListsEditorPanel {
         retainContextWhenHidden: true,
         localResourceRoots: [
           vscode.Uri.file(join(extensionPath, "dist", "views")),
-          vscode.Uri.file(
-            join(extensionPath, "node_modules", "vscode-codicons", "dist")
-          ),
         ],
       }
     );
@@ -94,13 +91,7 @@ export class CmakeListsEditorPanel {
       )
     );
 
-    const fontsPath = panel.webview.asWebviewUri(
-      vscode.Uri.file(
-        join(extensionPath, "dist", "views", "fonts", "codicon.ttf")
-      )
-    );
-
-    panel.webview.html = this.createCmakeListEditorHtml(scriptsPath, fontsPath);
+    panel.webview.html = this.createCmakeListEditorHtml(scriptsPath);
 
     const cmakeListsWatcher = vscode.workspace.createFileSystemWatcher(
       fileUri.fsPath,
@@ -150,10 +141,7 @@ export class CmakeListsEditorPanel {
     CmakeListsEditorPanel.cmakeListsPanels.add(fileUri.fsPath, panel);
   }
 
-  private createCmakeListEditorHtml(
-    scriptPath: vscode.Uri,
-    fontsUri: vscode.Uri
-  ): string {
+  private createCmakeListEditorHtml(scriptPath: vscode.Uri): string {
     return `<!DOCTYPE html>
         <html lang="en">
         <head>
@@ -162,12 +150,6 @@ export class CmakeListsEditorPanel {
             <title>CMakeLists.txt Editor</title>
             </head>
             <body>
-              <style>
-              @font-face {
-                  font-family: "codicon";
-                  src: url('${fontsUri}') format('truetype');
-              }
-              </style>
               <div id="editor"></div>
             </body>
             <script src="${scriptPath}"></script>

--- a/src/cmake/cmakeEditorPanel.ts
+++ b/src/cmake/cmakeEditorPanel.ts
@@ -10,7 +10,6 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-
 // limitations under the License.
 
 import { join } from "path";
@@ -95,7 +94,13 @@ export class CmakeListsEditorPanel {
       )
     );
 
-    panel.webview.html = this.createCmakeListEditorHtml(scriptsPath);
+    const fontsPath = panel.webview.asWebviewUri(
+      vscode.Uri.file(
+        join(extensionPath, "dist", "views", "fonts", "codicon.ttf")
+      )
+    );
+
+    panel.webview.html = this.createCmakeListEditorHtml(scriptsPath, fontsPath);
 
     const cmakeListsWatcher = vscode.workspace.createFileSystemWatcher(
       fileUri.fsPath,
@@ -145,7 +150,10 @@ export class CmakeListsEditorPanel {
     CmakeListsEditorPanel.cmakeListsPanels.add(fileUri.fsPath, panel);
   }
 
-  private createCmakeListEditorHtml(scriptPath: vscode.Uri): string {
+  private createCmakeListEditorHtml(
+    scriptPath: vscode.Uri,
+    fontsUri: vscode.Uri
+  ): string {
     return `<!DOCTYPE html>
         <html lang="en">
         <head>
@@ -154,7 +162,13 @@ export class CmakeListsEditorPanel {
             <title>CMakeLists.txt Editor</title>
             </head>
             <body>
-                <div id="editor"></div>
+              <style>
+              @font-face {
+                  font-family: "codicon";
+                  src: url('${fontsUri}') format('truetype');
+              }
+              </style>
+              <div id="editor"></div>
             </body>
             <script src="${scriptPath}"></script>
         </html>`;

--- a/src/cmake/cmakeEditorPanel.ts
+++ b/src/cmake/cmakeEditorPanel.ts
@@ -17,6 +17,7 @@ import { join } from "path";
 import * as vscode from "vscode";
 import { Logger } from "../logger/logger";
 import {
+  CMakeListsType,
   loadCmakeListBuilder,
   updateCmakeListFile,
   updateWithValuesCMakeLists,
@@ -25,7 +26,11 @@ import {
 export class CmakeListsEditorPanel {
   public static currentPanel: CmakeListsEditorPanel | undefined;
 
-  public static createOrShow(extensionPath: string, fileUri: vscode.Uri) {
+  public static createOrShow(
+    extensionPath: string,
+    fileUri: vscode.Uri,
+    type: CMakeListsType
+  ) {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : vscode.ViewColumn.One;
@@ -35,7 +40,8 @@ export class CmakeListsEditorPanel {
       CmakeListsEditorPanel.currentPanel = new CmakeListsEditorPanel(
         extensionPath,
         column,
-        fileUri
+        fileUri,
+        type
       );
     }
   }
@@ -47,7 +53,8 @@ export class CmakeListsEditorPanel {
   public constructor(
     extensionPath: string,
     column: vscode.ViewColumn,
-    fileUri: vscode.Uri
+    fileUri: vscode.Uri,
+    type: CMakeListsType
   ) {
     this.panel = vscode.window.createWebviewPanel(
       CmakeListsEditorPanel.viewType,
@@ -104,7 +111,10 @@ export class CmakeListsEditorPanel {
       switch (message.command) {
         case "loadCMakeListSchema":
           try {
-            let listWithValues = await loadCmakeListBuilder(extensionPath);
+            let listWithValues = await loadCmakeListBuilder(
+              extensionPath,
+              type
+            );
             listWithValues = await updateWithValuesCMakeLists(
               fileUri,
               listWithValues

--- a/src/cmake/cmakeEditorPanel.ts
+++ b/src/cmake/cmakeEditorPanel.ts
@@ -82,22 +82,7 @@ export class CmakeListsEditorPanel {
       )
     );
 
-    const codiconsUri = this.panel.webview.asWebviewUri(
-      vscode.Uri.file(
-        join(
-          extensionPath,
-          "node_modules",
-          "vscode-codicons",
-          "dist",
-          "codicon.css"
-        )
-      )
-    );
-
-    this.panel.webview.html = this.createCmakeListEditorHtml(
-      scriptsPath,
-      codiconsUri
-    );
+    this.panel.webview.html = this.createCmakeListEditorHtml(scriptsPath);
 
     this.panel.onDidDispose(
       () => {
@@ -147,17 +132,13 @@ export class CmakeListsEditorPanel {
     this.panel.dispose();
   }
 
-  private createCmakeListEditorHtml(
-    scriptPath: vscode.Uri,
-    codiconsUri: vscode.Uri
-  ): string {
+  private createCmakeListEditorHtml(scriptPath: vscode.Uri): string {
     return `<!DOCTYPE html>
         <html lang="en">
         <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>CMakeLists.txt Editor</title>
-            <link href="${codiconsUri}" rel="stylesheet" />
             </head>
             <body>
                 <div id="editor"></div>

--- a/src/cmake/cmakeEditorPanel.ts
+++ b/src/cmake/cmakeEditorPanel.ts
@@ -1,0 +1,158 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+// limitations under the License.
+
+import { join } from "path";
+import * as vscode from "vscode";
+import { Logger } from "../logger/logger";
+import {
+  loadCmakeListBuilder,
+  updateCmakeListFile,
+  updateWithValuesCMakeLists,
+} from "./cmakeListsBuilder";
+
+export class CmakeListsEditorPanel {
+  public static currentPanel: CmakeListsEditorPanel | undefined;
+
+  public static createOrShow(extensionPath: string, fileUri: vscode.Uri) {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : vscode.ViewColumn.One;
+    if (CmakeListsEditorPanel.currentPanel) {
+      CmakeListsEditorPanel.currentPanel.panel.reveal(column);
+    } else {
+      CmakeListsEditorPanel.currentPanel = new CmakeListsEditorPanel(
+        extensionPath,
+        column,
+        fileUri
+      );
+    }
+  }
+
+  private static readonly viewType = "cmakelists-editor";
+  private panel: vscode.WebviewPanel;
+  private disposables: vscode.Disposable[] = [];
+
+  public constructor(
+    extensionPath: string,
+    column: vscode.ViewColumn,
+    fileUri: vscode.Uri
+  ) {
+    this.panel = vscode.window.createWebviewPanel(
+      CmakeListsEditorPanel.viewType,
+      "CMakeLists.txt Editor",
+      column,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.file(join(extensionPath, "dist", "views")),
+          vscode.Uri.file(
+            join(extensionPath, "node_modules", "vscode-codicons", "dist")
+          ),
+        ],
+      }
+    );
+
+    this.panel.iconPath = vscode.Uri.file(
+      join(extensionPath, "media", "espressif_icon.png")
+    );
+
+    const scriptsPath = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(
+        join(extensionPath, "dist", "views", "cmakelistsEditor-bundle.js")
+      )
+    );
+
+    const codiconsUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(
+        join(
+          extensionPath,
+          "node_modules",
+          "vscode-codicons",
+          "dist",
+          "codicon.css"
+        )
+      )
+    );
+
+    this.panel.webview.html = this.createCmakeListEditorHtml(
+      scriptsPath,
+      codiconsUri
+    );
+
+    this.panel.onDidDispose(
+      () => {
+        this.dispose();
+      },
+      null,
+      this.disposables
+    );
+
+    this.panel.webview.onDidReceiveMessage(async (message) => {
+      switch (message.command) {
+        case "loadCMakeListSchema":
+          try {
+            let listWithValues = await loadCmakeListBuilder(extensionPath);
+            listWithValues = await updateWithValuesCMakeLists(
+              fileUri,
+              listWithValues
+            );
+            if (listWithValues) {
+              this.panel.webview.postMessage({
+                command: "loadElements",
+                elements: listWithValues,
+              });
+            }
+          } catch (error) {
+            Logger.errorNotify(`Failed reading ${fileUri.fsPath}`, error);
+          }
+        case "saveChanges":
+          if (message.newValues) {
+            await updateCmakeListFile(fileUri, message.newValues);
+            vscode.window.showInformationMessage(
+              `${fileUri.fsPath} has been updated`
+            );
+          }
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  private dispose() {
+    CmakeListsEditorPanel.currentPanel = undefined;
+    this.panel.dispose();
+  }
+
+  private createCmakeListEditorHtml(
+    scriptPath: vscode.Uri,
+    codiconsUri: vscode.Uri
+  ): string {
+    return `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>CMakeLists.txt Editor</title>
+            <link href="${codiconsUri}" rel="stylesheet" />
+            </head>
+            <body>
+                <div id="editor"></div>
+            </body>
+            <script src="${scriptPath}"></script>
+        </html>`;
+  }
+}

--- a/src/cmake/cmakeFilesCollection.ts
+++ b/src/cmake/cmakeFilesCollection.ts
@@ -1,0 +1,47 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { WebviewPanel } from "vscode";
+
+export default class CMakeListsWebviewCollection {
+  private readonly _webviews = new Set<{
+    readonly document: string;
+    readonly webview: WebviewPanel;
+  }>();
+
+  public add(filePath: string, webviewPanel: WebviewPanel) {
+    const entry = { document: filePath, webview: webviewPanel };
+    this._webviews.add(entry);
+
+    webviewPanel.onDidDispose(() => {
+      this._webviews.delete(entry);
+    });
+  }
+
+  public delete(filePath: string) {
+    for (const entry of this._webviews) {
+      if (entry.document === filePath) {
+        this._webviews.delete(entry);
+      }
+    }
+  }
+
+  public *get(filePath: string): Iterable<WebviewPanel> {
+    for (const entry of this._webviews) {
+      if (entry.document === filePath) {
+        yield entry.webview;
+      }
+    }
+  }
+}

--- a/src/cmake/cmakeListsBuilder.ts
+++ b/src/cmake/cmakeListsBuilder.ts
@@ -105,6 +105,28 @@ export async function updateCmakeListFile(
   } else {
     resultStr = otherValues.join(EOL).concat(EOL);
   }
+  const comments = await getExistingComments(fileUri);
+  resultStr = comments ? comments + resultStr : resultStr;
   await writeFile(fileUri.fsPath, resultStr);
   return resultStr;
+}
+
+export async function getExistingComments(fileUri: Uri) {
+  const fileString = await readFile(fileUri.fsPath, "utf-8");
+  const singleLineMatches = fileString.match(/^#.*/gm);
+  const multiLineMatches = fileString.match(/^#\[\[[\w\W]+?\]\]$/gm);
+  let resultStr: string = "";
+  if (multiLineMatches && multiLineMatches.length) {
+    for (let multiLineMatch of multiLineMatches) {
+      resultStr = resultStr + EOL + multiLineMatch;
+    }
+  }
+  if (singleLineMatches && singleLineMatches.length) {
+    for (let singleLineMatch of singleLineMatches) {
+      if (resultStr.indexOf(singleLineMatch) === -1) {
+        resultStr = resultStr + EOL + singleLineMatch;
+      }
+    }
+  }
+  return resultStr.concat(EOL);
 }

--- a/src/cmake/cmakeListsBuilder.ts
+++ b/src/cmake/cmakeListsBuilder.ts
@@ -18,7 +18,15 @@ import { Uri } from "vscode";
 import { CmakeListsElement } from "./CmakeListsElement";
 import { pathExists, readFile, readJSON, writeFile } from "fs-extra";
 
-export async function loadCmakeListBuilder(extensionPath: string) {
+export enum CMakeListsType {
+  Component = "component",
+  Project = "project",
+}
+
+export async function loadCmakeListBuilder(
+  extensionPath: string,
+  type: CMakeListsType
+) {
   const cmakeListsSchemaFile = join(
     extensionPath,
     "src",
@@ -33,6 +41,8 @@ export async function loadCmakeListBuilder(extensionPath: string) {
 
   // Component and Project settings are loaded together
   // Should refactor if there is a way to identify component/project CmakeLists.txt
+  console.log(schemaJson[type]);
+  return schemaJson[type] as CmakeListsElement[];
   return [].concat(
     schemaJson.project as CmakeListsElement[],
     schemaJson.component as CmakeListsElement[]
@@ -85,7 +95,7 @@ export async function updateCmakeListFile(
       );
       componentValues.push(elStr + EOL + spaces);
     } else if (el.value && el.value.length > 0) {
-      otherValues.push(el.template.replace("***", el.value.join("")));
+      otherValues.push(el.template.replace("***", "".concat(...el.value)));
     }
   }
   let resultStr: string;

--- a/src/cmake/cmakeListsBuilder.ts
+++ b/src/cmake/cmakeListsBuilder.ts
@@ -1,0 +1,105 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EOL } from "os";
+import { join } from "path";
+import { Uri } from "vscode";
+import { CmakeListsElement } from "./CmakeListsElement";
+import { pathExists, readFile, readJSON, writeFile } from "fs-extra";
+
+export async function loadCmakeListBuilder(extensionPath: string) {
+  const cmakeListsSchemaFile = join(
+    extensionPath,
+    "src",
+    "cmake",
+    "cmakeListsSchema.json"
+  );
+  const doesSchemaExists = await pathExists(cmakeListsSchemaFile);
+  if (!doesSchemaExists) {
+    return;
+  }
+  const schemaJson = await readJSON(cmakeListsSchemaFile);
+
+  // Component and Project settings are loaded together
+  // Should refactor if there is a way to identify component/project CmakeLists.txt
+  return [].concat(
+    schemaJson.project as CmakeListsElement[],
+    schemaJson.component as CmakeListsElement[]
+  ) as CmakeListsElement[];
+}
+
+export async function updateWithValuesCMakeLists(
+  fileUri: Uri,
+  list: CmakeListsElement[]
+) {
+  const fileString = await readFile(fileUri.fsPath, "utf-8");
+  return parseCmakeListsText(fileString, list);
+}
+
+export function parseCmakeListsText(
+  cmakeListFileText: string,
+  cmakeLists: CmakeListsElement[]
+) {
+  for (const element of cmakeLists) {
+    if (element.type === "array") {
+      const regex = new RegExp(element.regex);
+      const resultStr = cmakeListFileText.match(regex);
+      if (resultStr && resultStr[1].trim().split(" ").length > 0) {
+        element.value = resultStr[1].trim().replace(/\"/g, "").split(" ");
+      }
+    } else {
+      const regex = new RegExp(element.regex);
+      const resultStr = cmakeListFileText.match(regex);
+      if (resultStr && resultStr[1].trim().length > 0) {
+        element.value = [resultStr[1].trim()];
+      }
+    }
+  }
+  return cmakeLists;
+}
+
+export async function updateCmakeListFile(
+  fileUri: Uri,
+  values: CmakeListsElement[]
+) {
+  let componentStr = "idf_component_register(";
+  const spaces = new Array(componentStr.length + 1).join(" ");
+  const componentValues: string[] = [];
+  const otherValues: string[] = [];
+  for (const el of values) {
+    if (el.isComponentElement && el.value && el.value.length > 0) {
+      const elStr = el.template.replace(
+        "***",
+        el.value.map((v) => `"${v}"`).join(" ")
+      );
+      componentValues.push(elStr + EOL + spaces);
+    } else if (el.value && el.value.length > 0) {
+      otherValues.push(el.template.replace("***", el.value.join("")));
+    }
+  }
+  let resultStr: string;
+  if (componentValues.length > 0) {
+    componentStr = componentStr.concat(...componentValues);
+    componentStr = componentStr.slice(0, componentStr.lastIndexOf(EOL));
+    componentStr = componentStr.concat(")" + EOL);
+    resultStr =
+      otherValues.length > 0
+        ? otherValues.join(EOL).concat(EOL, componentStr)
+        : componentStr;
+  } else {
+    resultStr = otherValues.join(EOL).concat(EOL);
+  }
+  await writeFile(fileUri.fsPath, resultStr);
+  return resultStr;
+}

--- a/src/cmake/cmakeListsBuilder.ts
+++ b/src/cmake/cmakeListsBuilder.ts
@@ -15,7 +15,7 @@
 import { EOL } from "os";
 import { join } from "path";
 import { Uri } from "vscode";
-import { CmakeListsElement } from "./CmakeListsElement";
+import { CmakeListsElement } from "./cmakeListsElement";
 import { pathExists, readFile, readJSON, writeFile } from "fs-extra";
 
 export enum CMakeListsType {

--- a/src/cmake/cmakeListsBuilder.ts
+++ b/src/cmake/cmakeListsBuilder.ts
@@ -41,12 +41,7 @@ export async function loadCmakeListBuilder(
 
   // Component and Project settings are loaded together
   // Should refactor if there is a way to identify component/project CmakeLists.txt
-  console.log(schemaJson[type]);
   return schemaJson[type] as CmakeListsElement[];
-  return [].concat(
-    schemaJson.project as CmakeListsElement[],
-    schemaJson.component as CmakeListsElement[]
-  ) as CmakeListsElement[];
 }
 
 export async function updateWithValuesCMakeLists(

--- a/src/cmake/cmakeListsElement.ts
+++ b/src/cmake/cmakeListsElement.ts
@@ -1,0 +1,23 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class CmakeListsElement {
+  public isComponentElement: boolean;
+  public type: string;
+  public value: string[];
+  public title: string;
+  public template: string;
+  public regex: string;
+  public default: string;
+}

--- a/src/cmake/cmakeListsSchema.json
+++ b/src/cmake/cmakeListsSchema.json
@@ -1,0 +1,133 @@
+{
+  "component": [
+    {
+      "isEnabled": false,
+      "template": "SRCS ***",
+      "regex": "(?:SRCS)([^)\n\r]*)",
+      "title": "Component Sources (SRCS)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "EXCLUDE_SRCS ***",
+      "regex": "(?:EXCLUDE_SRCS)([^)\n\r]*)",
+      "title": "Remove files from static library build (EXCLUDE_SRCS)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "LDFRAGMENTS ***",
+      "regex": "(?:LDFRAGMENTS)([^)\n\r]*)",
+      "title": "Linker fragment files (LDFRAGMENTS)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "EMBED_FILES ***",
+      "regex": "(?:EMBED_FILES)([^)\n\r]*)",
+      "title": "Binary files to be embedded in the component (EMBED_FILES)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "EMBED_TXTFILES ***",
+      "regex": "(?:EMBED_TXTFILES)([^)\n\r]*)",
+      "title": "Text files to be embedded in the component (EMBED_TXTFILES)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "INCLUDE_DIRS ***",
+      "regex": "(?:INCLUDE_DIRS)([^)\n\r]*)",
+      "title": "Relative paths to the components (INCLUDE_DIRS) for all other components",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "PRIV_INCLUDE_DIRS ***",
+      "regex": "(?:PRIV_INCLUDE_DIRS)([^)\n\r]*)",
+      "title": "Relative paths to the components (PRIV_INCLUDE_DIRS) for this component",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "REQUIRES ***",
+      "regex": "(?:REQUIRES)([^)\n\r]*)",
+      "title": "Public component requirements for the component (REQUIRES)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "REQUIRED_IDF_TARGETS ***",
+      "regex": "(?:REQUIRED_IDF_TARGETS)([^)\n\r]*)",
+      "title": "Specify the only target the component supports (REQUIRED_IDF_TARGETS)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    },
+    {
+      "isEnabled": false,
+      "template": "PRIV_REQUIRES ***",
+      "regex": "(?:PRIV_REQUIRES)([^)\n\r]*)",
+      "title": "Private component requirements for the component (PRIV_REQUIRES)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": true
+    }
+  ],
+  "project": [
+    {
+      "isEnabled": false,
+      "regex": "(?:project\\()(.*)(?:\\))",
+      "template": "project(***)",
+      "title": "Project Name",
+      "type": "string",
+      "value": "",
+      "isComponentElement": false
+    },
+    {
+      "default": "VERSION 3.5",
+      "isEnabled": false,
+      "regex": "(?:cmake_minimum_required\\()(.*)(?:\\))",
+      "template": "cmake_minimum_required(***)",
+      "title": "CMake Minimum Requirement",
+      "type": "string",
+      "value": "VERSION 3.5",
+      "isComponentElement": false
+    },
+    {
+      "isEnabled": false,
+      "regex": "(?:include\\()(.*)(?:\\))",
+      "template": "include(***)",
+      "type": "string",
+      "title": "Include ESP-IDF CMake",
+      "value": "$ENV{IDF_PATH}/tools/cmake/project.cmake",
+      "isComponentElement": false
+    },
+    {
+      "isEnabled": false,
+      "template": "SET(EXTRA_COMPONENT_DIRS, ***)",
+      "regex": "(?:EXTRA_COMPONENT_DIRS)([^)\n\r]*)",
+      "title": "List of additional components (EXTRA_COMPONENT_DIRS)",
+      "type": "array",
+      "value": [],
+      "isComponentElement": false
+    }
+  ]
+}

--- a/src/cmake/cmakeListsSchema.json
+++ b/src/cmake/cmakeListsSchema.json
@@ -93,15 +93,6 @@
   ],
   "project": [
     {
-      "isEnabled": false,
-      "regex": "(?:project\\()(.*)(?:\\))",
-      "template": "project(***)",
-      "title": "Project Name",
-      "type": "string",
-      "value": "",
-      "isComponentElement": false
-    },
-    {
       "default": "VERSION 3.5",
       "isEnabled": false,
       "regex": "(?:cmake_minimum_required\\()(.*)(?:\\))",
@@ -118,6 +109,15 @@
       "type": "string",
       "title": "Include ESP-IDF CMake",
       "value": "$ENV{IDF_PATH}/tools/cmake/project.cmake",
+      "isComponentElement": false
+    },
+    {
+      "isEnabled": false,
+      "regex": "(?:project\\()(.*)(?:\\))",
+      "template": "project(***)",
+      "title": "Project Name",
+      "type": "string",
+      "value": "",
       "isComponentElement": false
     },
     {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,6 +211,7 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
       UpdateCmakeLists.updateSrcsInCmakeLists(e.fsPath, srcOp.delete);
     }
+    CmakeListsEditorPanel.deletePanel(e.fsPath);
   });
   context.subscriptions.push(srcWatchDeleteDisposable);
   const srcWatchCreateDisposable = newSrcWatcher.onDidCreate(async (e) => {
@@ -233,6 +234,7 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
       UpdateCmakeLists.updateSrcsInCmakeLists(e.fsPath, srcOp.other);
     }
+    CmakeListsEditorPanel.deletePanel(e.fsPath);
   });
   context.subscriptions.push(srcWatchOnChangeDisposable);
 
@@ -1041,29 +1043,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("cmakeListsEditor.start", async (fileUri: vscode.Uri) => {
     if (!fileUri) {
+      Logger.errorNotify(
+        "Cannot call this command directly, right click on any CMakeLists.txt file!",
+        new Error("INVALID_COMMAND")
+      );
       return;
     }
-    const selectType = await vscode.window.showQuickPick(
-      [
-        {
-          label: `Component CMakeLists.txt`,
-          target: CMakeListsType.Component,
-        },
-        {
-          label: `Project CMakeLists.txt`,
-          target: CMakeListsType.Project,
-        },
-      ],
-      { placeHolder: "Select CMakeLists.txt type" }
-    );
-    if (!selectType) {
-      return;
-    }
-    CmakeListsEditorPanel.createOrShow(
-      context.extensionPath,
-      fileUri,
-      selectType.target
-    );
+    PreCheck.perform([openFolderCheck], async () => {
+      await CmakeListsEditorPanel.createOrShow(context.extensionPath, fileUri);
+    });
   });
 
   registerIDFCommand("espIdf.openIdfDocument", (docUri: vscode.Uri) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1043,7 +1043,7 @@ export async function activate(context: vscode.ExtensionContext) {
     if (!fileUri) {
       Logger.errorNotify(
         "Cannot call this command directly, right click on any CMakeLists.txt file!",
-        new Error("INVALID_COMMAND")
+        new Error("INVALID_INVOCATION")
       );
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,7 @@ import { getEspAdf } from "./espAdf/espAdfDownload";
 import { getEspMdf } from "./espMdf/espMdfDownload";
 import { ChangelogViewer } from "./changelog-viewer";
 import EspIdfCustomTerminal from "./espIdfCustomTerminal";
+import { CmakeListsEditorPanel } from "./cmake/cmakeEditorPanel";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -1035,6 +1036,10 @@ export async function activate(context: vscode.ExtensionContext) {
     } catch (error) {
       Logger.errorNotify(error.message, error);
     }
+  });
+
+  registerIDFCommand("cmakeListsEditor.start", (fileUri: vscode.Uri) => {
+    CmakeListsEditorPanel.createOrShow(context.extensionPath, fileUri);
   });
 
   registerIDFCommand("espIdf.openIdfDocument", (docUri: vscode.Uri) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,6 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
       UpdateCmakeLists.updateSrcsInCmakeLists(e.fsPath, srcOp.delete);
     }
-    CmakeListsEditorPanel.deletePanel(e.fsPath);
   });
   context.subscriptions.push(srcWatchDeleteDisposable);
   const srcWatchCreateDisposable = newSrcWatcher.onDidCreate(async (e) => {
@@ -234,7 +233,6 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
       UpdateCmakeLists.updateSrcsInCmakeLists(e.fsPath, srcOp.other);
     }
-    CmakeListsEditorPanel.deletePanel(e.fsPath);
   });
   context.subscriptions.push(srcWatchOnChangeDisposable);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ import { getEspMdf } from "./espMdf/espMdfDownload";
 import { ChangelogViewer } from "./changelog-viewer";
 import EspIdfCustomTerminal from "./espIdfCustomTerminal";
 import { CmakeListsEditorPanel } from "./cmake/cmakeEditorPanel";
+import { CMakeListsType } from "./cmake/cmakeListsBuilder";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -1038,8 +1039,31 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  registerIDFCommand("cmakeListsEditor.start", (fileUri: vscode.Uri) => {
-    CmakeListsEditorPanel.createOrShow(context.extensionPath, fileUri);
+  registerIDFCommand("cmakeListsEditor.start", async (fileUri: vscode.Uri) => {
+    if (!fileUri) {
+      return;
+    }
+    const selectType = await vscode.window.showQuickPick(
+      [
+        {
+          label: `Component CMakeLists.txt`,
+          target: CMakeListsType.Component,
+        },
+        {
+          label: `Project CMakeLists.txt`,
+          target: CMakeListsType.Project,
+        },
+      ],
+      { placeHolder: "Select CMakeLists.txt type" }
+    );
+    if (!selectType) {
+      return;
+    }
+    CmakeListsEditorPanel.createOrShow(
+      context.extensionPath,
+      fileUri,
+      selectType.target
+    );
   });
 
   registerIDFCommand("espIdf.openIdfDocument", (docUri: vscode.Uri) => {

--- a/src/views/cmakelists-editor/CmakeListsEditor.vue
+++ b/src/views/cmakelists-editor/CmakeListsEditor.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Action, State } from "vuex-class";
-import { CmakeListsElement } from "../../cmake/CmakeListsElement";
+import { CmakeListsElement } from "../../cmake/cmakeListsElement";
 import CMakeElem from "./components/CMakeListsElement.vue";
 
 @Component({

--- a/src/views/cmakelists-editor/CmakeListsEditor.vue
+++ b/src/views/cmakelists-editor/CmakeListsEditor.vue
@@ -2,6 +2,7 @@
   <div class="section">
     <div class="control centerize">
       <h2 class="title is-spaced">{{ title }}</h2>
+      <h4 class="subtitle is-spaced">{{ fileName }}</h4>
     </div>
 
     <div class="field is-grouped" id="editor-btns">
@@ -33,12 +34,16 @@ import CMakeElem from "./components/CMakeListsElement.vue";
 })
 export default class CMakeListsEditor extends Vue {
   @State("elements") private storeElements: CmakeListsElement[];
+  @State("fileName") private storeFileName: string;
   @State("textDictionary") private storeTextDictionary;
   @Action private requestInitValues;
   @Action private saveChanges;
 
   get elements() {
     return this.storeElements;
+  }
+  get fileName() {
+    return this.storeFileName;
   }
   get save() {
     return this.storeTextDictionary.save;

--- a/src/views/cmakelists-editor/CmakeListsEditor.vue
+++ b/src/views/cmakelists-editor/CmakeListsEditor.vue
@@ -1,0 +1,82 @@
+<template>
+  <div id="cmake-editor">
+    <div class="control centerize">
+      <h2 class="title is-spaced">{{ title }}</h2>
+    </div>
+    <div class="notification">
+      <CMakeElem
+        v-for="elem in elements"
+        :key="elem.id"
+        :el.sync="elem"
+      ></CMakeElem>
+      <div class="field is-grouped" id="editor-btns">
+        <div class="control">
+          <button class="button" @click="saveChanges">{{ save }}</button>
+        </div>
+        <div class="control">
+          <button class="button" @click="requestInitValues">
+            {{ cancel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { Action, State } from "vuex-class";
+import { CmakeListsElement } from "../../cmake/CmakeListsElement";
+import CMakeElem from "./components/CMakeListsElement.vue";
+
+@Component({
+  components: {
+    CMakeElem,
+  },
+})
+export default class CMakeListsEditor extends Vue {
+  @State("elements") private storeElements: CmakeListsElement[];
+  @State("textDictionary") private storeTextDictionary;
+  @Action private requestInitValues;
+  @Action private saveChanges;
+
+  get elements() {
+    return this.storeElements;
+  }
+  get save() {
+    return this.storeTextDictionary.save;
+  }
+  get cancel() {
+    return this.storeTextDictionary.discard;
+  }
+  get title() {
+    return this.storeTextDictionary.title;
+  }
+
+  private mounted() {
+    this.requestInitValues();
+  }
+}
+</script>
+
+<style lang="scss">
+@import "../commons/espCommons.scss";
+#cmake-editor {
+  padding: 1em;
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-editor-background);
+  height: -webkit-fill-available;
+}
+.centerize {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+#editor-btns {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+</style>

--- a/src/views/cmakelists-editor/CmakeListsEditor.vue
+++ b/src/views/cmakelists-editor/CmakeListsEditor.vue
@@ -1,24 +1,21 @@
 <template>
-  <div id="cmake-editor">
+  <div class="section">
     <div class="control centerize">
       <h2 class="title is-spaced">{{ title }}</h2>
     </div>
-    <div class="notification">
-      <CMakeElem
-        v-for="elem in elements"
-        :key="elem.id"
-        :el.sync="elem"
-      ></CMakeElem>
-      <div class="field is-grouped" id="editor-btns">
-        <div class="control">
-          <button class="button" @click="saveChanges">{{ save }}</button>
-        </div>
-        <div class="control">
-          <button class="button" @click="requestInitValues">
-            {{ cancel }}
-          </button>
-        </div>
+
+    <div class="field is-grouped" id="editor-btns">
+      <div class="control">
+        <button class="button" @click="saveChanges">{{ save }}</button>
       </div>
+      <div class="control">
+        <button class="button" @click="requestInitValues">
+          {{ cancel }}
+        </button>
+      </div>
+    </div>
+    <div class="notification">
+      <CMakeElem v-for="elem in elements" :key="elem.id" :el="elem"></CMakeElem>
     </div>
   </div>
 </template>
@@ -61,12 +58,6 @@ export default class CMakeListsEditor extends Vue {
 
 <style lang="scss">
 @import "../commons/espCommons.scss";
-#cmake-editor {
-  padding: 1em;
-  color: var(--vscode-foreground);
-  background-color: var(--vscode-editor-background);
-  height: -webkit-fill-available;
-}
 .centerize {
   align-items: center;
   display: flex;

--- a/src/views/cmakelists-editor/components/CMakeListsElement.vue
+++ b/src/views/cmakelists-editor/components/CMakeListsElement.vue
@@ -8,7 +8,7 @@
         <li v-for="v in el.value" :key="v" class="field is-grouped">
           <p class="label">{{ v }}</p>
           <div class="icon" @click="removeFromArray(v)">
-            <i class="codicon codicon-close"></i>
+            <iconify-icon icon="close" />
           </div>
         </li>
       </ul>
@@ -24,7 +24,7 @@
       </div>
       <div class="control">
         <div class="icon" @click="addToArray">
-          <i class="codicon codicon-add"></i>
+          <iconify-icon icon="add" />
         </div>
       </div>
     </div>

--- a/src/views/cmakelists-editor/components/CMakeListsElement.vue
+++ b/src/views/cmakelists-editor/components/CMakeListsElement.vue
@@ -39,7 +39,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
 import { State } from "vuex-class";
-import { CmakeListsElement } from "../../../cmake/CmakeListsElement";
+import { CmakeListsElement } from "../../../cmake/cmakeListsElement";
 
 @Component
 export default class CMakeListElement extends Vue {

--- a/src/views/cmakelists-editor/components/CMakeListsElement.vue
+++ b/src/views/cmakelists-editor/components/CMakeListsElement.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="cmake-element">
+    <div class="field">
+      <div class="control">
+        <label :for="el.id" class="label">{{ el.title }} </label>
+      </div>
+      <ul v-if="el.type === 'array'">
+        <li v-for="v in el.value" :key="v" class="field has-addons">
+          <p class="label">{{ v }}</p>
+          <div class="icon" @click="removeFromArray(v)">
+            <i class="codicon codicon-close"></i>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div v-if="el.type === 'array'" class="field has-addons">
+      <div class="control">
+        <input type="text" v-model="elementValueToPush" class="input" />
+      </div>
+      <div class="control">
+        <div class="icon" @click="addToArray">
+          <i class="codicon codicon-add"></i>
+        </div>
+      </div>
+    </div>
+    <div v-else class="field">
+      <div class="control">
+        <input type="text" v-model="el.value" class="input" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { State } from "vuex-class";
+import { CmakeListsElement } from "../../../cmake/CmakeListsElement";
+
+@Component
+export default class CMakeListElement extends Vue {
+  @Prop() public el: CmakeListsElement;
+  @State("textDictionary") private storeTextDictionary;
+  private valueToPush: string;
+
+  get elementValueToPush() {
+    return this.valueToPush;
+  }
+  set elementValueToPush(newVal: string) {
+    this.valueToPush = newVal;
+  }
+
+  get saveText() {
+    return this.storeTextDictionary.save;
+  }
+  get cancelText() {
+    return this.storeTextDictionary.discard;
+  }
+
+  public removeFromArray(value) {
+    const index = this.el.value.indexOf(value);
+    this.el.value.splice(index, 1);
+  }
+
+  public addToArray() {
+    this.el.value.push(this.valueToPush);
+    this.valueToPush = "";
+  }
+}
+</script>
+
+<style scoped>
+.icon:hover {
+  background-color: var(--vscode-button-background);
+}
+</style>

--- a/src/views/cmakelists-editor/components/CMakeListsElement.vue
+++ b/src/views/cmakelists-editor/components/CMakeListsElement.vue
@@ -5,7 +5,7 @@
         <label :for="el.id" class="label">{{ el.title }} </label>
       </div>
       <ul v-if="el.type === 'array'">
-        <li v-for="v in el.value" :key="v" class="field has-addons">
+        <li v-for="v in el.value" :key="v" class="field is-grouped">
           <p class="label">{{ v }}</p>
           <div class="icon" @click="removeFromArray(v)">
             <i class="codicon codicon-close"></i>
@@ -13,7 +13,7 @@
         </li>
       </ul>
     </div>
-    <div v-if="el.type === 'array'" class="field has-addons">
+    <div v-if="el.type === 'array'" class="field is-grouped">
       <div class="control">
         <input type="text" v-model="elementValueToPush" class="input" />
       </div>
@@ -71,5 +71,11 @@ export default class CMakeListElement extends Vue {
 <style scoped>
 .icon:hover {
   background-color: var(--vscode-button-background);
+}
+.is-grouped {
+  align-items: center;
+}
+li.is-grouped .icon {
+  margin-bottom: 0.5em;
 }
 </style>

--- a/src/views/cmakelists-editor/components/CMakeListsElement.vue
+++ b/src/views/cmakelists-editor/components/CMakeListsElement.vue
@@ -15,7 +15,12 @@
     </div>
     <div v-if="el.type === 'array'" class="field is-grouped">
       <div class="control">
-        <input type="text" v-model="elementValueToPush" class="input" />
+        <input
+          type="text is-small"
+          v-model="elementValueToPush"
+          class="input"
+          @keyup.enter="addToArray"
+        />
       </div>
       <div class="control">
         <div class="icon" @click="addToArray">
@@ -25,7 +30,7 @@
     </div>
     <div v-else class="field">
       <div class="control">
-        <input type="text" v-model="el.value" class="input" />
+        <input type="text is-small" v-model="el.value" class="input" />
       </div>
     </div>
   </div>

--- a/src/views/cmakelists-editor/main.ts
+++ b/src/views/cmakelists-editor/main.ts
@@ -37,6 +37,11 @@ window.addEventListener("message", (event) => {
         store.commit("loadCmakeListsElements", message.elements);
       }
       break;
+    case "setFileName":
+      if (message.fileName) {
+        store.commit("setFileName", message.fileName);
+      }
+      break;
     default:
       break;
   }

--- a/src/views/cmakelists-editor/main.ts
+++ b/src/views/cmakelists-editor/main.ts
@@ -15,6 +15,12 @@ import Vue from "vue";
 // @ts-ignore
 import CMakeListsEditor from "./CmakeListsEditor.vue";
 import { store } from "./store";
+import IconifyIcon from "@iconify/vue";
+import add from "@iconify-icons/codicon/add";
+import close from "@iconify-icons/codicon/close";
+IconifyIcon.addIcon("add", add);
+IconifyIcon.addIcon("close", close);
+Vue.component("iconify-icon", IconifyIcon);
 
 // tslint:disable-next-line: no-unused-expression
 const app = new Vue({

--- a/src/views/cmakelists-editor/main.ts
+++ b/src/views/cmakelists-editor/main.ts
@@ -1,0 +1,44 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import Vue from "vue";
+// @ts-ignore
+import CMakeListsEditor from "./CmakeListsEditor.vue";
+import { store } from "./store";
+import "../commons/espCommons.scss";
+
+// tslint:disable-next-line: no-unused-expression
+const app = new Vue({
+  el: "#editor",
+  components: { CMakeListsEditor },
+  store,
+  template: "<CMakeListsEditor />",
+});
+
+window.addEventListener("message", (event) => {
+  const message = event.data;
+  switch (message.command) {
+    case "command":
+      if (message.value) {
+        store.commit("command", message.value);
+      }
+      break;
+    case "loadElements":
+      if (message.elements) {
+        store.commit("loadCmakeListsElements", message.elements);
+      }
+      break;
+    default:
+      break;
+  }
+});

--- a/src/views/cmakelists-editor/main.ts
+++ b/src/views/cmakelists-editor/main.ts
@@ -15,7 +15,6 @@ import Vue from "vue";
 // @ts-ignore
 import CMakeListsEditor from "./CmakeListsEditor.vue";
 import { store } from "./store";
-import "../commons/espCommons.scss";
 
 // tslint:disable-next-line: no-unused-expression
 const app = new Vue({

--- a/src/views/cmakelists-editor/store/index.ts
+++ b/src/views/cmakelists-editor/store/index.ts
@@ -21,6 +21,7 @@ Vue.use(Vuex);
 // tslint:disable-next-line: interface-name
 export interface IState {
   elements: CmakeListsElement[];
+  fileName: string;
   textDictionary: {
     save: string;
     discard: string;
@@ -30,6 +31,7 @@ export interface IState {
 
 export const CMakeListEditorState: IState = {
   elements: [],
+  fileName: "",
   textDictionary: {
     discard: "Discard",
     save: "Save",
@@ -73,6 +75,11 @@ export const mutations: MutationTree<IState> = {
   loadCmakeListsElements(state, elements) {
     const newState = state;
     newState.elements = elements;
+    state = { ...newState };
+  },
+  setFileName(state, fileName) {
+    const newState = state;
+    newState.fileName = fileName;
     state = { ...newState };
   },
 };

--- a/src/views/cmakelists-editor/store/index.ts
+++ b/src/views/cmakelists-editor/store/index.ts
@@ -1,0 +1,86 @@
+// Copyright 2020 Espressif Systems (Shanghai) CO LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Vue from "vue";
+import Vuex from "vuex";
+import { ActionTree, MutationTree, StoreOptions } from "vuex";
+import { CmakeListsElement } from "../../../cmake/CmakeListsElement";
+Vue.use(Vuex);
+
+// tslint:disable-next-line: interface-name
+export interface IState {
+  elements: CmakeListsElement[];
+  textDictionary: {
+    save: string;
+    discard: string;
+    title: string;
+  };
+}
+
+export const CMakeListEditorState: IState = {
+  elements: [],
+  textDictionary: {
+    discard: "Discard",
+    save: "Save",
+    title: "CMakeLists.txt Editor",
+  },
+};
+
+declare var acquireVsCodeApi: any;
+let vscode: any;
+try {
+  vscode = acquireVsCodeApi();
+} catch (error) {
+  // tslint:disable-next-line: no-console
+  console.error(error);
+}
+
+export const actions: ActionTree<IState, any> = {
+  sendNewValue(context, newValue) {
+    vscode.postMessage({
+      command: "updateValue",
+      updated_value: newValue,
+    });
+  },
+  saveChanges(context) {
+    vscode.postMessage({
+      command: "saveChanges",
+      newValues: context.state.elements,
+    });
+  },
+  requestInitValues(context) {
+    vscode.postMessage({ command: "loadCMakeListSchema" });
+  },
+};
+
+export const mutations: MutationTree<IState> = {
+  loadTextDictionary(state, textDictionary) {
+    const newState = state;
+    newState.textDictionary = textDictionary;
+    state = { ...newState };
+  },
+  loadCmakeListsElements(state, elements) {
+    const newState = state;
+    newState.elements = elements;
+    state = { ...newState };
+  },
+};
+
+export const cmakelists: StoreOptions<IState> = {
+  actions,
+  mutations,
+  state: CMakeListEditorState,
+};
+
+export const store = new Vuex.Store(cmakelists);

--- a/src/views/cmakelists-editor/store/index.ts
+++ b/src/views/cmakelists-editor/store/index.ts
@@ -15,7 +15,7 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import { ActionTree, MutationTree, StoreOptions } from "vuex";
-import { CmakeListsElement } from "../../../cmake/CmakeListsElement";
+import { CmakeListsElement } from "../../../cmake/cmakeListsElement";
 Vue.use(Vuex);
 
 // tslint:disable-next-line: interface-name

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,13 @@ const extensionConfig = {
 
 const webViewConfig = {
   entry: {
+    cmakelistsEditor: path.resolve(
+      __dirname,
+      "src",
+      "views",
+      "cmakelists-editor",
+      "main.ts"
+    ),
     examples: path.resolve(__dirname, "src", "views", "examples", "main.ts"),
     size: path.resolve(__dirname, "src", "views", "size", "main.ts"),
     tracing: path.resolve(__dirname, "src", "views", "tracing", "main.ts"),


### PR DESCRIPTION
Allow user to set project CMakelists.txt or ESP-IDF component CMakelists.txt with a group of input options to fill `idf_component_register` on (component CmakeLists.txt) or  ESP-IDF project CMake in project one.

Closes #188 
