### PR TITLE
check arduino component exists rm clone branches

### DIFF
--- a/src/espIdf/arduino/addArduinoComponent.ts
+++ b/src/espIdf/arduino/addArduinoComponent.ts
@@ -92,8 +92,7 @@ export class ArduinoComponentInstaller {
         ? majorMinorMatches[1]
         : "x.x";
     const results: { [key: string]: string } = {
-      "4.0": "idf-release/v4.0",
-      "4.2": "idf-release/v4.2",
+      "3.3": "idf-release/v3.3",
     };
     return results[espIdfVersion] || "master";
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -506,6 +506,15 @@ export async function activate(context: vscode.ExtensionContext) {
             const arduinoComponentManager = new ArduinoComponentInstaller(
               workspaceRoot.fsPath
             );
+            const arduinoDirPath = path.join(
+              workspaceRoot.fsPath,
+              "components",
+              "arduino"
+            );
+            const arduinoDirExists = utils.dirExistPromise(arduinoDirPath);
+            if (arduinoDirExists) {
+              return Logger.infoNotify(`${arduinoDirPath} already exists.`);
+            }
             cancelToken.onCancellationRequested(() => {
               arduinoComponentManager.cancel();
             });


### PR DESCRIPTION
Check `arduino` component folder exists before cloning Arduino-esp32 as IDF Component.

Also removed non existing branches that were used before.