### PR TITLE
Bugfix/get compiler path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ The **Show Examples Projects** command allows you create a new project using one
 The **Install ESP-ADF** will clone ESP-ADF to a selected directory and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows) configuration setting.
 The **Install ESP-MDF** will clone ESP-MDF to a selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
 
+### Commands for tasks.json and launch.json
+
+We have implemented some utilities commands that can be used in tasks.json and launch.json like
+
+```json
+"miDebuggerPath": "${command:espIdf.getXtensaGdb}"
+```
+
+as shown in the [debugging documentation](./DEBUGGING.md).
+
+- `espIdf.getXtensaGcc`: Return the absolute path of the xtensa toolchain gcc for the ESP-IDF target given by `idf.adapterTargetName` configuration setting and `idf.customExtraPaths`.
+- `espIdf.getXtensaGdb`: Return the absolute path of the xtensa toolchain gdb for the ESP-IDF target given by `idf.adapterTargetName` configuration setting and `idf.customExtraPaths`.
+
 ## Available Tasks in tasks.json
 
 There is also some tasks defined in Tasks.json, which can be executed by running <kbd>F1</kbd> and writing `Tasks: Run task` and selecting one of

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -100,7 +100,7 @@ The user can also use [Microsoft C/C++ Extension](https://marketplace.visualstud
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "miDebuggerPath": "${command:espIdf.getXtensaGcc}",
+      "miDebuggerPath": "${command:espIdf.getXtensaGdb}",
       "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
       "windows": {
         "program": "${workspaceFolder}\\build\\${command:espIdf.getProjectName}.elf"

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -100,7 +100,7 @@ The user can also use [Microsoft C/C++ Extension](https://marketplace.visualstud
       "type": "cppdbg",
       "request": "launch",
       "MIMode": "gdb",
-      "miDebuggerPath": "${command:espIdf.getXtensaGdb}",
+      "miDebuggerPath": "${command:espIdf.getXtensaGcc}",
       "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
       "windows": {
         "program": "${workspaceFolder}\\build\\${command:espIdf.getProjectName}.elf"

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -115,7 +115,7 @@ export class ExamplesPlanel {
               const modifiedEnv = utils.appendIdfAndToolsToPath();
               const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
               const compilerPath = await utils.isBinInPath(
-                `xtensa-${idfTarget}-elf-gdb`,
+                `xtensa-${idfTarget}-elf-gcc`,
                 resultFolder,
                 modifiedEnv
               );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -940,18 +940,19 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
-  registerIDFCommand("espIdf.getXtensaGdb", () => {
+  registerIDFCommand("espIdf.getXtensaGcc", () => {
     return PreCheck.perform([openFolderCheck], async () => {
       const modifiedEnv = utils.appendIdfAndToolsToPath();
+      const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
       try {
         return await utils.isBinInPath(
-          "xtensa-esp32-elf-gdb",
+          `xtensa-${idfTarget}-elf-gcc`,
           workspaceRoot.fsPath,
           modifiedEnv
         );
       } catch (error) {
         Logger.errorNotify(
-          "xtensa-esp32-elf-gdb is not found in idf.customExtraPaths",
+          "xtensa-esp32-elf-gcc is not found in idf.customExtraPaths",
           error
         );
         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -940,6 +940,26 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerIDFCommand("espIdf.getXtensaGdb", () => {
+    return PreCheck.perform([openFolderCheck], async () => {
+      const modifiedEnv = utils.appendIdfAndToolsToPath();
+      const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
+      try {
+        return await utils.isBinInPath(
+          `xtensa-${idfTarget}-elf-gdb`,
+          workspaceRoot.fsPath,
+          modifiedEnv
+        );
+      } catch (error) {
+        Logger.errorNotify(
+          "xtensa-esp32-elf-gdb is not found in idf.customExtraPaths",
+          error
+        );
+        return;
+      }
+    });
+  });
+
   registerIDFCommand("espIdf.getXtensaGcc", () => {
     return PreCheck.perform([openFolderCheck], async () => {
       const modifiedEnv = utils.appendIdfAndToolsToPath();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -952,7 +952,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
       } catch (error) {
         Logger.errorNotify(
-          "xtensa-esp32-elf-gdb is not found in idf.customExtraPaths",
+          "xtensa-TARGET-elf-gdb is not found in idf.customExtraPaths",
           error
         );
         return;
@@ -972,7 +972,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
       } catch (error) {
         Logger.errorNotify(
-          "xtensa-esp32-elf-gcc is not found in idf.customExtraPaths",
+          "xtensa-TARGET-elf-gcc is not found in idf.customExtraPaths",
           error
         );
         return;


### PR DESCRIPTION
Fix #323 

Was using gdb instead of gcc for settings.json default compiler path in ESP-IDF Examples webview. Also use IDF target from configuration settings.

Also add `${command:espIdf.getXtensaGdb}` description in README.

Please take a look @boarchuz 