### PR TITLE
dispose confserver command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,39 +74,40 @@ All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using
 
 Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to see possible actions.
 
-| Command Description                             | Keyboard Shortcuts (Mac)               | Keyboard Shortcuts (Windows/ Linux)       |
-| ----------------------------------------------- | -------------------------------------- | ----------------------------------------- |
-| Configure ESP-IDF extension                     |                                        |                                           |
-| Create ESP-IDF project                          | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
-| Add vscode configuration folder                 |                                        |                                           |
-| Add Arduino ESP32 as ESP-IDF Component          |                                        |                                           |
-| Configure Paths                                 |                                        |                                           |
-| Set Espressif device target                     |                                        |                                           |
-| Device configuration                            |                                        |                                           |
-| SDK Configuration editor                        |                                        |                                           |
-| Set default sdkconfig file in project           |                                        |                                           |
-| Select port to use                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>P</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>P</kbd> |
-| Full clean project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
-| Build your project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>B</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>B</kbd> |
-| Flash your project                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
-| Monitor your device                             | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>M</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>M</kbd> |
-| Build, Flash and start a monitor on your device | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
-| Open ESP-IDF Terminal                           | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>T</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>T</kbd> |
-| Pick a workspace folder                         |                                        |                                           |
-| Size analysis of the binaries                   | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>S</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>S</kbd> |
-| Show Examples Projects                          |                                        |                                           |
-| Add Editor coverage                             |                                        |                                           |
-| Remove Editor coverage                          |                                        |                                           |
-| Get HTML Coverage Report for project            |                                        |                                           |
-| Search in documentation...                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
-| Install ESP-ADF                                 |                                        |                                           |
-| Install ESP-MDF                                 |                                        |                                           |
-| Install ESP-IDF Python Packages                 |                                        |                                           |
-| Open NVS Partition Editor                       |                                        |                                           |
-| Select OpenOCD Board Configuration              |                                        |                                           |
-| Doctor command                                  |                                        |                                           |
-| Create new ESP-IDF Component                    |                                        |                                           |
-| Show ninja build summary                        |                                        |                                           |
+| Command Description                                     | Keyboard Shortcuts (Mac)               | Keyboard Shortcuts (Windows/ Linux)       |
+| ------------------------------------------------------- | -------------------------------------- | ----------------------------------------- |
+| Configure ESP-IDF extension                             |                                        |                                           |
+| Create ESP-IDF project                                  | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
+| Add vscode configuration folder                         |                                        |                                           |
+| Add Arduino ESP32 as ESP-IDF Component                  |                                        |                                           |
+| Configure Paths                                         |                                        |                                           |
+| Set Espressif device target                             |                                        |                                           |
+| Device configuration                                    |                                        |                                           |
+| SDK Configuration editor                                |                                        |                                           |
+| Set default sdkconfig file in project                   |                                        |                                           |
+| Select port to use                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>P</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>P</kbd> |
+| Full clean project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
+| Build your project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>B</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>B</kbd> |
+| Flash your project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
+| Monitor your device                                     | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>M</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>M</kbd> |
+| Build, Flash and start a monitor on your device         | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
+| Open ESP-IDF Terminal                                   | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>T</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>T</kbd> |
+| Pick a workspace folder                                 |                                        |                                           |
+| Size analysis of the binaries                           | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>S</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>S</kbd> |
+| Show Examples Projects                                  |                                        |                                           |
+| Add Editor coverage                                     |                                        |                                           |
+| Remove Editor coverage                                  |                                        |                                           |
+| Get HTML Coverage Report for project                    |                                        |                                           |
+| Search in documentation...                              | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
+| Install ESP-ADF                                         |                                        |                                           |
+| Install ESP-MDF                                         |                                        |                                           |
+| Install ESP-IDF Python Packages                         |                                        |                                           |
+| Open NVS Partition Editor                               |                                        |                                           |
+| Select OpenOCD Board Configuration                      |                                        |                                           |
+| Doctor command                                          |                                        |                                           |
+| Create new ESP-IDF Component                            |                                        |                                           |
+| Show ninja build summary                                |                                        |                                           |
+| Dispose current SDK Configuration editor server process |                                        |                                           |
 
 The **Add Arduino-ESP32 as ESP-IDF Component** command will add [Arduino-ESP32](https://github.com/espressif/arduino-esp32) as a ESP-IDF component in your current directory (`${CURRENT_DIRECTORY}/components/arduino`). You can also use the **Create ESP-IDF project** command with `arduino-as-component` template to create a new project directory that includes Arduino-esp32 as an ESP-IDF component.
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -37,6 +37,7 @@
   "espIdf.webview.nvsPartitionEditor.title": "ESP-IDF: Open NVS Partition Editor",
   "espIdf.selectOpenOcdConfigFiles.title": "ESP-IDF: Select OpenOCD Board Configuration",
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
+  "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -37,6 +37,7 @@
   "espIdf.webview.nvsPartitionEditor.title": "ESP-IDF: Abrir editor de particiones NVS",
   "espIdf.selectOpenOcdConfigFiles.title": "ESP-IDF: Selecciona configuración OpenOCD Board",
   "espIdf.ninja.summary.title": "ESP-IDF: Mostrar resumen de construccion con ninja",
+  "espIdf.disposeConfserverProcess.title": "ESP-IDF: Cerrar proceso de servidor de editor de Configuración SDK",
   "debug.initConfig.name": "Lanzar ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -37,6 +37,7 @@
   "espIdf.webview.nvsPartitionEditor.title": "ESP-IDF: Откройте редактор разделов NVS",
   "espIdf.selectOpenOcdConfigFiles.title": "ESP-IDF: Выберите конфигурацию платы OpenOCD",
   "espIdf.ninja.summary.title": "ESP-IDF: Показать сводку сборки ninja",
+  "espIdf.disposeConfserverProcess.title": "ESP-IDF: Удалить текущий процесс сервера редактора конфигурации SDK",
   "debug.initConfig.name": "ESP-IDF: Запустить",
   "debug.initConfig.description": "Новая конфигурация для запуска проектов ESP-IDF",
   "param.adapterTargetName": "Целевое устройство для адаптера отладки ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -37,6 +37,7 @@
   "espIdf.webview.nvsPartitionEditor.title": "ESP-IDF: 打开NVS分区编辑器",
   "espIdf.selectOpenOcdConfigFiles.title": "ESP-IDF: 选择OpenOCD板配置",
   "espIdf.ninja.summary.title": "ESP-IDF: 显示ninja构建摘要",
+  "espIdf.disposeConfserverProcess.title": "ESP-IDF: 释放当前SDK配置编辑器服务器进程",
   "debug.initConfig.name": "ESP-IDF：启动",
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF调试适配器的目标名称",

--- a/package.json
+++ b/package.json
@@ -806,6 +806,10 @@
       {
         "command": "espIdf.ninja.summary",
         "title": "%espIdf.ninja.summary.title%"
+      },
+      {
+        "command": "espIdf.disposeConfserverProcess",
+        "title": "%espIdf.disposeConfserverProcess.title%"
       }
     ],
     "breakpoints": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -37,6 +37,7 @@
   "espIdf.webview.nvsPartitionEditor.title": "ESP-IDF: Open NVS Partition Editor",
   "espIdf.selectOpenOcdConfigFiles.title": "ESP-IDF: Select OpenOCD Board Configuration",
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
+  "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1039,6 +1039,16 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerIDFCommand("espIdf.disposeConfserverProcess", () => {
+    try {
+      if (ConfserverProcess.exists()) {
+        ConfserverProcess.dispose();
+      }
+    } catch (error) {
+      Logger.errorNotify(error.message, error);
+    }
+  });
+
   registerIDFCommand("espIdf.setTarget", () => {
     PreCheck.perform([openFolderCheck], async () => {
       const enterDeviceTargetMsg = locDic.localize(


### PR DESCRIPTION
Add **Dispose current SDK Configuration editor server process** to dispose the confserver process with the SDK Configuration Editor, useful when Kconfig files change.

Fix #322