### PR TITLE
Fix/release ci actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,6 @@ jobs:
       - name: Lint Check
         run: yarn lint
 
-      - name: Package .vsix
-        run: yarn package
-
-      - name: Upload .vsix File
-        uses: actions/upload-artifact@v1
-        with:
-          name: esp-idf-extension.vsix
-          path: esp-idf-extension.vsix
-
       - name: Package open .vsix
         run: yarn packageWithoutDependencies
 
@@ -53,6 +44,15 @@ jobs:
         with:
           name: esp-idf-extension-open.vsix
           path: esp-idf-extension-open.vsix
+
+      - name: Package .vsix
+        run: yarn package
+
+      - name: Upload .vsix File
+        uses: actions/upload-artifact@v1
+        with:
+          name: esp-idf-extension.vsix
+          path: esp-idf-extension.vsix
 
       - name: Extension Test
         uses: GabrielBB/xvfb-action@v1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Package open .vsix
+        run: yarn run packageWithoutDependencies
+
       - name: VSIX Package
         run: yarn run package
 
@@ -54,6 +57,17 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./esp-idf-extension.vsix
           asset_name: esp-idf-extension-${{ steps.version.outputs.version }}.vsix
+          asset_content_type: application/zip
+
+      - name: Upload no dependencies release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./esp-idf-extension-open.vsix
+          asset_name: esp-idf-extension-open-${{ steps.version.outputs.version }}.vsix
           asset_content_type: application/zip
 
       - name: Marketplace release

--- a/package.json
+++ b/package.json
@@ -1006,7 +1006,7 @@
     "watch": "webpack --watch --mode development",
     "test": "tsc -p ./ && node ./out/test/runTest.js --VERBOSE 2>&1 >> testing.results.log",
     "package": "vsce package --yarn -o esp-idf-extension.vsix",
-    "release": "vsce publish --yarn -p ${VS_MARKETPLACE_TOKEN}",
+    "release": "vsce publish --yarn -p ${VS_MARKETPLACE_TOKEN} --packagePath esp-idf-extension.vsix",
     "clean": "gulp clean",
     "validateLocalization": "gulp validateLocalization",
     "webpack": "webpack --mode production",

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -44,6 +44,21 @@ const defTargetList: IdfTarget[] = [
     name: "ESP32-S2",
     openOcdFiles: "interface/ftdi/esp32_devkitj_v1.cfg,target/esp32s2.cfg",
   } as IdfTarget,
+  {
+    id: "esp32s3",
+    name: "ESP32-S3",
+    openOcdFiles: "interface/ftdi/esp32_devkitj_v1.cfg,target/esp32s3.cfg",
+  } as IdfTarget,
+  {
+    id: "esp32c3",
+    name: "ESP32-C3 USB",
+    openOcdFiles: "board/esp32c3-builtin.cfg",
+  } as IdfTarget,
+  {
+    id: "esp32c3",
+    name: "ESP32-C3 PROG",
+    openOcdFiles: "board/esp32c3-ftdi.cfg",
+  } as IdfTarget,
 ];
 
 export async function getBoards() {
@@ -96,8 +111,18 @@ export async function getNewProjectArgs(
   progress.report({ increment: 10, message: "Loading ESP-IDF components..." });
   const components = [];
   progress.report({ increment: 10, message: "Loading serial ports..." });
-  const serialPortListDetails = await SerialPort.shared().getListArray();
-  const serialPortList = serialPortListDetails.map((p) => p.comName);
+  let serialPortList: Array<string>;
+  try {
+    const serialPortListDetails = await SerialPort.shared().getListArray();
+    serialPortList = serialPortListDetails.map((p) => p.comName);
+  } catch (error) {
+    const msg = error.message
+      ? error.message
+      : "Error looking for serial ports.";
+    Logger.infoNotify(msg);
+    Logger.error(msg, error);
+    serialPortList = ["no port"];
+  }
   progress.report({ increment: 10, message: "Loading ESP-IDF Boards list..." });
   const espBoards = await getBoards();
   progress.report({ increment: 10, message: "Loading ESP-IDF Target list..." });

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import marked from "marked";
 import * as path from "path";
 import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
@@ -272,18 +271,32 @@ export class NewProjectPanel {
           const toolsDir = idfConf.readParameter("idf.toolsPath");
           const pyPath = idfConf.readParameter("idf.pythonBinPath");
           const isWin = process.platform === "win32" ? "Win" : "";
-          const modifiedEnv = utils.appendIdfAndToolsToPath();
-          const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
-          settingsJson["idf.adapterTargetName"] = idfTarget;
-          settingsJson["idf.customExtraPaths"] = extraPaths;
-          settingsJson["idf.customExtraVars"] = extraVars;
-          settingsJson["idf.espIdfPath" + isWin] = idfPathDir;
-          settingsJson["idf.espAdfPath" + isWin] = adfPathDir;
-          settingsJson["idf.espMdfPath" + isWin] = mdfPathDir;
+          settingsJson["idf.adapterTargetName"] = idfTarget || "esp32";
+          if (extraPaths) {
+            settingsJson["idf.customExtraPaths"] = extraPaths;
+          }
+          if (extraVars) {
+            settingsJson["idf.customExtraVars"] = extraVars;
+          }
+          if (idfPathDir) {
+            settingsJson["idf.espIdfPath" + isWin] = idfPathDir;
+          }
+          if (adfPathDir) {
+            settingsJson["idf.espAdfPath" + isWin] = adfPathDir;
+          }
+          if (mdfPathDir) {
+            settingsJson["idf.espMdfPath" + isWin] = mdfPathDir;
+          }
           settingsJson["idf.openOcdConfigs"] = openOcdConfigs;
-          settingsJson["idf.port" + isWin] = port;
-          settingsJson["idf.pythonBinPath" + isWin] = pyPath;
-          settingsJson["idf.toolsPath" + isWin] = toolsDir;
+          if (port.indexOf("no port") === -1) {
+            settingsJson["idf.port" + isWin] = port;
+          }
+          if (pyPath) {
+            settingsJson["idf.pythonBinPath" + isWin] = pyPath;
+          }
+          if (toolsDir) {
+            settingsJson["idf.toolsPath" + isWin] = toolsDir;
+          }
           await writeJSON(settingsJsonPath, settingsJson, {
             spaces:
               vscode.workspace.getConfiguration().get("editor.tabSize") || 2,

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -29,10 +29,10 @@ export async function writeTextReport(
   const lineBreak = `--------------------------------------------------------------------------------------------------------------------------------------------${EOL}`;
   output += `OS ${reportedResult.systemInfo.platform} ${reportedResult.systemInfo.architecture} ${reportedResult.systemInfo.systemName} ${EOL}`;
   output += `System environment variable PATH ${EOL} ${reportedResult.systemInfo.envPath} ${EOL}`;
-  output += `Visual Studio Code version ${reportedResult.systemInfo.extensionVersion} ${EOL}`;
+  output += `Visual Studio Code version ${reportedResult.systemInfo.vscodeVersion} ${EOL}`;
   output += `Visual Studio Code language ${reportedResult.systemInfo.language} ${EOL}`;
   output += `Visual Studio Code shell ${reportedResult.systemInfo.shell} ${EOL}`;
-  output += `ESP-IDF Extension version ${reportedResult.systemInfo.vscodeVersion} ${EOL}`;
+  output += `ESP-IDF Extension version ${reportedResult.systemInfo.extensionVersion} ${EOL}`;
   output += `---------------------------------------------------- Extension configuration settings ------------------------------------------------------${EOL}`;
   output += `ESP-IDF Path (idf.espIdfPath) ${reportedResult.configurationSettings.espIdfPath}${EOL}`;
   output += `Custom extra paths (idf.customExtraPaths) ${reportedResult.configurationSettings.customExtraPaths}${EOL}`;

--- a/src/views/new-project/store/index.ts
+++ b/src/views/new-project/store/index.ts
@@ -163,7 +163,7 @@ export const actions: ActionTree<IState, any> = {
       openOcdConfigFiles: context.state.openOcdConfigFiles,
       port: context.state.selectedPort,
       projectName: context.state.projectName,
-      target: context.state.target,
+      target: context.state.target.id,
       template: context.state.selectedTemplate,
     });
   },


### PR DESCRIPTION
Fix #375  to allow New Project Wizard when no serial ports are found. Add esp32s3 and esp32c3 in default targets.

Package VSIX without dependencies before regular VSIX package and specify VSIX for marketplace release.