### PR TITLE
Configure project for Gcov command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Build your project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>B</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>B</kbd> |
 | Configure ESP-IDF extension                             |                                        |                                           |
 | Configure Paths                                         |                                        |                                           |
+| Configure project sdkconfig for coverage                |                                        |                                           |
 | Create project from extension template                  | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
 | Create new ESP-IDF Component                            |                                        |                                           |
 | Device configuration                                    |                                        |                                           |

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -12,6 +12,8 @@ This extension requires `gcovr` to generate JSON and HTML reports from generated
 
 Make sure you had properly configure the toolchain in `idf.customExtraPaths` or in your environment variable PATH since the gcov executable used is `{TOOLCHAIN_PREFIX}-gcov` (replacing TOOLCHAIN_PREFIX for your IDF_TARGET toolchain prefix) and `gcovr` exists in the same directory as your `${idf.pythonBinPath}` path.
 
+The **ESP-IDF: Configure project sdkconfig for coverage** command can set required values in your project sdkconfig to enable Code coverage.
+
 ## Editor Coverage
 
 For the text editor highlighting, the **ESP-IDF: Add Editor coverage** command execute a child process with `gcovr -r . --gcov-executable {TOOLCHAIN_PREFIX}-gcov --json`. You can remove the coverage highlight with **ESP-IDF; Remove Editor coverage**.

--- a/docs/tutorial/code_coverage.md
+++ b/docs/tutorial/code_coverage.md
@@ -24,7 +24,7 @@ Let's use the ESP-IDF [gcov example](https://github.com/espressif/esp-idf/tree/m
 
 4. First the user should select an Espressif target (esp32, esp32s2, etc.) with the **ESP-IDF: Set Espressif device target** command. Default is `esp32` and the one used in this tutorial.
 
-5. Next configure your project using menuconfig. Use the **ESP-IDF: SDK Configuration editor** command (<kbd>CTRL</kbd> <kbd>E</kbd> <kbd>G</kbd> keyboard shortcut ) where the user can modify the ESP-IDF project settings. After all changes are made, click save and close this window.
+5. Next configure your sdkconfig project with the **ESP-IDF: Configure project sdkconfig for coverage** command or by yourself using the **ESP-IDF: SDK Configuration editor** command (<kbd>CTRL</kbd> <kbd>E</kbd> <kbd>G</kbd> keyboard shortcut ) where the user can modify the ESP-IDF project settings. After all changes are made, click save and close this window.
 
 <p>
   <img src="../../media/tutorials/basic_use/gui_menuconfig.png" alt="GUI Menuconfig" height="500">

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -40,6 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
+  "espIdf.setGcovConfig.title": " ESP-IDF: Configure project for coverage",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -40,7 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
-  "espIdf.setGcovConfig.title": " ESP-IDF: Configure project for coverage",
+  "espIdf.setGcovConfig.title": "ESP-IDF: Configure project sdkconfig for coverage",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -40,6 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Mostrar resumen de construccion con ninja",
   "espIdf.eraseFlash.title": "ESP-IDF: Borrar memoria flash del dispositivo",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Cerrar proceso de servidor de editor de Configuración SDK",
+  "espIdf.setGcovConfig.title": " ESP-IDF: Configurar proyecto para cobertura de codigo fuente",
   "debug.initConfig.name": "Lanzar ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -40,7 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Mostrar resumen de construccion con ninja",
   "espIdf.eraseFlash.title": "ESP-IDF: Borrar memoria flash del dispositivo",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Cerrar proceso de servidor de editor de Configuración SDK",
-  "espIdf.setGcovConfig.title": " ESP-IDF: Configurar proyecto para cobertura de codigo fuente",
+  "espIdf.setGcovConfig.title": "ESP-IDF: Configurar sdkconfig del proyecto para cobertura de codigo fuente",
   "debug.initConfig.name": "Lanzar ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -40,7 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Показать сводку сборки ninja",
   "espIdf.eraseFlash.title": "ESP-IDF: Стереть флеш-память с устройства",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Удалить текущий процесс сервера редактора конфигурации SDK",
-  "espIdf.setGcovConfig.title": " ESP-IDF: Настроить проект для покрытия",
+  "espIdf.setGcovConfig.title": "ESP-IDF: Настроить проект sdkconfig для покрытия",
   "debug.initConfig.name": "ESP-IDF: Запустить",
   "debug.initConfig.description": "Новая конфигурация для запуска проектов ESP-IDF",
   "param.adapterTargetName": "Целевое устройство для адаптера отладки ESP-IDF",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -40,6 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Показать сводку сборки ninja",
   "espIdf.eraseFlash.title": "ESP-IDF: Стереть флеш-память с устройства",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Удалить текущий процесс сервера редактора конфигурации SDK",
+  "espIdf.setGcovConfig.title": " ESP-IDF: Настроить проект для покрытия",
   "debug.initConfig.name": "ESP-IDF: Запустить",
   "debug.initConfig.description": "Новая конфигурация для запуска проектов ESP-IDF",
   "param.adapterTargetName": "Целевое устройство для адаптера отладки ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -40,7 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: 显示ninja构建摘要",
   "espIdf.eraseFlash.title": "ESP-IDF: 从设备中擦除闪存",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: 释放当前SDK配置编辑器服务器进程",
-  "espIdf.setGcovConfig.title": " ESP-IDF: 为覆盖范围配置项目",
+  "espIdf.setGcovConfig.title": "ESP-IDF: 为覆盖范围配置项目sdkconfig",
   "debug.initConfig.name": "ESP-IDF：启动",
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF调试适配器的目标名称",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -40,6 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: 显示ninja构建摘要",
   "espIdf.eraseFlash.title": "ESP-IDF: 从设备中擦除闪存",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: 释放当前SDK配置编辑器服务器进程",
+  "espIdf.setGcovConfig.title": " ESP-IDF: 为覆盖范围配置项目",
   "debug.initConfig.name": "ESP-IDF：启动",
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF调试适配器的目标名称",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "onCommand:espIdf.createNewComponent",
     "onCommand:espIdf.ninja.summary",
     "onCommand:espIdf.newProject.start",
+    "onCommand:espIdf.setGcovConfig",
     "onView:idfAppTracer",
     "onView:idfAppTraceArchive",
     "onView:espRainmaker",
@@ -865,6 +866,10 @@
       {
         "command": "espIdf.eraseFlash",
         "title": "%espIdf.eraseFlash.title%"
+      },
+      {
+        "command": "espIdf.setGcovConfig",
+        "title": "%espIdf.setGcovConfig.title%"
       }
     ],
     "breakpoints": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -40,6 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
+  "espIdf.setGcovConfig.title": " ESP-IDF: Configure project for coverage",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/package.nls.json
+++ b/package.nls.json
@@ -40,7 +40,7 @@
   "espIdf.ninja.summary.title": "ESP-IDF: Show ninja build summary",
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
-  "espIdf.setGcovConfig.title": " ESP-IDF: Configure project for coverage",
+  "espIdf.setGcovConfig.title": "ESP-IDF: Configure project sdkconfig for coverage",
   "debug.initConfig.name": "ESP-IDF: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -122,6 +122,7 @@
     "espIdf.webview.nvsPartitionEditor.title",
     "espIdf.doctorCommand.title",
     "espIdf.ninja.summary.title",
+    "espIdf.setGcovConfig.title",
     "espIdf.eraseFlash.title",
     "debug.initConfig.name",
     "debug.initConfig.description",

--- a/src/coverage/configureProject.ts
+++ b/src/coverage/configureProject.ts
@@ -1,0 +1,108 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Thursday, 18th March 2021 9:41:56 pm
+ * Copyright 2021 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { extensionContext, getConfigValueFromSDKConfig } from "../utils";
+import { ConfserverProcess } from "../espIdf/menuconfig/confServerProcess";
+import {
+  window,
+  Uri,
+  ProgressLocation,
+  Progress,
+  CancellationToken,
+} from "vscode";
+import { MenuConfigPanel } from "../espIdf/menuconfig/MenuconfigPanel";
+
+export async function configureProjectWithGcov(workspacePath: Uri) {
+  const appTraceDestTrax = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_DEST_TRAX",
+    workspacePath.fsPath
+  );
+  const appTraceEnable = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_ENABLE",
+    workspacePath.fsPath
+  );
+  const appTraceLockEnable = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_LOCK_ENABLE",
+    workspacePath.fsPath
+  );
+  const onPanicHostFlushTmo = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_ONPANIC_HOST_FLUSH_TMO",
+    workspacePath.fsPath
+  );
+  const postmortemFlushThresh = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_POSTMORTEM_FLUSH_THRESH",
+    workspacePath.fsPath
+  );
+  const appTracePendingDataSizeMax = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_PENDING_DATA_SIZE_MAX",
+    workspacePath.fsPath
+  );
+  const appTraceGcovEnable = getConfigValueFromSDKConfig(
+    "CONFIG_APPTRACE_GCOV_ENABLE",
+    workspacePath.fsPath
+  );
+
+  const isGcovEnabled =
+    appTraceDestTrax === "y" &&
+    appTraceEnable === "y" &&
+    appTraceLockEnable === "y" &&
+    onPanicHostFlushTmo === "-1" &&
+    postmortemFlushThresh === "0" &&
+    appTracePendingDataSizeMax === "0" &&
+    appTraceGcovEnable === "y";
+
+  // if (isGcovEnabled) {
+  //   return;
+  // }
+
+  if (!ConfserverProcess.exists()) {
+    const response = await window.showInformationMessage(
+      "SDK Configuration Editor is not running. Start ?",
+      "Start",
+      "Cancel"
+    );
+    if (response !== "Start") {
+      return;
+    }
+    await window.withProgress(
+      {
+        cancellable: true,
+        location: ProgressLocation.Notification,
+        title: "ESP-IDF: Configuring coverage",
+      },
+      async (
+        progress: Progress<{ message: string; increment: number }>,
+        cancelToken: CancellationToken
+      ) => {
+        ConfserverProcess.registerProgress(progress);
+        cancelToken.onCancellationRequested(() => {
+          ConfserverProcess.dispose();
+        });
+        await ConfserverProcess.init(
+          workspacePath,
+          extensionContext.extensionPath
+        );
+      }
+    );
+  }
+  const destTraxRequest = `{"version": 2, "set": { "APPTRACE_DEST_TRAX": true }}\n`;
+  const gcovEnableRequest = `{"version": 2, "set": { "APPTRACE_GCOV_ENABLE": true }}\n`;
+  ConfserverProcess.sendUpdatedValue(destTraxRequest);
+  ConfserverProcess.sendUpdatedValue(gcovEnableRequest);
+  ConfserverProcess.saveGuiConfigValues();
+}

--- a/src/espIdf/documentation/getDocsVersion.ts
+++ b/src/espIdf/documentation/getDocsVersion.ts
@@ -59,7 +59,7 @@ export function getDocsBaseUrl(docVersion: string, idfTarget?: string) {
   }`;
 }
 
-function getDocsLocaleLang() {
+export function getDocsLocaleLang() {
   let localeLang: string = "en";
   try {
     const localeConf = JSON.parse(process.env.VSCODE_NLS_CONFIG);

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -122,6 +122,10 @@ export class ConfserverProcess {
         newValueRequest = `{"version": 2, "set": { "${updatedValue.id}": ${updatedValue.value} }}\n`;
         break;
     }
+    ConfserverProcess.sendUpdatedValue(newValueRequest);
+  }
+
+  public static sendUpdatedValue(newValueRequest: string) {
     ConfserverProcess.instance.confServerChannel.appendLine(newValueRequest);
     ConfserverProcess.instance.confServerProcess.stdin.write(newValueRequest);
     ConfserverProcess.instance.areValuesSaved = false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,6 +99,7 @@ import { uartFlashCommand } from "./flash/uartFlash";
 import { jtagFlashCommand } from "./flash/jtagCmd";
 import { createMonitorTerminal } from "./espIdf/monitor/command";
 import { KconfigLangClient } from "./kconfig";
+import { configureProjectWithGcov } from "./coverage/configureProject";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -1544,6 +1545,16 @@ export async function activate(context: vscode.ExtensionContext) {
             }
           }
         );
+      } catch (error) {
+        Logger.errorNotify(error.message, error);
+      }
+    });
+  });
+
+  registerIDFCommand("espIdf.setGcovConfig", async () => {
+    PreCheck.perform([openFolderCheck], async () => {
+      try {
+        await configureProjectWithGcov(workspaceRoot);
       } catch (error) {
         Logger.errorNotify(error.message, error);
       }


### PR DESCRIPTION
Add `ESP-IDF: Configure project for coverage` to add configuration in SDK Configuration Editor for Gcov code coverage.

TODO: Add coverage compile flags in CMakeLists.txt ? How to decide where and which files ?

```
set_source_files_properties(gcov_example_main.c
                            gcov_example_func.c
    PROPERTIES COMPILE_FLAGS
    --coverage)
```