### PR TITLE
add recursive categorization of examples

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -61,7 +61,6 @@ export class SerialPort {
       if (kernelMatch && kernelMatch.length) {
         isWsl2Kernel = compareVersion(kernelMatch[1], "4.19");
       }
-      console.log(isWsl2Kernel);
       let portList: SerialPortDetails[];
       if (
         process.platform === "linux" &&

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -30,7 +30,7 @@ export interface INewProjectArgs {
   components: IComponent[];
   serialPortList: string[];
   targetList: IdfTarget[];
-  templates: IExampleCategory;
+  templates: { [key: string]: IExampleCategory };
 }
 
 const defTargetList: IdfTarget[] = [
@@ -131,22 +131,22 @@ export async function getNewProjectArgs(
   const espIdfPath = idfConf.readParameter("idf.espIdfPath") as string;
   const espAdfPath = idfConf.readParameter("idf.espAdfPath") as string;
   const espMdfPath = idfConf.readParameter("idf.espMdfPath") as string;
-  let templates: IExampleCategory;
+  let templates: { [key:string]: IExampleCategory} = {};
   const idfExists = await dirExistPromise(espIdfPath);
   if (idfExists) {
     const idfTemplates = getExamplesList(espIdfPath);
-    templates = idfTemplates;
+    templates["ESP-IDF"] = idfTemplates;
   }
   const adfExists = await dirExistPromise(espAdfPath);
-  // if (adfExists) {
-  //   const adfTemplates = getExamplesList(espAdfPath);
-  //   templates = templates.concat(adfTemplates);// templates, adfTemplates;
-  // }
+  if (adfExists) {
+    const adfTemplates = getExamplesList(espAdfPath);
+    templates["ESP-ADF"] = adfTemplates;
+  }
   const mdfExists = await dirExistPromise(espMdfPath);
-  // if (mdfExists) {
-  //   const mdfTemplates = getExamplesList(espMdfPath);
-  //   templates = templates.concat(mdfTemplates);
-  // }
+  if (mdfExists) {
+    const mdfTemplates = getExamplesList(espMdfPath);
+    templates["ESP-MDF"] = mdfTemplates;
+  }
   progress.report({ increment: 50, message: "Initializing wizard..." });
   return {
     boards: espBoards,

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 import { join } from "path";
 import { Progress } from "vscode";
-import { getExamplesList, IExample } from "../examples/Example";
+import { getExamplesList, IExampleCategory } from "../examples/Example";
 import { IComponent } from "../espIdf/idfComponent/IdfComponent";
 import * as idfConf from "../idfConfiguration";
 import { IdfBoard, IdfTarget } from "../views/new-project/store";
@@ -30,7 +30,7 @@ export interface INewProjectArgs {
   components: IComponent[];
   serialPortList: string[];
   targetList: IdfTarget[];
-  templates: IExample[];
+  templates: IExampleCategory;
 }
 
 const defTargetList: IdfTarget[] = [
@@ -131,22 +131,22 @@ export async function getNewProjectArgs(
   const espIdfPath = idfConf.readParameter("idf.espIdfPath") as string;
   const espAdfPath = idfConf.readParameter("idf.espAdfPath") as string;
   const espMdfPath = idfConf.readParameter("idf.espMdfPath") as string;
-  let templates = [];
+  let templates: IExampleCategory;
   const idfExists = await dirExistPromise(espIdfPath);
   if (idfExists) {
     const idfTemplates = getExamplesList(espIdfPath);
-    templates = templates.concat(idfTemplates);
+    templates = idfTemplates;
   }
   const adfExists = await dirExistPromise(espAdfPath);
-  if (adfExists) {
-    const adfTemplates = getExamplesList(espAdfPath);
-    templates = templates.concat(adfTemplates);
-  }
+  // if (adfExists) {
+  //   const adfTemplates = getExamplesList(espAdfPath);
+  //   templates = templates.concat(adfTemplates);// templates, adfTemplates;
+  // }
   const mdfExists = await dirExistPromise(espMdfPath);
-  if (mdfExists) {
-    const mdfTemplates = getExamplesList(espMdfPath);
-    templates = templates.concat(mdfTemplates);
-  }
+  // if (mdfExists) {
+  //   const mdfTemplates = getExamplesList(espMdfPath);
+  //   templates = templates.concat(mdfTemplates);
+  // }
   progress.report({ increment: 50, message: "Initializing wizard..." });
   return {
     boards: espBoards,

--- a/src/views/examples/Examples.vue
+++ b/src/views/examples/Examples.vue
@@ -2,20 +2,11 @@
   <div id="examples-window">
     <div id="sidenav" class="content">
       <ul>
-        <li v-for="category in templateCategories" :key="category">
-          <p class="category subtitle" v-text="category" />
-          <ul class="examples">
-            <li v-for="item in groups[category]" :key="item.path">
-              <p
-                @click="toggleExampleDetail(item)"
-                v-text="item.name"
-                :class="{
-                  selectedItem: storeSelectedExample.path === item.path,
-                }"
-              />
-            </li>
-          </ul>
-        </li>
+        <ExampleList
+          v-for="cat of exampleRootPath.subcategories"
+          :node="cat"
+          :key="cat.name"
+        />
       </ul>
     </div>
 
@@ -42,61 +33,30 @@
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import { Action, Mutation, State } from "vuex-class";
-import { IExample } from "./store";
+import { IExample } from "../../examples/Example";
+import ExampleList from "./components/exampleList.vue";
 
-@Component
+@Component({
+  components: {
+    ExampleList,
+  },
+})
 export default class Examples extends Vue {
-  @State("examplesPaths") private storeExamplesPath;
-  @State("selectedExample") private storeSelectedExample;
-  @State("hasExampleDetail") private hasExampleDetail;
+  @State("exampleRootPath") private storeExampleRootPath;
   @State("exampleDetail") private storeExampleDetail;
+  @State("hasExampleDetail") private hasExampleDetail;
+  @State("selectedExample") private storeSelectedExample;
   @Action("openExample") private storeOpenExample;
   @Action private getExamplesList;
-  @Action private getExampleDetail;
-  @Mutation private showExampleDetail;
-  @Mutation private setSelectedExample;
-  @Mutation private setExampleDetail;
 
   get selectedExample() {
     return this.storeSelectedExample;
   }
-  get examplesPaths() {
-    return this.storeExamplesPath;
+  get exampleRootPath() {
+    return this.storeExampleRootPath;
   }
   get exampleDetail() {
     return this.storeExampleDetail;
-  }
-  get groups() {
-    return this.groupBy(this.storeExamplesPath, "category");
-  }
-  get templateCategories() {
-    const uniqueCategories = [
-      ...new Set(this.storeExamplesPath.map((t) => t.category)),
-    ];
-    const getStarted = uniqueCategories.indexOf("get-started");
-    uniqueCategories.splice(0, 0, uniqueCategories.splice(getStarted, 1)[0]);
-    return uniqueCategories;
-  }
-
-  public toggleExampleDetail(example: IExample) {
-    if (example.path !== this.storeSelectedExample.path) {
-      this.setSelectedExample(example);
-      this.setExampleDetail("No README.md available for this project.");
-      this.getExampleDetail({ pathToOpen: example.path });
-    } else {
-      this.showExampleDetail();
-    }
-  }
-
-  public groupBy(array: string[], key: string) {
-    const result = {};
-    array.forEach((item) => {
-      if (!result[item[key]]) {
-        result[item[key]] = [];
-      }
-      result[item[key]].push(item);
-    });
-    return result;
   }
 
   public openExample(selectedExample: IExample) {

--- a/src/views/examples/components/exampleList.vue
+++ b/src/views/examples/components/exampleList.vue
@@ -1,0 +1,53 @@
+<template>
+  <li>
+    <h3 class="category is-3" v-text="node.name"></h3>
+    <ul class="subcategories">
+      <ExampleList
+        v-for="nodeSubCat in node.subcategories"
+        :key="nodeSubCat.name"
+        :node="nodeSubCat"
+      />
+    </ul>
+    <ul class="examples" v-if="node.examples && node.examples.length">
+      <li v-for="item in node.examples" :key="item.path">
+        <p
+          @click="toggleExampleDetail(item)"
+          v-text="item.name"
+          :class="{
+            selectedItem: storeSelectedExample.path === item.path,
+          }"
+        />
+      </li>
+    </ul>
+  </li>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { IExampleCategory, IExample } from "../../../examples/Example";
+import { Action, Mutation, State } from "vuex-class";
+
+@Component
+export default class ExampleList extends Vue {
+  @Action private getExampleDetail;
+  @Mutation private showExampleDetail;
+  @Mutation private setSelectedExample;
+  @Mutation private setExampleDetail;
+  @State("selectedExample") private storeSelectedExample: IExample;
+  @Prop() node: IExampleCategory;
+
+  get selectedExample(): IExample {
+    return this.storeSelectedExample;
+  }
+
+  public toggleExampleDetail(example: IExample) {
+    if (example.path !== this.selectedExample.path) {
+      this.setSelectedExample(example);
+      this.setExampleDetail("No README.md available for this project.");
+      this.getExampleDetail({ pathToOpen: example.path });
+    } else {
+      this.showExampleDetail();
+    }
+  }
+}
+</script>

--- a/src/views/examples/store/index.ts
+++ b/src/views/examples/store/index.ts
@@ -54,7 +54,6 @@ export const mutations: MutationTree<IState> = {
     Object.assign(state, newState);
   },
   setSelectedExample(state, selectedExample: IExample) {
-    console.log(selectedExample);
     const newState = state;
     newState.selectedExample = selectedExample;
     Object.assign(state, newState);

--- a/src/views/examples/store/index.ts
+++ b/src/views/examples/store/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Vue from "vue";
+import { IExampleCategory, IExample } from "../../../examples/Example";
 import Vuex, { ActionTree, MutationTree, StoreOptions } from "vuex";
 
 Vue.use(Vuex);
@@ -26,22 +27,16 @@ try {
   console.error(error);
 }
 
-export interface IExample {
-  path: string;
-  category: string;
-  name: string;
-}
-
 export interface IState {
-  examplesPaths: string[];
+  exampleRootPath: IExampleCategory;
   selectedExample: IExample;
   hasExampleDetail: boolean;
   exampleDetail: string;
 }
 
 export const examplesState: IState = {
-  examplesPaths: [],
-  selectedExample: { path: "", category: "", name: "" },
+  exampleRootPath: { name: "", examples: [], subcategories: [] },
+  selectedExample: { name: "", path: "" },
   hasExampleDetail: false,
   exampleDetail: "",
 };
@@ -55,10 +50,11 @@ export const mutations: MutationTree<IState> = {
   },
   setExamplesPath(state, exampleList) {
     const newState = state;
-    newState.examplesPaths = exampleList;
+    newState.exampleRootPath = exampleList;
     Object.assign(state, newState);
   },
   setSelectedExample(state, selectedExample: IExample) {
+    console.log(selectedExample);
     const newState = state;
     newState.selectedExample = selectedExample;
     Object.assign(state, newState);

--- a/src/views/new-project/Configure.vue
+++ b/src/views/new-project/Configure.vue
@@ -40,7 +40,7 @@
         <div class="control">
           <div class="select">
             <select name="idf-target" id="idf-target" v-model="target">
-              <option v-for="t of targetList" :key="t.id" :value="t">{{
+              <option v-for="t of targetList" :key="t.name" :value="t">{{
                 t.name
               }}</option>
             </select>

--- a/src/views/new-project/Templates.vue
+++ b/src/views/new-project/Templates.vue
@@ -1,26 +1,17 @@
 <template>
   <div id="templates-window">
     <div id="sidenav" class="content">
-      <ul>
-        <li v-for="category in templateCategories" :key="category">
-          <p class="category subtitle" v-text="category" />
-          <ul class="templates">
-            <li v-for="item in groups[category]" :key="item.path">
-              <p
-                @click="toggleTemplateDetail(item)"
-                v-text="item.name"
-                :class="{
-                  selectedItem: selectedTemplate.path === item.path,
-                }"
-              />
-            </li>
-          </ul>
-        </li>
+      <ul class="templates">
+        <TemplateList
+          v-for="cat of templates"
+          :node="cat"
+          :key="cat.name"
+        />
       </ul>
     </div>
 
     <div id="template-content" class="content">
-      <div v-if="isTemplateDetailVisible" class="has-text-centered">
+      <div v-if="hasTemplateDetail" class="has-text-centered">
         <button
           v-if="selectedTemplate.name !== ''"
           v-on:click="createProject"
@@ -30,7 +21,7 @@
         </button>
       </div>
       <div
-        v-if="isTemplateDetailVisible"
+        v-if="hasTemplateDetail"
         id="templateDetail"
         v-html="templateDetail"
       ></div>
@@ -41,63 +32,44 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { Action, Mutation, State } from "vuex-class";
-import { IExample } from "../../examples/Example";
+import { IExample, IExampleCategory } from "../../examples/Example";
+import TemplateList from "./components/templateList.vue";
 
-@Component
+@Component({
+  components: {
+    TemplateList
+  }
+})
 export default class Templates extends Vue {
-  @State("templates") private storeTemplates: IExample[];
+  @State("templatesRootPath") private storeTemplatesRootPath: IExampleCategory;
+  @State("hasTemplateDetail") private storeHasTemplateDetail;
   @State("selectedTemplate") private storeSelectedTemplate: IExample;
   @State("templateDetail") private storeTemplateDetail;
   @Action private createProject;
-  @Action private getTemplateDetail;
-  @Mutation private setSelectedTemplate;
-  @Mutation private setTemplateDetail;
-  private isTemplateDetailVisible = true;
 
-  public groupBy(array: IExample[]) {
-    const result = {};
-    array.forEach((item) => {
-      if (!result[item.category]) {
-        result[item.category] = [];
-      }
-      result[item.category].push(item);
-    });
-    return result;
-  }
-
-  get groups() {
-    return this.groupBy(this.storeTemplates);
+  get hasTemplateDetail() {
+    return this.storeHasTemplateDetail;
   }
 
   get selectedTemplate() {
     return this.storeSelectedTemplate;
   }
 
-  get templateCategories() {
-    const uniqueCategories = [
-      ...new Set(this.storeTemplates.map((t) => t.category)),
-    ];
-    const getStarted = uniqueCategories.indexOf("get-started");
-    uniqueCategories.splice(0, 0, uniqueCategories.splice(getStarted, 1)[0]);
-    return uniqueCategories;
+  get templates() {
+    return this.storeTemplatesRootPath.subcategories;
   }
+
+  // get templateCategories() {
+  //   const uniqueCategories = [
+  //     ...new Set(this.storeTemplates.map((t) => t.name)),
+  //   ];
+  //   const getStarted = uniqueCategories.indexOf("get-started");
+  //   uniqueCategories.splice(0, 0, uniqueCategories.splice(getStarted, 1)[0]);
+  //   return uniqueCategories;
+  // }
 
   get templateDetail() {
     return this.storeTemplateDetail;
-  }
-
-  public toggleTemplateDetail(template: IExample) {
-    if (template.path !== this.storeSelectedTemplate.path) {
-      this.setSelectedTemplate(template);
-      this.setTemplateDetail("No README.md available for this project.");
-      this.getTemplateDetail({ pathToOpen: template.path });
-    } else {
-      this.showTemplateDetail();
-    }
-  }
-
-  showTemplateDetail() {
-    this.isTemplateDetailVisible = !this.isTemplateDetailVisible;
   }
 }
 </script>

--- a/src/views/new-project/Templates.vue
+++ b/src/views/new-project/Templates.vue
@@ -1,12 +1,15 @@
 <template>
   <div id="templates-window">
     <div id="sidenav" class="content">
+      <div class="select">
+        <select v-model="selectedFramework">
+          <option v-for="f in frameworks" :key="f" :value="f">
+            {{ f }}
+          </option>
+        </select>
+      </div>
       <ul class="templates">
-        <TemplateList
-          v-for="cat of templates"
-          :node="cat"
-          :key="cat.name"
-        />
+        <TemplateList v-for="cat of templates" :node="cat" :key="cat.name" />
       </ul>
     </div>
 
@@ -37,15 +40,19 @@ import TemplateList from "./components/templateList.vue";
 
 @Component({
   components: {
-    TemplateList
-  }
+    TemplateList,
+  },
 })
 export default class Templates extends Vue {
-  @State("templatesRootPath") private storeTemplatesRootPath: IExampleCategory;
+  @Action private createProject;
+  @Mutation private setSelectedFramework;
+  @State("templatesRootPath") private storeTemplatesRootPath: {
+    [key: string]: IExampleCategory;
+  };
   @State("hasTemplateDetail") private storeHasTemplateDetail;
   @State("selectedTemplate") private storeSelectedTemplate: IExample;
   @State("templateDetail") private storeTemplateDetail;
-  @Action private createProject;
+  @State("selectedFramework") private storeSelectedFramework: string;
 
   get hasTemplateDetail() {
     return this.storeHasTemplateDetail;
@@ -56,20 +63,35 @@ export default class Templates extends Vue {
   }
 
   get templates() {
-    return this.storeTemplatesRootPath.subcategories;
+    if (
+      this.storeTemplatesRootPath &&
+      this.storeTemplatesRootPath[this.selectedFramework]
+    ) {
+      return this.storeTemplatesRootPath[this.selectedFramework].subcategories;
+    }
   }
 
-  // get templateCategories() {
-  //   const uniqueCategories = [
-  //     ...new Set(this.storeTemplates.map((t) => t.name)),
-  //   ];
-  //   const getStarted = uniqueCategories.indexOf("get-started");
-  //   uniqueCategories.splice(0, 0, uniqueCategories.splice(getStarted, 1)[0]);
-  //   return uniqueCategories;
-  // }
+  get frameworks() {
+    return Object.keys(this.storeTemplatesRootPath);
+  }
 
   get templateDetail() {
     return this.storeTemplateDetail;
+  }
+
+  get selectedFramework() {
+    return this.storeSelectedFramework;
+  }
+
+  set selectedFramework(framework: string) {
+    this.setSelectedFramework(framework);
+  }
+
+  created() {
+    if (this.storeTemplatesRootPath) {
+      const frameworks = Object.keys(this.storeTemplatesRootPath);
+      this.selectedFramework = frameworks.length ? frameworks[0] : "";
+    }
   }
 }
 </script>

--- a/src/views/new-project/components/templateList.vue
+++ b/src/views/new-project/components/templateList.vue
@@ -1,0 +1,53 @@
+<template>
+  <li>
+    <h3 class="category is-3" v-text="node.name"></h3>
+    <ul class="subcategories">
+      <TemplateList
+        v-for="nodeSubCat in node.subcategories"
+        :key="nodeSubCat.name"
+        :node="nodeSubCat"
+      />
+    </ul>
+    <ul class="templates" v-if="node.examples && node.examples.length">
+      <li v-for="item in node.examples" :key="item.path">
+        <p
+          @click="toggleTemplateDetail(item)"
+          v-text="item.name"
+          :class="{
+            selectedItem: selectedTemplate.path === item.path,
+          }"
+        />
+      </li>
+    </ul>
+  </li>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { IExampleCategory, IExample } from "../../../examples/Example";
+import { Action, Mutation, State } from "vuex-class";
+
+@Component
+export default class TemplateList extends Vue {
+  @Action private getTemplateDetail;
+  @Mutation private setSelectedTemplate;
+  @Mutation private setTemplateDetail;
+  @Mutation private showTemplateDetail;
+  @State("selectedTemplate") private storeSelectedTemplate: IExample;
+  @Prop() node: IExampleCategory;
+
+  get selectedTemplate() {
+    return this.storeSelectedTemplate;
+  }
+
+  public toggleTemplateDetail(template: IExample) {
+    if (template.path !== this.storeSelectedTemplate.path) {
+      this.setSelectedTemplate(template);
+      this.setTemplateDetail("No README.md available for this project.");
+      this.getTemplateDetail({ pathToOpen: template.path });
+    } else {
+      this.showTemplateDetail();
+    }
+  }
+}
+</script>

--- a/src/views/new-project/main.ts
+++ b/src/views/new-project/main.ts
@@ -82,7 +82,6 @@ window.addEventListener("message", (event) => {
       }
       if (msg.templates) {
         store.commit("setTemplates", msg.templates);
-        store.commit("setSelectedTemplate", msg.templates[0]);
       }
       if (msg.openOcdConfigFiles) {
         store.commit("setOpenOcdConfigFiles", msg.openOcdConfigFiles);
@@ -94,6 +93,7 @@ window.addEventListener("message", (event) => {
       }
       break;
     case "setExampleDetail":
+      console.log(msg.templateDetail);
       if (msg.templateDetail) {
         store.commit("setTemplateDetail", msg.templateDetail);
       }

--- a/src/views/new-project/main.ts
+++ b/src/views/new-project/main.ts
@@ -93,7 +93,6 @@ window.addEventListener("message", (event) => {
       }
       break;
     case "setExampleDetail":
-      console.log(msg.templateDetail);
       if (msg.templateDetail) {
         store.commit("setTemplateDetail", msg.templateDetail);
       }

--- a/src/views/new-project/store/index.ts
+++ b/src/views/new-project/store/index.ts
@@ -15,7 +15,7 @@
 import Vue from "vue";
 import Vuex, { ActionTree, MutationTree, StoreOptions } from "vuex";
 import { IComponent } from "../../../espIdf/idfComponent/IdfComponent";
-import { IExample } from "../../../examples/Example";
+import { IExample, IExampleCategory } from "../../../examples/Example";
 
 Vue.use(Vuex);
 
@@ -45,6 +45,7 @@ export interface IState {
   components: IComponent[];
   containerDirectory: string;
   currentComponentPath: string;
+  hasTemplateDetail: boolean;
   openOcdConfigFiles: string;
   projectName: string;
   selectedBoard: IdfBoard;
@@ -54,7 +55,7 @@ export interface IState {
   target: IdfTarget;
   targetList: IdfTarget[];
   templateDetail: string;
-  templates: IExample[];
+  templatesRootPath: IExampleCategory;
 }
 
 const newProjectState: IState = {
@@ -62,16 +63,17 @@ const newProjectState: IState = {
   components: [],
   containerDirectory: "",
   currentComponentPath: "",
+  hasTemplateDetail: false,
   openOcdConfigFiles: "",
   projectName: "project-name",
   selectedBoard: null,
   selectedPort: "",
-  selectedTemplate: null,
+  selectedTemplate: { name: "", path: "" },
   serialPortList: [],
   target: null,
   targetList: [],
   templateDetail: "",
-  templates: [],
+  templatesRootPath: { name: "", examples: [], subcategories: [] },
 };
 
 export const mutations: MutationTree<IState> = {
@@ -139,12 +141,18 @@ export const mutations: MutationTree<IState> = {
   setTemplateDetail(state, templateDetail: string) {
     const newState = state;
     newState.templateDetail = templateDetail;
+    newState.hasTemplateDetail = true;
     state = { ...newState };
   },
-  setTemplates(state, templates: IExample[]) {
+  setTemplates(state, templates: IExampleCategory) {
     const newState = state;
-    newState.templates = templates;
+    newState.templatesRootPath = templates;
     state = { ...newState };
+  },
+  showTemplateDetail(state) {
+    const newState = state;
+    newState.hasTemplateDetail = !newState.hasTemplateDetail;
+    Object.assign(state, newState);
   },
   removeComponent(state, component: IComponent) {
     const newState = state;

--- a/src/views/new-project/store/index.ts
+++ b/src/views/new-project/store/index.ts
@@ -49,13 +49,14 @@ export interface IState {
   openOcdConfigFiles: string;
   projectName: string;
   selectedBoard: IdfBoard;
+  selectedFramework: string;
   selectedPort: string;
   selectedTemplate: IExample;
   serialPortList: string[];
   target: IdfTarget;
   targetList: IdfTarget[];
   templateDetail: string;
-  templatesRootPath: IExampleCategory;
+  templatesRootPath: { [key: string]: IExampleCategory };
 }
 
 const newProjectState: IState = {
@@ -67,13 +68,14 @@ const newProjectState: IState = {
   openOcdConfigFiles: "",
   projectName: "project-name",
   selectedBoard: null,
+  selectedFramework: "",
   selectedPort: "",
   selectedTemplate: { name: "", path: "" },
   serialPortList: [],
   target: null,
   targetList: [],
   templateDetail: "",
-  templatesRootPath: { name: "", examples: [], subcategories: [] },
+  templatesRootPath: {},
 };
 
 export const mutations: MutationTree<IState> = {
@@ -112,6 +114,11 @@ export const mutations: MutationTree<IState> = {
     newState.selectedBoard = board;
     state = { ...newState };
   },
+  setSelectedFramework(state, selectedFramework: string) {
+    const newState = state;
+    newState.selectedFramework = selectedFramework;
+    state = { ...newState };
+  },
   setSelectedPort(state, port: string) {
     const newState = state;
     newState.selectedPort = port;
@@ -144,7 +151,7 @@ export const mutations: MutationTree<IState> = {
     newState.hasTemplateDetail = true;
     state = { ...newState };
   },
-  setTemplates(state, templates: IExampleCategory) {
+  setTemplates(state, templates: { [key: string]: IExampleCategory }) {
     const newState = state;
     newState.templatesRootPath = templates;
     state = { ...newState };

--- a/src/views/new-project/store/index.ts
+++ b/src/views/new-project/store/index.ts
@@ -136,7 +136,6 @@ export const mutations: MutationTree<IState> = {
   },
   setTarget(state, target: IdfTarget) {
     const newState = state;
-    console.log(target);
     state.target = target;
     state = { ...newState };
   },


### PR DESCRIPTION
Fix #401 

Before we only use top level directories as categories of examples (IDF, ADF, etc.)

This PR uses a recursive approach to provide all directories as sub-categories for examples.

![Screen Shot 2021-05-20 at 8 07 32 PM](https://user-images.githubusercontent.com/6033246/118976383-85c6b000-b9a7-11eb-8671-4b6b5957da5c.png)
