### PR TITLE
send exit sequence instead of kill timeout

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -80,7 +80,6 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.useIDFKconfigStyle`          | Enable style validation for Kconfig files                         |
 | `idf.saveScope`                   | Where to save extension settings                                  |
 | `idf.launchMonitorOnDebugSession` | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
-| `idf.killMonitorTimeout`          | Timeout (milliseconds) for ESP-IDF monitor process kill           |
 
 The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md).
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -78,7 +78,6 @@
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
-  "param.killMonitorTimeout.title": "Timeout (milliseconds) for ESP-IDF monitor process kill",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -64,7 +64,6 @@
   "param.uncoveredLightTheme": "Color de fondo para lineas no cubiertas en temas claros por ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Color de fondo para lineas no cubiertas en temas oscuros por ESP-IDF Coverage.",
   "param.launchMonitorOnDebugSession.title": "Iniciar IDF Monitor junto a la sesión ESP-IDF Debug Adapter",
-  "param.killMonitorTimeout.title": "Timeout (milliseconds) for ESP-IDF monitor process kill",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -64,7 +64,6 @@
   "param.uncoveredLightTheme": "Цвет фона для непокрытых линий в светлой теме для покрытия кода ESP-IDF.",
   "param.uncoveredDarkTheme": "Цвет фона для непокрытых линий в темной теме для покрытия кода ESP-IDF.",
   "param.launchMonitorOnDebugSession.title": "Запустите IDF Monitor вместе с сеансом ESP-IDF Debug Adapter.",
-  "param.killMonitorTimeout.title": "Тайм-аут (миллисекунды) для завершения процесса монитора ESP-IDF",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -64,7 +64,6 @@
   "param.uncoveredLightTheme": "ESP-IDF覆盖的光主题中未覆盖线条的背景色",
   "param.uncoveredDarkTheme": "ESP-IDF覆盖的深色主题中未覆盖线条的背景色",
   "param.launchMonitorOnDebugSession.title": "启动IDF监视器和ESP-IDF调试适配器会话",
-  "param.killMonitorTimeout.title": "ESP-IDF监视器进程终止超时（毫秒)",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -616,13 +616,7 @@
             "type": "boolean",
             "description": "%param.launchMonitorOnDebugSession.title%",
             "scope": "resource",
-            "default": true
-          },
-          "idf.killMonitorTimeout": {
-            "type": "number",
-            "description": "%param.killMonitorTimeout.title%",
-            "scope": "resource",
-            "default": 1000
+            "default": false
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -78,7 +78,6 @@
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
-  "param.killMonitorTimeout.title": "Timeout (milliseconds) for ESP-IDF monitor process kill",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -132,7 +132,6 @@
     "param.partialDarkTheme",
     "param.uncoveredLightTheme",
     "param.uncoveredDarkTheme",
-    "param.killMonitorTimeout.title",
     "view.components.name",
     "configuration.title",
     "espIdf.apptrace.archive.refresh.title",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ import { IEspIdfDocVersion } from "./espIdf/documentation/getDocsVersion";
 import { RainmakerStore } from "./rainmaker/store";
 
 export namespace ESP {
+  export const CTRL_RBRACKET = "\u001D";
   export const extensionID = "espressif.esp-idf-extension";
   export const HTTP_USER_AGENT =
     "vscode.extensions.espressif.esp-idf.extension/1.0.0 axios-client";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2487,9 +2487,7 @@ const flash = () => {
     }
 
     if (monitorTerminal) {
-      const CTRL_RBRACKET = "\u001D";
-      monitorTerminal.sendText(CTRL_RBRACKET);
-      monitorTerminal.dispose();
+      monitorTerminal.sendText(ESP.CTRL_RBRACKET);
     }
 
     const idfPathDir = idfConf.readParameter("idf.espIdfPath");
@@ -2617,9 +2615,7 @@ const buildFlashAndMonitor = (runMonitor: boolean = true) => {
       return;
     }
     if (monitorTerminal) {
-      const CTRL_RBRACKET = "\u001D";
-      monitorTerminal.sendText(CTRL_RBRACKET);
-      monitorTerminal.dispose();
+      monitorTerminal.sendText(ESP.CTRL_RBRACKET);
     }
     const buildTask = new BuildTask(workspaceRoot.fsPath);
     const buildPath = path.join(workspaceRoot.fsPath, "build");
@@ -2864,21 +2860,19 @@ function createIdfTerminal() {
 export function deactivate() {
   Telemetry.dispose();
   if (monitorTerminal) {
-    const CTRL_RBRACKET = "\u001D";
-    monitorTerminal.sendText(CTRL_RBRACKET);
     monitorTerminal.dispose();
   }
   OutputChannel.end();
-
-  if (!kconfigLangClient) {
-    return undefined;
-  }
-  kconfigLangClient.stop();
   ConfserverProcess.dispose();
   for (const statusItem of statusBarItems) {
     statusItem.dispose();
   }
-  covRenderer.dispose();
+  if (covRenderer) {
+    covRenderer.dispose();
+  }
+  if (kconfigLangClient) {
+    kconfigLangClient.stop();
+  }
 }
 
 class IdfDebugConfigurationProvider

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2487,10 +2487,9 @@ const flash = () => {
     }
 
     if (monitorTerminal) {
+      const CTRL_RBRACKET = "\u001D";
+      monitorTerminal.sendText(CTRL_RBRACKET);
       monitorTerminal.dispose();
-      const killTimeout = idfConf.readParameter("idf.killMonitorTimeout");
-      await utils.sleep(killTimeout);
-      Logger.warnNotify("ESP-IDF Monitor was open. Closing it.");
     }
 
     const idfPathDir = idfConf.readParameter("idf.espIdfPath");
@@ -2618,10 +2617,9 @@ const buildFlashAndMonitor = (runMonitor: boolean = true) => {
       return;
     }
     if (monitorTerminal) {
+      const CTRL_RBRACKET = "\u001D";
+      monitorTerminal.sendText(CTRL_RBRACKET);
       monitorTerminal.dispose();
-      const killTimeout = idfConf.readParameter("idf.killMonitorTimeout");
-      await utils.sleep(killTimeout);
-      Logger.warnNotify("ESP-IDF Monitor was open. Closing it.");
     }
     const buildTask = new BuildTask(workspaceRoot.fsPath);
     const buildPath = path.join(workspaceRoot.fsPath, "build");
@@ -2866,6 +2864,8 @@ function createIdfTerminal() {
 export function deactivate() {
   Telemetry.dispose();
   if (monitorTerminal) {
+    const CTRL_RBRACKET = "\u001D";
+    monitorTerminal.sendText(CTRL_RBRACKET);
     monitorTerminal.dispose();
   }
   OutputChannel.end();


### PR DESCRIPTION
Instead of timeout to kill the monitor, use the `CTRL + ]` control sequence to exit IDF Monitor.