### PR TITLE
enable component manager as configuration setting

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -8,16 +8,17 @@ This extension contributes the following settings that can be later updated in s
 
 These are the configuration settings that ESP-IDF extension contributes to your Visual Studio Code editor settings.
 
-| Setting ID             | Description                                                                   |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| `idf.customExtraPaths` | Paths to be appended to \$PATH                                                |
-| `idf.customExtraVars`  | Variables to be added to system environment variables                         |
-| `idf.espIdfPath`       | Path to locate ESP-IDF framework (IDF_PATH)                                   |
-| `idf.espIdfPathWin`    | Path to locate ESP-IDF framework in Windows (IDF_PATH)                        |
-| `idf.pythonBinPath`    | Python absolute binary path used to execute ESP-IDF Python Scripts            |
-| `idf.pythonBinPathWin` | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows |
-| `idf.toolsPath`        | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                 |
-| `idf.toolsPathWin`     | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                      |
+| Setting ID                      | Description                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                |
+| `idf.customExtraVars`           | Variables to be added to system environment variables                         |
+| `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                   |
+| `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                        |
+| `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts            |
+| `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows |
+| `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                 |
+| `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                      |
+| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                 |
 
 This is how the extension uses them:
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -78,6 +78,7 @@
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
+  "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -64,6 +64,7 @@
   "param.uncoveredLightTheme": "Color de fondo para lineas no cubiertas en temas claros por ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Color de fondo para lineas no cubiertas en temas oscuros por ESP-IDF Coverage.",
   "param.launchMonitorOnDebugSession.title": "Iniciar IDF Monitor junto a la sesión ESP-IDF Debug Adapter",
+  "param.enableIdfComponentManager.title": "Habilitar IDF Component Manager en construccion de proyecto",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -64,6 +64,7 @@
   "param.uncoveredLightTheme": "Цвет фона для непокрытых линий в светлой теме для покрытия кода ESP-IDF.",
   "param.uncoveredDarkTheme": "Цвет фона для непокрытых линий в темной теме для покрытия кода ESP-IDF.",
   "param.launchMonitorOnDebugSession.title": "Запустите IDF Monitor вместе с сеансом ESP-IDF Debug Adapter.",
+  "param.enableIdfComponentManager.title": "Включить диспетчер компонентов IDF в задаче сборки",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -64,6 +64,7 @@
   "param.uncoveredLightTheme": "ESP-IDF覆盖的光主题中未覆盖线条的背景色",
   "param.uncoveredDarkTheme": "ESP-IDF覆盖的深色主题中未覆盖线条的背景色",
   "param.launchMonitorOnDebugSession.title": "启动IDF监视器和ESP-IDF调试适配器会话",
+  "param.enableIdfComponentManager.title": "在生成任务中启用IDF组件管理器",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -617,6 +617,11 @@
             "description": "%param.launchMonitorOnDebugSession.title%",
             "scope": "resource",
             "default": false
+          },
+          "idf.enableIdfComponentManager": {
+            "type": "boolean",
+            "description": "%param.enableIdfComponentManager.title%",
+            "default": false
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -78,6 +78,7 @@
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
+  "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -776,7 +776,13 @@ export function appendIdfAndToolsToPath() {
   }
   modifiedEnv.IDF_TARGET = idfTarget || process.env.IDF_TARGET;
 
-  modifiedEnv.IDF_COMPONENT_MANAGER = "1";
+  let enableComponentManager = idfConf.readParameter(
+    "idf.enableIdfComponentManager"
+  ) as boolean;
+
+  if (enableComponentManager) {
+    modifiedEnv.IDF_COMPONENT_MANAGER = "1";
+  }
 
   return modifiedEnv;
 }


### PR DESCRIPTION
Remove IDF_COMPONENT_MANAGER from build task by default and enable only with boolean configuration setting.

Fix #387 

Fix #388 