### PR TITLE
Add environment variable support for Powershell Core for Linux and macOS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2455,6 +2455,8 @@ function getTxtCmd(variable: string, modifiedEnv: { [key: string]: string }) {
     case "powershell.exe":
     case "pwsh.exe":
       return `$Env:${variable}="${modifiedEnv[variable]}"`;
+    case "pwsh":
+      return `$Env:${variable}="${modifiedEnv[variable]}"`;
     default:
       return `export ${variable}="${modifiedEnv[variable]}"`;
   }


### PR DESCRIPTION
PowerShell Core binary is called `pwsh` under Linux and macOS. This fix allows it to be detected properly.