### PR TITLE
rm check tools before cmds update tasks

### DIFF
--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -21,7 +21,7 @@ import { join } from "path";
 import { Logger } from "../logger/logger";
 import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
-import { appendIdfAndToolsToPath } from "../utils";
+import { appendIdfAndToolsToPath, isBinInPath } from "../utils";
 import { TaskManager } from "../taskManager";
 import EspIdfCustomTerminal from "../espIdfCustomTerminal";
 import { SpawnOptions } from "child_process";
@@ -65,6 +65,19 @@ export class BuildTask {
     }
     this.building(true);
     const modifiedEnv = appendIdfAndToolsToPath();
+    const canAccessCMake = await isBinInPath(
+      "cmake",
+      this.curWorkspace,
+      modifiedEnv
+    );
+    const canAccessNinja = await isBinInPath(
+      "ninja",
+      this.curWorkspace,
+      modifiedEnv
+    );
+    if (canAccessCMake === "" && canAccessNinja === "") {
+      throw new Error("CMake or Ninja executables not found");
+    }
     await ensureDir(this.curWorkspace);
     const options: SpawnOptions = {
       cwd: this.curWorkspace,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,11 +86,7 @@ import { SetupPanel } from "./setup/SetupPanel";
 import { TCLClient } from "./espIdf/openOcd/tcl/tclClient";
 import { JTAGFlash } from "./flash/jtag";
 import { ChangelogViewer } from "./changelog-viewer";
-import {
-  getSetupInitialValues,
-  isCurrentInstallValid,
-  ISetupInitArgs,
-} from "./setup/setupInit";
+import { getSetupInitialValues, ISetupInitArgs } from "./setup/setupInit";
 import { installReqs } from "./pythonManager";
 import { checkExtensionSettings } from "./checkExtensionSettings";
 import { CmakeListsEditorPanel } from "./cmake/cmakeEditorPanel";
@@ -2039,10 +2035,6 @@ const build = () => {
           buildTask.building(false);
         });
         try {
-          const checkToolsAreValid = await isCurrentInstallValid();
-          if (!checkToolsAreValid) {
-            return;
-          }
           await buildTask.build();
           await TaskManager.runTasks();
           if (!cancelToken.isCancellationRequested) {
@@ -2151,10 +2143,6 @@ const flash = () => {
           TaskManager.disposeListeners();
         });
         try {
-          const checkToolsAreValid = await isCurrentInstallValid();
-          if (!checkToolsAreValid) {
-            return;
-          }
           const model = await createFlashModel(
             flasherArgsJsonPath,
             port,
@@ -2270,10 +2258,6 @@ const buildFlashAndMonitor = (runMonitor: boolean = true) => {
           buildTask.building(false);
         });
         try {
-          const checkToolsAreValid = await isCurrentInstallValid();
-          if (!checkToolsAreValid) {
-            return;
-          }
           progress.report({ message: "Building project...", increment: 20 });
           await buildTask.build().then(() => {
             buildTask.building(false);
@@ -2451,7 +2435,7 @@ function getTxtCmd(variable: string, modifiedEnv: { [key: string]: string }) {
   const shellExecutable = path.basename(vscode.env.shell);
   switch (shellExecutable) {
     case "cmd.exe":
-      return `set ${variable}="${modifiedEnv[variable]}"`;
+      return `set "${variable}=${modifiedEnv[variable]}"`;
     case "powershell.exe":
     case "pwsh.exe":
       return `$Env:${variable}="${modifiedEnv[variable]}"`;

--- a/templates/.vscode/tasks.json
+++ b/templates/.vscode/tasks.json
@@ -6,17 +6,25 @@
             "type": "shell",
             "command": "${config:idf.pythonBinPath} ${config:idf.espIdfPath}/tools/idf.py build",
             "windows": {
-                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py build"
+                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py build",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}"
+                    }
+                }
             },
             "options": {
                 "env": {
-                    "PATH": "${config:idf.customExtraPaths}"
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}"
                 }
             },
             "problemMatcher": [
                 {
                     "owner": "cpp",
-                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "fileLocation": [
+                        "relative",
+                        "${workspaceFolder}"
+                    ],
                     "pattern": {
                         "regexp": "^\\.\\.(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
                         "file": 1,
@@ -59,24 +67,32 @@
                     "severity": 4,
                     "message": 5
                 }
-            },
+            }
         },
         {
             "label": "Clean - Clean the project",
             "type": "shell",
             "command": "${config:idf.pythonBinPath} ${config:idf.espIdfPath}/tools/idf.py fullclean",
             "windows": {
-                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py fullclean"
+                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py fullclean",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}"
+                    }
+                }
             },
             "options": {
                 "env": {
-                    "PATH": "${config:idf.customExtraPaths}"
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}"
                 }
             },
             "problemMatcher": [
                 {
                     "owner": "cpp",
-                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "fileLocation": [
+                        "relative",
+                        "${workspaceFolder}"
+                    ],
                     "pattern": {
                         "regexp": "^\\.\\.(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
                         "file": 1,
@@ -98,24 +114,79 @@
                         "message": 5
                     }
                 }
-            ],
+            ]
         },
         {
             "label": "Flash - Flash the device",
             "type": "shell",
             "command": "${config:idf.pythonBinPath} ${config:idf.espIdfPath}/tools/idf.py -p ${config:idf.port} -b ${config:idf.flashBaudRate} flash",
             "windows": {
-                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py flash -p ${config:idf.portWin} -b ${config:idf.flashBaudRate}"
+                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py flash -p ${config:idf.portWin} -b ${config:idf.flashBaudRate}",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}"
+                    }
+                }
             },
             "options": {
                 "env": {
-                    "PATH": "${config:idf.customExtraPaths}"
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}"
                 }
             },
             "problemMatcher": [
                 {
                     "owner": "cpp",
-                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "fileLocation": [
+                        "relative",
+                        "${workspaceFolder}"
+                    ],
+                    "pattern": {
+                        "regexp": "^\\.\\.(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3,
+                        "severity": 4,
+                        "message": 5
+                    }
+                },
+                {
+                    "owner": "cpp",
+                    "fileLocation": "absolute",
+                    "pattern": {
+                        "regexp": "^[^\\.](.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3,
+                        "severity": 4,
+                        "message": 5
+                    }
+                }
+            ]
+        },
+        {
+            "label": "Monitor: Start the monitor",
+            "type": "shell",
+            "command": "${config:idf.pythonBinPath} ${config:idf.espIdfPath}/tools/idf.py -p ${config:idf.port} monitor",
+            "windows": {
+                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py -p ${config:idf.portWin} monitor",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}"
+                    }
+                }
+            },
+            "options": {
+                "env": {
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}"
+                }
+            },
+            "problemMatcher": [
+                {
+                    "owner": "cpp",
+                    "fileLocation": [
+                        "relative",
+                        "${workspaceFolder}"
+                    ],
                     "pattern": {
                         "regexp": "^\\.\\.(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
                         "file": 1,
@@ -138,37 +209,29 @@
                     }
                 }
             ],
+            "dependsOn": "Flash - Flash the device"
         },
         {
-            "label": "Monitor: Start the monitor",
+            "label": "OpenOCD: Start openOCD",
             "type": "shell",
-            "command": "${config:idf.pythonBinPath} ${config:idf.espIdfPath}/tools/idf.py -p ${config:idf.port} monitor",
-            "windows": {
-                "command": "${config:idf.pythonBinPathWin} ${config:idf.espIdfPathWin}\\tools\\idf.py monitor -p ${config:idf.portWin}"
-            },
-            "options": {
-                "env": {
-                    "PATH": "${config:idf.customExtraPaths}",
-                }
-            },
-            "dependsOn": "Flash - Flash the device",
-        },
-        {
-            "label":"OpenOCD: Start openOCD",
-            "type":"shell",
             "presentation": {
                 "echo": true,
                 "reveal": "never",
                 "focus": false,
-                "panel":"new"
+                "panel": "new"
             },
-            "command":"openocd -s ${command:espIdf.getOpenOcdScriptValue} ${command:espIdf.getOpenOcdConfigs}",
+            "command": "openocd -s ${command:espIdf.getOpenOcdScriptValue} ${command:espIdf.getOpenOcdConfigs}",
             "windows": {
-                "command": "openocd.exe -s ${command:espIdf.getOpenOcdScriptValue} ${command:espIdf.getOpenOcdConfigs}"
+                "command": "openocd.exe -s ${command:espIdf.getOpenOcdScriptValue} ${command:espIdf.getOpenOcdConfigs}",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}"
+                    }
+                }
             },
             "options": {
                 "env": {
-                    "PATH": "${config:idf.customExtraPaths}"
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}"
                 }
             },
             "problemMatcher": {
@@ -182,7 +245,7 @@
                     "severity": 4,
                     "message": 5
                 }
-            },
+            }
         },
         {
             "label": "adapter",
@@ -191,7 +254,7 @@
             "isBackground": true,
             "options": {
                 "env": {
-                    "PATH": "${config:idf.customExtraPaths}",
+                    "PATH": "${env:PATH}:${config:idf.customExtraPaths}",
                     "PYTHONPATH": "${command:espIdf.getExtensionPath}/esp_debug_adapter/debug_adapter"
                 }
             },
@@ -212,23 +275,25 @@
             },
             "args": [
                 "${command:espIdf.getExtensionPath}/esp_debug_adapter/debug_adapter_main.py",
-                "-e", "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
-                "-s", "${command:espIdf.getOpenOcdScriptValue}",
-                "-ip", "localhost",
-                "-dn", "${config:idf.adapterTargetName}",
+                "-e",
+                "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
+                "-s",
+                "${command:espIdf.getOpenOcdScriptValue}",
+                "-ip",
+                "localhost",
+                "-dn",
+                "${config:idf.adapterTargetName}",
                 "-om",
                 "connect_to_instance"
             ],
             "windows": {
-                "args": [
-                    "${command:espIdf.getExtensionPath}/esp_debug_adapter/debug_adapter_main.py",
-                    "-e", "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
-                    "-s", "${command:espIdf.getOpenOcdScriptValue}",
-                    "-ip", "localhost",
-                    "-dn", "${config:idf.adapterTargetName}",
-                    "-om",
-                    "connect_to_instance"
-                ]
+                "command": "${config:idf.pythonBinPathWin}",
+                "options": {
+                    "env": {
+                        "PATH": "${env:PATH};${config:idf.customExtraPaths}",
+                        "PYTHONPATH": "${command:espIdf.getExtensionPath}/esp_debug_adapter/debug_adapter"
+                    }
+                }
             }
         }
     ]


### PR DESCRIPTION
Fix #280
Fix #278 
Fix #277
Fix #276 

Add env:PATH and reorder monitor args in tasks.json
Fix quotes on cmd.exe
Remove check esp-idf tools are valid from build flash commands.