### PR TITLE
Update Translations

### DIFF
--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -85,7 +85,7 @@
   "openocd.tcl.port.description": "Port for openocd tcl connection",
   "espIdf.launchWSServerAndMonitor.title": "Launch IDF Monitor for CoreDump / GDB-Stub Mode",
   "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
-  "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.initGdbCommands.description": "One or more GDB commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -85,7 +85,7 @@
   "openocd.tcl.port.description": "Puerto para conexión tcl openocd",
   "espIdf.launchWSServerAndMonitor.title": "Inicie el monitor IDF para el modo CoreDump / GDB-Stub",
   "esp_idf.appOffset.description": "Sobrescribir offset de inicio de programa (ESP32_APP_FLASH_OFF)",
-  "esp_idf.initGdbCommands.description": "Uno o varios comandos xtensa-esp32-elf-gdb a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.initGdbCommands.description": "Uno o varios comandos GDB a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "ruta del archivo gdbinit para el ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "Comando a ejecutar"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -85,7 +85,7 @@
   "openocd.tcl.port.description": "openocd tcl连接的端口",
   "espIdf.launchWSServerAndMonitor.title": "为CoreDump / GDB-Stub模式启动IDF监视器",
   "esp_idf.appOffset.description": "重写生成程序开始地址偏移量 (ESP32_APP_FLASH_OFF)",
-  "esp_idf.initGdbCommands.description": "要执行的一个或多个xtensa-esp32-elf-gdb命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
+  "esp_idf.initGdbCommands.description": "要执行的一个或多个GDB命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
   "esp_idf.gdbinitFile.description": "ESP-IDF调试适配器的gdbinit文件路径",
   "esp_idf.debuggers.text.description": "要执行的命令"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -85,7 +85,7 @@
   "openocd.tcl.port.description": "Port for openocd tcl connection",
   "espIdf.launchWSServerAndMonitor.title": "Launch IDF Monitor for CoreDump / GDB-Stub Mode",
   "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
-  "esp_idf.initGdbCommands.description": "One or more xtensa-esp32-elf-gdb commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
+  "esp_idf.initGdbCommands.description": "One or more GDB commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
   "esp_idf.debuggers.text.description": "The command to execute"
 }


### PR DESCRIPTION
Use `GDB` instead of `xtensa-esp32-elf-gdb` for more suitable naming

Closes #283 