### PR TITLE
Full clean button and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <img src="./media/espressif_icon.png" alt="espressif logo" title="Espressif" align="right" height="60" />
 </a>
 
-# ESP-IDF VS Code Extension
+ESP-IDF VS Code Extension
+===
 
 Develop and debug applications for Espressif [ESP32](https://espressif.com/en/products/hardware/esp32), [ESP32-S2](https://www.espressif.com/en/products/socs/esp32-s2) chips with [ESP-IDF](https://github.com/espressif/esp-idf) IoT Development Framework.
 
@@ -35,6 +36,7 @@ There are a few dependencies which needs to be downloaded and installed before y
 - [CMake](https://cmake.org/download) and [Ninja](https://github.com/ninja-build/ninja/releases) for **Linux or MacOS users**. For Windows users, it is part of the onboarding configuration tools intall.
 
 > Please note that this extension **only [supports](https://github.com/espressif/esp-idf/blob/master/SUPPORT_POLICY.md)** the release versions of ESP-IDF, you can still use the extension on `master` branch or some other branch, but certain feature might not work fully.
+
 
 ## Quick Installation Guide
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
   <img src="./media/espressif_icon.png" alt="espressif logo" title="Espressif" align="right" height="60" />
 </a>
 
-ESP-IDF VS Code Extension
-===
+# ESP-IDF VS Code Extension
 
 Develop and debug applications for Espressif [ESP32](https://espressif.com/en/products/hardware/esp32), [ESP32-S2](https://www.espressif.com/en/products/socs/esp32-s2) chips with [ESP-IDF](https://github.com/espressif/esp-idf) IoT Development Framework.
 
@@ -36,7 +35,6 @@ There are a few dependencies which needs to be downloaded and installed before y
 - [CMake](https://cmake.org/download) and [Ninja](https://github.com/ninja-build/ninja/releases) for **Linux or MacOS users**. For Windows users, it is part of the onboarding configuration tools intall.
 
 > Please note that this extension **only [supports](https://github.com/espressif/esp-idf/blob/master/SUPPORT_POLICY.md)** the release versions of ESP-IDF, you can still use the extension on `master` branch or some other branch, but certain feature might not work fully.
-
 
 ## Quick Installation Guide
 
@@ -108,6 +106,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | SDK Configuration editor                        |                                        |                                           |
 | Set default sdkconfig file in project           |                                        |                                           |
 | Select port to use                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>P</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>P</kbd> |
+| Full clean project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
 | Build your project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>B</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>B</kbd> |
 | Flash your project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
 | Monitor your device                             | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>M</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>M</kbd> |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -30,6 +30,7 @@
   "espIdf.getEspMdf.title": "ESP-IDF: Install ESP-MDF",
   "espIdf.openDocUrl.title": "ESP-IDF: Open ESP-IDF Documentation...",
   "espIdf.clearDocsSearchResult.title": "ESP-IDF: Clear ESP-IDF Search results",
+  "espIdf.fullClean.title": "ESP-IDF: Full clean project",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -30,6 +30,7 @@
   "espIdf.getEspMdf.title": "ESP-IDF: Instalar ESP-MDF",
   "espIdf.openDocUrl.title": "ESP-IDF: Abrir documentación ESP-IDF...",
   "espIdf.clearDocsSearchResult.title": "ESP-IDF: Limpiar resultados de busqueda",
+  "espIdf.fullClean.title": "ESP-IDF: Limpiar el proyecto",
   "debug.initConfig.name": "Lanzar ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -30,6 +30,7 @@
   "espIdf.getEspMdf.title": "ESP-ADF: 安装ESP-MDF",
   "espIdf.openDocUrl.title": "ESP-IDF: 打开ESP-IDF文档...",
   "espIdf.clearDocsSearchResult.title": "ESP-IDF: 清除ESP-IDF搜索结果",
+  "espIdf.fullClean.title": "ESP-IDF: 全清洁工程",
   "debug.initConfig.name": "ESP-IDF：启动",
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF调试适配器的目标名称",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "onCommand:espIdf.cleanProject",
     "onCommand:espIdf.erase_flash",
     "onCommand:espIdf.size",
+    "onCommand:espIdf.fullClean",
     "onCommand:espIdf.apptrace",
     "onCommand:espIdf.heaptrace",
     "onCommand:espIdf.openOCDCommand",
@@ -239,6 +240,11 @@
         "command": "espIdf.createFiles",
         "key": "ctrl+e c",
         "mac": "cmd+e c"
+      },
+      {
+        "command": "espIdf.fullClean",
+        "key": "ctrl+e f",
+        "mac": "cmd+e f"
       },
       {
         "command": "espIdf.buildDevice",
@@ -744,6 +750,10 @@
         "command": "espIdf.selectFlashMethodAndFlash",
         "title": "%espIdf.selectFlashMethodAndFlash.title%",
         "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.fullClean",
+        "title": "%espIdf.fullClean.title%"
       }
     ],
     "breakpoints": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,6 +30,7 @@
   "espIdf.getEspMdf.title": "ESP-IDF: Install ESP-MDF",
   "espIdf.openDocUrl.title": "ESP-IDF: Open ESP-IDF Documentation...",
   "espIdf.clearDocsSearchResult.title": "ESP-IDF: Clear ESP-IDF Search results",
+  "espIdf.fullClean.title": "ESP-IDF: Full clean project",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -431,8 +431,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const buildDir = path.join(workspaceRoot.fsPath, "build");
       const buildDirExists = await utils.dirExistPromise(buildDir);
       if (!buildDirExists) {
-        Logger.infoNotify(`Directory ${buildDir} does not exists.`);
-        return;
+        return Logger.warnNotify(
+          `There is no build directory to clean, exiting!`
+        );
       }
       const cmakeCacheFile = path.join(buildDir, "CMakeCache.txt");
       const doesCmakeCacheExists = utils.canAccessFile(
@@ -440,11 +441,16 @@ export async function activate(context: vscode.ExtensionContext) {
         constants.R_OK
       );
       if (!doesCmakeCacheExists) {
-        Logger.infoNotify(
-          `Directory ${buildDir} doesn't seem to be a CMake build directory or is empty.`
+        return Logger.warnNotify(
+          `There is no build directory to clean, exiting!`
         );
-        return;
       }
+      if (BuildTask.isBuilding || FlashTask.isFlashing) {
+        return Logger.warnNotify(
+          `There is a build or flash task running. Wait for it to finish or cancel before clean.`
+        );
+      }
+
       await del(buildDir, { force: true });
     });
   });


### PR DESCRIPTION
Add `espIdf.fullClean` command to delete the build directory and status bar button.

Fix #247 