### PR TITLE
ignore patch version in python_env directory making

### DIFF
--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -65,7 +65,11 @@ export class IdfToolsManager {
           this.allPackages = this.toolsJson.tools as IPackage[];
           // Change relative path to desired full paths.
           for (const pkg of this.allPackages) {
-            if (pkg.export_paths && pkg.export_paths[0][0] !== "") {
+            if (
+              pkg.export_paths &&
+              pkg.export_paths.length > 0 &&
+              pkg.export_paths[0][0] !== ""
+            ) {
               pkg.binaries = pkg.export_paths[0];
             }
             if (pkg.platform_overrides) {

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -269,7 +269,12 @@ export async function getPythonEnvPath(
       espIdfDir
     )
   ).replace(/(\n|\r|\r\n)/gm, "");
-  const espIdfVersion = await utils.getEspIdfVersion(espIdfDir);
+  const fullEspIdfVersion = await utils.getEspIdfVersion(espIdfDir);
+  const majorMinorMatches = fullEspIdfVersion.match(/([0-9]+\.[0-9]+).*/);
+  const espIdfVersion =
+    majorMinorMatches && majorMinorMatches.length > 0
+      ? majorMinorMatches[1]
+      : "x.x";
   const resultVersion = `idf${espIdfVersion}_py${pythonVersion}_env`;
   const idfPyEnvPath = path.join(idfToolsDir, "python_env", resultVersion);
 


### PR DESCRIPTION
Fix #309 

Use only IDF major and minor version for python_env creation. (`idf4.1_py3.8` instead of `idf4.1.1_py3.8_env` to comply with idf_tools.py)

Check a package export_paths length.