### PR TITLE
update srcs in CMakelists file enable disable

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -75,14 +75,15 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
 ### Extension Behaviour Settings
 
-| Setting ID                        | Description                                                       |
-| --------------------------------- | ----------------------------------------------------------------- |
-| `idf.notificationSilentMode`      | Silent all notifications messages (excluding error notifications) |
-| `idf.saveBeforeBuild`             | Save all the edited files before building (default `true`)        |
-| `idf.showOnboardingOnInit`        | Show ESP-IDF Configuration window on extension activation         |
-| `idf.useIDFKconfigStyle`          | Enable style validation for Kconfig files                         |
-| `idf.saveScope`                   | Where to save extension settings                                  |
-| `idf.launchMonitorOnDebugSession` | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
+| Setting ID                             | Description                                                       |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `idf.notificationSilentMode`           | Silent all notifications messages (excluding error notifications) |
+| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)        |
+| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation         |
+| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                         |
+| `idf.saveScope`                        | Where to save extension settings                                  |
+| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
+| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)     |
 
 The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md).
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -65,6 +65,7 @@
   "param.partialDarkTheme": "Background color for partially covered lines in Dark theme for ESP-IDF Coverage.",
   "param.uncoveredLightTheme": "Background color for uncovered lines in Light theme for ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Background color for uncovered lines in Dark theme for ESP-IDF Coverage.",
+  "param.enableUpdateSrcsToCMakeListsFile": "Enable update source files in CMakeLists.txt",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -65,6 +65,7 @@
   "param.partialDarkTheme": "Color de fondo para lineas parcialmente cubiertas en temas oscuros por ESP-IDF Coverage.",
   "param.uncoveredLightTheme": "Color de fondo para lineas no cubiertas en temas claros por ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Color de fondo para lineas no cubiertas en temas oscuros por ESP-IDF Coverage.",
+  "param.enableUpdateSrcsToCMakeListsFile": "Habilitar actualización de archivos fuente en CMakeLists.txt",
   "param.launchMonitorOnDebugSession.title": "Iniciar IDF Monitor junto a la sesión ESP-IDF Debug Adapter",
   "param.enableIdfComponentManager.title": "Habilitar IDF Component Manager en construccion de proyecto",
   "view.components.name": "Componentes de proyecto",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -65,6 +65,7 @@
   "param.partialDarkTheme": "Цвет фона для частично покрытых линий в темной теме для покрытия кода ESP-IDF.",
   "param.uncoveredLightTheme": "Цвет фона для непокрытых линий в светлой теме для покрытия кода ESP-IDF.",
   "param.uncoveredDarkTheme": "Цвет фона для непокрытых линий в темной теме для покрытия кода ESP-IDF.",
+  "param.enableUpdateSrcsToCMakeListsFile": "Включить файлы источников обновлений в CMakeLists.txt",
   "param.launchMonitorOnDebugSession.title": "Запустите IDF Monitor вместе с сеансом ESP-IDF Debug Adapter.",
   "param.enableIdfComponentManager.title": "Включить диспетчер компонентов IDF в задаче сборки",
   "view.components.name": "Компоненты проекта",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -65,6 +65,7 @@
   "param.partialDarkTheme": "ESP-IDF覆盖的暗主题部分覆盖线的背景色",
   "param.uncoveredLightTheme": "ESP-IDF覆盖的光主题中未覆盖线条的背景色",
   "param.uncoveredDarkTheme": "ESP-IDF覆盖的深色主题中未覆盖线条的背景色",
+  "param.enableUpdateSrcsToCMakeListsFile": "启用CMakeLists.txt中的更新源文件",
   "param.launchMonitorOnDebugSession.title": "启动IDF监视器和ESP-IDF调试适配器会话",
   "param.enableIdfComponentManager.title": "在生成任务中启用IDF组件管理器",
   "view.components.name": "项目组件",

--- a/package.json
+++ b/package.json
@@ -628,6 +628,11 @@
             "type": "string",
             "description": "%param.gitPath.title%",
             "default": "git"
+          },
+          "idf.enableUpdateSrcsToCMakeListsFile": {
+            "type": "boolean",
+            "description": "%param.enableUpdateSrcsToCMakeListsFile%",
+            "default": true
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -65,6 +65,7 @@
   "param.partialDarkTheme": "Background color for partially covered lines in Dark theme for ESP-IDF Coverage.",
   "param.uncoveredLightTheme": "Background color for uncovered lines in Light theme for ESP-IDF Coverage.",
   "param.uncoveredDarkTheme": "Background color for uncovered lines in Dark theme for ESP-IDF Coverage.",
+  "param.enableUpdateSrcsToCMakeListsFile": "Enable update source files in CMakeLists.txt",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -1,9 +1,7 @@
 {
   "out": {
     "build": {
-      "buildCmd": [
-        "build.waitProcessIsFinishedMessage"
-      ]
+      "buildCmd": ["build.waitProcessIsFinishedMessage"]
     },
     "espIdf": {
       "menuconfig": {
@@ -20,9 +18,7 @@
         ]
       },
       "monitor": {
-        "command": [
-          "monitor.waitProcessIsFinishedMessage"
-        ]
+        "command": ["monitor.waitProcessIsFinishedMessage"]
       },
       "serial": {
         "serialPort": [
@@ -44,9 +40,7 @@
       }
     },
     "flash": {
-      "flashCmd": [
-        "flash.waitProcessIsFinishedMessage"
-      ]
+      "flashCmd": ["flash.waitProcessIsFinishedMessage"]
     },
     "extension": [
       "extension.defaultFoldersGeneratedMessage",
@@ -183,6 +177,7 @@
     "esp_idf.gdbinitFile.description",
     "param.launchMonitorOnDebugSession.title",
     "param.enableIdfComponentManager.title",
-    "param.gitPath.title"
+    "param.gitPath.title",
+    "param.enableUpdateSrcsToCMakeListsFile"
   ]
 }


### PR DESCRIPTION
Fix #432 

Enable or disable updating source file automatically in CMakeLists.txt with the `idf.enableUpdateSrcsToCMakeListsFile` configuration setting.