### PR TITLE
Fix/device conf target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@
 
 All notable changes to the "Espressif IDF" extension will be documented in this file.
 
+## [1.0.3](https://github.com/espressif/vscode-esp-idf-extension/releases/tag/v1.0.3)
+
+### Features and enhancements
+
+- [Separate Python Pip errors in extension setup](https://github.com/espressif/vscode-esp-idf-extension/pull/377)
+- [Add Component manager flag for build task](https://github.com/espressif/vscode-esp-idf-extension/pull/374)
+- [Package vsix without extension dependencies](https://github.com/espressif/vscode-esp-idf-extension/pull/372)
+- [Customize compiler and build tasks arguments, use esptool_extra_args and encrypted flags from build/flasher_args.json](https://github.com/espressif/vscode-esp-idf-extension/pull/363)
+
+### Bug Fixes
+
+- [Send Ctrl + \] signal to exit idf monitor on flash tasks](https://github.com/espressif/vscode-esp-idf-extension/pull/382)
+- [Fix New project wizard require serial ports, add esp32s3 esp32c3, release vsix without extension dependencies](https://github.com/espressif/vscode-esp-idf-extension/pull/378)
+- [Check arduino component directory exists, remove old arduino-esp32 cloning branches](hhttps://github.com/espressif/vscode-esp-idf-extension/pull/370)
+- [Remove IDF Tools exact match on extension activation](https://github.com/espressif/vscode-esp-idf-extension/pull/359)
+
 ## [1.0.2](https://github.com/espressif/vscode-esp-idf-extension/releases/tag/v1.0.2)
 
 ### Features and enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the "Espressif IDF" extension will be documented in this 
 - [Fix New project wizard require serial ports, add esp32s3 esp32c3, release vsix without extension dependencies](https://github.com/espressif/vscode-esp-idf-extension/pull/378)
 - [Check arduino component directory exists, remove old arduino-esp32 cloning branches](hhttps://github.com/espressif/vscode-esp-idf-extension/pull/370)
 - [Remove IDF Tools exact match on extension activation](https://github.com/espressif/vscode-esp-idf-extension/pull/359)
+- [Fix device configuration target setting](https://github.com/espressif/vscode-esp-idf-extension/pull/384)
 
 ## [1.0.2](https://github.com/espressif/vscode-esp-idf-extension/releases/tag/v1.0.2)
 

--- a/i18n/en/out/extension.i18n.json
+++ b/i18n/en/out/extension.i18n.json
@@ -16,7 +16,7 @@
   "extension.enterIdfPathMessage": "Enter IDF_PATH Path",
   "extension.enterIdfToolsPathMessage": "Enter IDF_TOOLS_PATH path",
   "extension.enterDevicePortMessage": "Enter device port Path",
-  "extension.enterDeviceTargetMessage": "Enter Espressif device to use",
+  "extension.enterDeviceTargetMessage": "Enter target name (IDF_TARGET)",
   "extension.enterFlashBaudRateMessage": "Enter flash baud rate",
   "extension.enterOpenOcdConfigMessage": "Enter list of configuration files inside OpenOCD Scripts directory",
   "extension.enterCustomPathsMessage": "Enter extra paths to append to PATH",

--- a/i18n/es/out/extension.i18n.json
+++ b/i18n/es/out/extension.i18n.json
@@ -18,7 +18,7 @@
   "extension.enterDevicePortMessage": "Introduzca la ruta del puerto serial ESP-IDF",
   "extension.enterFlashBaudRateMessage": "Introduzca la tasa de baudios flash ",
   "extension.cmdNotWebIDE": "El comando seleccionado no esta disponible en WebIDE",
-  "extension.enterDeviceTargetMessage": "Introduzca dispositivo Espressif a utilizar",
+  "extension.enterDeviceTargetMessage": "Introduzca nombre del dispositivo (IDF_TARGET)",
   "extension.enterOpenOcdConfigMessage": "Introduzca la lista de archivos de configuracion dentro del directorio OpenOCD Scripts",
   "extension.enterCustomPathsMessage": "Introduzca rutas adicionales para expandir PATH"
 }

--- a/i18n/ru/out/extension.i18n.json
+++ b/i18n/ru/out/extension.i18n.json
@@ -16,7 +16,7 @@
   "extension.enterIdfPathMessage": "Введите путь IDF_PATH",
   "extension.enterIdfToolsPathMessage": "Введите путь IDF_TOOLS_PATH",
   "extension.enterDevicePortMessage": "Введите путь к порту устройства",
-  "extension.enterDeviceTargetMessage": "Выберите целевое устройство Espressif",
+  "extension.enterDeviceTargetMessage": "Введите имя цели (IDF_TARGET)",
   "extension.enterFlashBaudRateMessage": "Введите скорость загрузки прошивки",
   "extension.enterOpenOcdConfigMessage": "Введите список файлов конфигурации внутри каталога OpenOCD Scripts",
   "extension.enterCustomPathsMessage": "Введите дополнительные пути для добавления в PATH",

--- a/i18n/zh-CN/out/extension.i18n.json
+++ b/i18n/zh-CN/out/extension.i18n.json
@@ -16,7 +16,7 @@
   "extension.enterIdfPathMessage": "请输入 IDF_PATH 路径",
   "extension.enterIdfToolsPathMessage": "请输入 IDF_TOOLS_PATH 路径",
   "extension.enterDevicePortMessage": "请输入设备端口路径",
-  "extension.enterDeviceTargetMessage": "输入要使用的 Espressif 设备",
+  "extension.enterDeviceTargetMessage": "输入目标名称（IDF_TARGET)",
   "extension.enterFlashBaudRateMessage": "输入闪存波特率",
   "extension.cmdNotWebIDE": "所选命令在WebIDE中不可用",
   "extension.enterOpenOcdConfigMessage": "在OpenOCD脚本目录中输入配置文件列表",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -725,17 +725,17 @@ export async function activate(context: vscode.ExtensionContext) {
       const option = await vscode.window.showQuickPick(
         [
           {
-            description: "Device target (esp32, esp32s2)",
+            description: "Target (IDF_TARGET)",
             label: "Device Target",
             target: "deviceTarget",
           },
           {
-            description: "Device port path",
+            description: "Serial port",
             label: "Device Port",
             target: "devicePort",
           },
           {
-            description: "Flash baud rate of device",
+            description: "Flash baud rate",
             label: "Flash Baud Rate",
             target: "flashBaudRate",
           },
@@ -761,12 +761,7 @@ export async function activate(context: vscode.ExtensionContext) {
       let paramName: string;
       switch (option.target) {
         case "deviceTarget":
-          msg = locDic.localize(
-            "extension.enterDeviceTargetMessage",
-            "Enter device target name"
-          );
-          paramName = "idf.adapterTargetName";
-          break;
+          return vscode.commands.executeCommand("espIdf.setTarget");
         case "devicePort":
           msg = locDic.localize(
             "extension.enterDevicePortMessage",
@@ -1158,7 +1153,7 @@ export async function activate(context: vscode.ExtensionContext) {
     PreCheck.perform([openFolderCheck], async () => {
       const enterDeviceTargetMsg = locDic.localize(
         "extension.enterDeviceTargetMessage",
-        "Enter device target name"
+        "Enter target name (IDF_TARGET)"
       );
       const selectedTarget = await vscode.window.showQuickPick(
         [
@@ -1191,7 +1186,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const configurationTarget = idfConf.readParameter("idf.saveScope");
       if (selectedTarget.target === "custom") {
         const customIdfTarget = await vscode.window.showInputBox({
-          placeHolder: "Enter custom target name (IDF_TARGET)",
+          placeHolder: enterDeviceTargetMsg,
           value: "",
         });
         if (!customIdfTarget) {


### PR DESCRIPTION
Redirect from `ESP-IDF: Device Configuration` to `ESP-IDF: Set Espressif target` when configuring device target.

Add 1.0.3 changelog