### PR TITLE
add app offset to debug adapter (VSC-492)

### DIFF
--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -71,6 +71,7 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
   "espIdf.launchWSServerAndMonitor.title": "Launch IDF Monitor for CoreDump / GDB-Stub Mode",
+  "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -71,6 +71,7 @@
   "param.esp.rainmaker.oauth.url": "URL del servidor ESP-Rainmaker OAuth",
   "idf.wssPort.description": "Puerto del servidor Web Socket para Core-Dump o GDB-Stub",
   "espIdf.launchWSServerAndMonitor.title": "Inicie el monitor IDF para el modo CoreDump / GDB-Stub",
+  "esp_idf.appOffset.description": "Sobrescribir offset de inicio de programa (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "ruta del archivo gdbinit para el ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "Comando a ejecutar"

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -71,6 +71,7 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth服务器网址",
   "idf.wssPort.description": "用于核心转储或GDB存根的Web套接字服务器端口",
   "espIdf.launchWSServerAndMonitor.title": "为CoreDump / GDB-Stub模式启动IDF监视器",
+  "esp_idf.appOffset.description": "重写生成程序开始地址偏移量 (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
   "esp_idf.gdbinitFile.description": "ESP-IDF调试适配器的gdbinit文件路径",
   "esp_idf.debuggers.text.description": "要执行的命令"

--- a/package.json
+++ b/package.json
@@ -698,6 +698,10 @@
         "configurationAttributes": {
           "launch": {
             "properties": {
+              "appOffset": {
+                "type": "string",
+                "description": "%esp_idf.appOffset.description%"
+              },
               "debugPort": {
                 "type": "number",
                 "description": "Port for ESP-IDF Debug Adapter. Default: 43474",

--- a/package.nls.json
+++ b/package.nls.json
@@ -71,6 +71,7 @@
   "param.esp.rainmaker.oauth.url": "ESP-Rainmaker OAuth server URL",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
   "espIdf.launchWSServerAndMonitor.title": "Launch IDF Monitor for CoreDump / GDB-Stub Mode",
+  "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -141,6 +141,7 @@
     "param.esp.rainmaker.oauth.url",
     "idf.wssPort.description",
     "espIdf.launchWSServerAndMonitor.title",
+    "esp_idf.appOffset.description",
     "esp_idf.initGdbCommands.description",
     "esp_idf.debuggers.text.description",
     "esp_idf.gdbinitFile.description"

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -116,6 +116,7 @@ export class DebugAdapterManager extends EventEmitter {
         serialPort,
         flashBaudRate
       );
+      const appOffset = parseInt(model.app.address, 16).toString();
 
       const pythonBinPath = idfConf.readParameter(
         "idf.pythonBinPath"
@@ -133,7 +134,7 @@ export class DebugAdapterManager extends EventEmitter {
         "-dn",
         this.target,
         "-a",
-        model.app.address,
+        appOffset,
       ];
       if (this.isPostMortemDebugMode) {
         adapterArgs.push("-pm");

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -30,6 +30,7 @@ import {
 } from "../../utils";
 import { EOL } from "os";
 import { outputFile, constants } from "fs-extra";
+import { createFlashModel } from "../../flash/flashModelBuilder";
 
 export interface IDebugAdapterConfig {
   coreDumpFile?: string;
@@ -102,6 +103,20 @@ export class DebugAdapterManager extends EventEmitter {
       }
       const logFile = path.join(this.currentWorkspace.fsPath, "debug") + ".log";
 
+      const serialPort = idfConf.readParameter("idf.port");
+      const flashBaudRate = idfConf.readParameter("idf.flashBaudRate");
+
+      const flasherArgsJsonPath = path.join(
+        this.currentWorkspace.fsPath,
+        "build",
+        "flasher_args.json"
+      );
+      const model = await createFlashModel(
+        flasherArgsJsonPath,
+        serialPort,
+        flashBaudRate
+      );
+
       const pythonBinPath = idfConf.readParameter(
         "idf.pythonBinPath"
       ) as string;
@@ -117,6 +132,8 @@ export class DebugAdapterManager extends EventEmitter {
         this.port.toString(),
         "-dn",
         this.target,
+        "-a",
+        model.app.address,
       ];
       if (this.isPostMortemDebugMode) {
         adapterArgs.push("-pm");

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -105,15 +105,14 @@ export class DebugAdapterManager extends EventEmitter {
       }
       const logFile = path.join(this.currentWorkspace.fsPath, "debug") + ".log";
 
-      const serialPort = idfConf.readParameter("idf.port");
-      const flashBaudRate = idfConf.readParameter("idf.flashBaudRate");
-
-      const flasherArgsJsonPath = path.join(
-        this.currentWorkspace.fsPath,
-        "build",
-        "flasher_args.json"
-      );
       if (!this.appOffset) {
+        const serialPort = idfConf.readParameter("idf.port");
+        const flashBaudRate = idfConf.readParameter("idf.flashBaudRate");
+        const flasherArgsJsonPath = path.join(
+          this.currentWorkspace.fsPath,
+          "build",
+          "flasher_args.json"
+        );
         if (!canAccessFile(flasherArgsJsonPath, constants.R_OK)) {
           return reject(
             new Error(`${flasherArgsJsonPath} doesn't exist. Build first.`)
@@ -238,9 +237,7 @@ export class DebugAdapterManager extends EventEmitter {
     if (config.target) {
       this.target = config.target;
     }
-    if (config.appOffset) {
-      this.appOffset = config.appOffset;
-    }
+    this.appOffset = config.appOffset;
   }
 
   public isRunning(): boolean {

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -123,7 +123,7 @@ export class DebugAdapterManager extends EventEmitter {
           serialPort,
           flashBaudRate
         );
-        this.appOffset = parseInt(model.app.address, 16).toString();
+        this.appOffset = model.app.address;
       }
 
       const pythonBinPath = idfConf.readParameter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -709,6 +709,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         if (launchMode === "auto" && !debugAdapterManager.isRunning()) {
           const debugAdapterConfig = {
+            appOffset: session.configuration.appOffset,
             debugAdapterPort: portToUse,
             elfFile: session.configuration.elfFilePath,
             env: session.configuration.env,
@@ -1524,13 +1525,17 @@ export async function activate(context: vscode.ExtensionContext) {
           isPostMortemDebugMode: true,
           elfFile: resp.prog,
         } as IDebugAdapterConfig;
-        debugAdapterManager.configureAdapter(debugAdapterConfig);
-        await vscode.debug.startDebugging(undefined, {
-          name: "GDB Stub Debug",
-          type: "espidf",
-          request: "launch",
-        });
-        wsServer.done();
+        try {
+          debugAdapterManager.configureAdapter(debugAdapterConfig);
+          await vscode.debug.startDebugging(undefined, {
+            name: "GDB Stub Debug",
+            type: "espidf",
+            request: "launch",
+          });
+          wsServer.done();
+        } catch (error) {
+          Logger.errorNotify("Failed to launch debugger for postmortem", error);
+        }
       })
       .on("close", (resp) => {
         wsServer.close();

--- a/src/flash/flashModel.ts
+++ b/src/flash/flashModel.ts
@@ -18,12 +18,15 @@
 
 // tslint:disable: interface-name
 export interface FlashModel {
-  port: string;
+  app: FlashSection;
   baudRate: string;
-  mode: string;
-  frequency: string;
-  size: string;
+  bootloader: FlashSection;
   flashSections: FlashSection[];
+  frequency: string;
+  mode: string;
+  partitionTable: FlashSection;
+  port: string;
+  size: string;
 }
 export interface FlashSection {
   address: string;

--- a/src/flash/flashModelBuilder.ts
+++ b/src/flash/flashModelBuilder.ts
@@ -26,6 +26,18 @@ export function createFlashModel(
 ): Promise<FlashModel> {
   return readJSON(modelJsonPath).then((flashArgsJson) => {
     const flashModel: FlashModel = {
+      app: {
+        address: flashArgsJson.app.offset,
+        binFilePath: flashArgsJson.app.file,
+      } as FlashSection,
+      bootloader: {
+        address: flashArgsJson.bootloader.offset,
+        binFilePath: flashArgsJson.bootloader.file,
+      } as FlashSection,
+      partitionTable: {
+        address: flashArgsJson.partition_table.offset,
+        binFilePath: flashArgsJson.partition_table.file,
+      } as FlashSection,
       baudRate,
       port,
       size: flashArgsJson.flash_settings.flash_size,


### PR DESCRIPTION
Previously the app offset was not being given to debug adapter parameters.

Now, parsing `your_project_directory/build/flasher_args.json` for app offset and include it to debug adapter arguments.

Fix #225 