### PR TITLE
WSL1 bugfix

### DIFF
--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -1,12 +1,14 @@
 # Using this extension on Windows Subsystem for Linux (WSL)
 
-We have tested this extension using Windows 10 Build 19041 with WSL 2 with the Microsoft's Ubuntu 20.04 distribution for WSL.
+> **NOTE**: On WSL 1 serial ports are available so the behavior doesn't change from regular Linux extension environment.
 
-Currently in WSL 2, we have no access to serial ports. Calling `powershell.exe` from distribution's shell we obtain serial ports and perform flash and monitor tasks.
+This extension was tested in Windows 10 Build 19041 with the Microsoft's Ubuntu 20.04 distribution for WSL 2.
+
+Currently in WSL 2, there is no access to serial ports. Calling `powershell.exe` from distribution's shell we obtain serial ports and perform flash and monitor tasks.
 
 ## Limitations
 
-- Currently Python is also required in Windows machine.
+- Currently Python is also required in Windows machine and available in environment PATH as `python`.
 - Based on build 17063, sharing environment variables between WSL and Windows is done with a single environment variable `WSLENV` which translates WSL paths to Windows paths and viceversa. We have tried to include tools like `xtensa-esp32-elf-gcc` in PATH without success. (If you can make it work, please contribute with a pull request). This issue makes certain features not to work in WSL like `xtensa-esp32-elf-addr2line` in ESP-IDF Monitor.
 
 ## WSL extension setup
@@ -19,4 +21,4 @@ sudo apt-get install git wget flex bison gperf python3-pip python3-venv python3-
 
 2. Configure the extension as explained in [SETUP](./SETUP.md).
 
-3. Create a ESP-IDF project and use extension features.
+3. Create an ESP-IDF project and use extension features.

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -102,6 +102,8 @@
     "espIdf.openDocUrl.title",
     "espIdf.clearDocsSearchResult.title",
     "espIdf.selectOpenOcdConfigFiles.title",
+    "espIdf.fullClean.title",
+    "espIdf.webview.nvsPartitionEditor.title",
     "debug.initConfig.name",
     "debug.initConfig.description",
     "param.adapterTargetName",

--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -21,7 +21,12 @@ import * as vscode from "vscode";
 import * as idfConf from "../../idfConfiguration";
 import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
-import { execChildProcess, extensionContext, spawn } from "../../utils";
+import {
+  compareVersion,
+  execChildProcess,
+  extensionContext,
+  spawn,
+} from "../../utils";
 import { SerialPortDetails } from "./serialPortDetails";
 
 export class SerialPort {
@@ -51,10 +56,17 @@ export class SerialPort {
 
     try {
       const osRelease = release();
+      const kernelMatch = osRelease.toLowerCase().match(/(.*)-(.*)-(.*)/);
+      let isWsl2Kernel: number = -1; // WSL 2 is implemented on Microsoft Linux Kernel >=4.19
+      if (kernelMatch && kernelMatch.length) {
+        isWsl2Kernel = compareVersion(kernelMatch[1], "4.19");
+      }
+      console.log(isWsl2Kernel);
       let portList: SerialPortDetails[];
       if (
         process.platform === "linux" &&
-        osRelease.toLowerCase().indexOf("microsoft") !== -1
+        osRelease.toLowerCase().indexOf("microsoft") !== -1 &&
+        isWsl2Kernel !== -1
       ) {
         portList = await this.wslList();
       } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2436,9 +2436,15 @@ function createMonitor(): any {
     monitorTerminal.show();
     overrideVscodeTerminalWithIdfEnv(monitorTerminal, modifiedEnv);
     const osRelease = release();
+    const kernelMatch = osRelease.toLowerCase().match(/(.*)-(.*)-(.*)/);
+    let isWsl2Kernel: number = -1; // WSL 2 is implemented on Microsoft Linux Kernel >=4.19
+    if (kernelMatch && kernelMatch.length) {
+      isWsl2Kernel = utils.compareVersion(kernelMatch[1], "4.19");
+    }
     if (
       process.platform === "linux" &&
-      osRelease.toLowerCase().indexOf("microsoft") !== -1
+      osRelease.toLowerCase().indexOf("microsoft") !== -1 &&
+      isWsl2Kernel !== -1
     ) {
       const wslRoot = utils.extensionContext.extensionPath.replace(/\//g, "\\");
       const wslCurrPath = await utils.execChildProcess(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -754,3 +754,26 @@ export function getWebViewFavicon(extensionPath: string): vscode.Uri {
     path.join(extensionPath, "media", "espressif_icon.png")
   );
 }
+
+/**
+ * Compare two version strings based on semantic versioning.
+ * @param {string} v1 - String containing dot-separated numbers.
+ * @param {string} v2 - String containing dot-separated numbers.
+ * @return {number} v1 > v2 => 1 | v1 < v2 => -1 | v1 = v2 => 0
+ */
+export function compareVersion(v1: string, v2: string) {
+  const v1Parts = v1.split(".");
+  const v2Parts = v2.split(".");
+  const minParts = Math.min(v1Parts.length, v2Parts.length);
+  for (let i = 0; i < minParts; i++) {
+    let v1Ver = parseInt(v1Parts[i], 10);
+    let v2Ver = parseInt(v2Parts[i], 10);
+    if (v1Ver > v2Ver) return 1;
+    if (v1Ver < v2Ver) return -1;
+  }
+  return v1Parts.length === v2Parts.length
+    ? 0
+    : v1Parts.length < v2Parts.length
+    ? -1
+    : 1;
+}


### PR DESCRIPTION
On WSL 1, serial ports are available. The previous fix for WSL2 in #224 is not required for WSL 1.

add semver version compare method in `src/utils.ts`. Could be used in other methods.

Fix #295 