### PR TITLE
add espAdfPath espMdfPath to platform dep settings

### DIFF
--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -21,6 +21,8 @@ const locDic = new LocDictionary(__filename);
 
 const platformDepConfigurations: string[] = [
   "idf.espIdfPath",
+  "idf.espAdfPath",
+  "idf.espMdfPath",
   "idf.pythonBinPath",
   "idf.port",
   "idf.deviceInterface",


### PR DESCRIPTION
Missed adding espAdfPath and espMdfPath as platform dependent settings.

Fix #318 