### PR TITLE
Feature/launch monitor with debug session

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -68,13 +68,14 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
 ### Extension Behaviour Settings
 
-| Setting ID                   | Description                                                       |
-| ---------------------------- | ----------------------------------------------------------------- |
-| `idf.notificationSilentMode` | Silent all notifications messages (excluding error notifications) |
-| `idf.saveBeforeBuild`        | Save all the edited files before building (default `true`)        |
-| `idf.showOnboardingOnInit`   | Show ESP-IDF Configuration window on extension activation         |
-| `idf.useIDFKconfigStyle`     | Enable style validation for Kconfig files                         |
-| `idf.saveScope`              | Where to save extension settings                                  |
+| Setting ID                        | Description                                                       |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `idf.notificationSilentMode`      | Silent all notifications messages (excluding error notifications) |
+| `idf.saveBeforeBuild`             | Save all the edited files before building (default `true`)        |
+| `idf.showOnboardingOnInit`        | Show ESP-IDF Configuration window on extension activation         |
+| `idf.useIDFKconfigStyle`          | Enable style validation for Kconfig files                         |
+| `idf.saveScope`                   | Where to save extension settings                                  |
+| `idf.launchMonitorOnDebugSession` | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
 
 The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md).
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -69,6 +69,7 @@
   "param.notificationSilentMode": "Disable all ESP-IDF extension notifications (excluding error notifications)",
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
+  "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -55,6 +55,7 @@
   "param.partialDarkTheme": "Color de fondo para lineas parcialmente cubiertas en temas oscuros por ESP-IDF Coverage.",
   "param.uncoveredLightTheme": "Color de fondo para lineas no cubiertas en temas claros por ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Color de fondo para lineas no cubiertas en temas oscuros por ESP-IDF Coverage.",
+  "param.launchMonitorOnDebugSession.title": "Iniciar IDF Monitor junto a la sesión ESP-IDF Debug Adapter",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -55,6 +55,7 @@
   "param.partialDarkTheme": "Цвет фона для частично покрытых линий в темной теме для покрытия кода ESP-IDF.",
   "param.uncoveredLightTheme": "Цвет фона для непокрытых линий в светлой теме для покрытия кода ESP-IDF.",
   "param.uncoveredDarkTheme": "Цвет фона для непокрытых линий в темной теме для покрытия кода ESP-IDF.",
+  "param.launchMonitorOnDebugSession.title": "Запустите IDF Monitor вместе с сеансом ESP-IDF Debug Adapter.",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -55,6 +55,7 @@
   "param.partialDarkTheme": "ESP-IDF覆盖的暗主题部分覆盖线的背景色",
   "param.uncoveredLightTheme": "ESP-IDF覆盖的光主题中未覆盖线条的背景色",
   "param.uncoveredDarkTheme": "ESP-IDF覆盖的深色主题中未覆盖线条的背景色",
+  "param.launchMonitorOnDebugSession.title": "启动IDF监视器和ESP-IDF调试适配器会话",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -568,6 +568,12 @@
           "openocd.jtag.command.force_unix_path_separator": {
             "type": "boolean",
             "default": true
+          },
+          "idf.launchMonitorOnDebugSession": {
+            "type": "boolean",
+            "description": "%param.launchMonitorOnDebugSession.title%",
+            "scope": "resource",
+            "default": true
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -69,6 +69,7 @@
   "param.notificationSilentMode": "Disable all ESP-IDF extension notifications (excluding errors)",
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
+  "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -157,6 +157,7 @@
     "esp_idf.appOffset.description",
     "esp_idf.initGdbCommands.description",
     "esp_idf.debuggers.text.description",
-    "esp_idf.gdbinitFile.description"
+    "esp_idf.gdbinitFile.description",
+    "param.launchMonitorOnDebugSession.title"
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,7 @@ const statusBarItems: vscode.StatusBarItem[] = [];
 const openOCDManager = OpenOCDManager.init();
 let isOpenOCDLaunchedByDebug: boolean = false;
 let debugAdapterManager: DebugAdapterManager;
+let isMonitorLaunchedByDebug: boolean = false;
 
 // ESP-IDF Docs search results Tree view
 let espIdfDocsResultTreeDataProvider: DocSearchResultTreeDataProvider;
@@ -312,7 +313,8 @@ export async function activate(context: vscode.ExtensionContext) {
       openOCDManager.stop();
     }
     debugAdapterManager.stop();
-    if (monitorTerminal) {
+    if (isMonitorLaunchedByDebug) {
+      isMonitorLaunchedByDebug = false;
       monitorTerminal.dispose();
     }
   });
@@ -802,6 +804,7 @@ export async function activate(context: vscode.ExtensionContext) {
             session.configuration.sessionID !== "gdbstub.debug.session.ws") &&
           useMonitorWithDebug
         ) {
+          isMonitorLaunchedByDebug = true;
           createMonitor();
         }
         return new vscode.DebugAdapterServer(portToUse);


### PR DESCRIPTION
`idf.launchMonitorOnDebugSession` configuration setting to launch IDF Monitor when ESP-IDF debug session starts, default is true.

If launched by debug session, the IDF Monitor will be disposed on end of debug session.