### PR TITLE
Fix JTAG Flashing issue (on windows)

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -33,13 +33,14 @@ This is how the extension uses them:
 
 These settings are specific to the ESP32 Chip/ Board
 
-| Setting                 | Description                                                         |
-| ----------------------- | ------------------------------------------------------------------- |
-| `idf.adapterTargetName` | ESP-IDF target Chip (Example: esp32)                                |
-| `idf.flashBaudRate`     | Flash Baud rate                                                     |
-| `idf.openOcdConfigs`    | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder |
-| `idf.port`              | Path of selected device port                                        |
-| `idf.portWin`           | Path of selected device port in Windows                             |
+| Setting                                          | Description                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------- |
+| `idf.adapterTargetName`                          | ESP-IDF target Chip (Example: esp32)                                |
+| `idf.flashBaudRate`                              | Flash Baud rate                                                     |
+| `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder |
+| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
+| `idf.port`                                       | Path of selected device port                                        |
+| `idf.portWin`                                    | Path of selected device port in Windows                             |
 
 This is how the extension uses them:
 

--- a/package.json
+++ b/package.json
@@ -564,6 +564,10 @@
             "description": "%openocd.tcl.port.description%",
             "scope": "resource",
             "default": 6666
+          },
+          "openocd.jtag.command.force_unix_path_separator": {
+            "type": "boolean",
+            "default": true
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1836,7 +1836,7 @@ export async function activate(context: vscode.ExtensionContext) {
     PreCheck.perform(
       [openFolderCheck, webIdeCheck, minOpenOCDVersion20201125],
       async () => {
-        const buildFolder = path.join(workspaceRoot.fsPath, "build");
+        let buildFolder = path.join(workspaceRoot.fsPath, "build");
         if (!(await pathExists(buildFolder))) {
           return Logger.warnNotify("First you need to build before flashing!!");
         }
@@ -1877,6 +1877,12 @@ export async function activate(context: vscode.ExtensionContext) {
             const port = idfConf.readParameter("openocd.tcl.port");
             const client = new TCLClient({ host, port });
             const jtag = new JTAGFlash(client);
+            const forceUNIXPathSeparator = idfConf.readParameter(
+              "openocd.jtag.command.force_unix_path_separator"
+            );
+            if (forceUNIXPathSeparator === true) {
+              buildFolder = buildFolder.replace(/\\/g, "/");
+            }
             try {
               await jtag.flash(
                 `program_esp_bins ${buildFolder} flasher_args.json verify reset`

--- a/src/flash/jtag.ts
+++ b/src/flash/jtag.ts
@@ -32,7 +32,7 @@ export class JTAGFlash {
           }
 
           //Flash successful when response is 0
-          resolve();
+          resolve(response);
         })
         .on("error", (err) => {
           reject(


### PR DESCRIPTION
Use forced `/` instead of `\\`.

One can disable this by changing the configuration `openocd.jtag.command.force_unix_path_separator` (default `true`)

Closes #297 