### PR TITLE
import idf project command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ There are few dependencies required in your system and available in environment 
 | [CMake](https://cmake.org/download)                          | [CMake](https://cmake.org/download)                          |                                                                              |
 | [Ninja-build](https://github.com/ninja-build/ninja/releases) | [Ninja-build](https://github.com/ninja-build/ninja/releases) |                                                                              |
 
-
 All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using the **ESP-IDF: Configure ESP-IDF extension** setup wizard or following the steps in the [setup documentation](./docs/SETUP.md).
 
 > Please note that this extension **only [supports](https://github.com/espressif/esp-idf/blob/master/SUPPORT_POLICY.md)** the release versions of ESP-IDF, you can still use the extension on `master` branch or some other branch, but certain feature might not properly work.
@@ -97,6 +96,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Flash your project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>F</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>F</kbd> |
 | Full clean project                                      | <kbd>⌘</kbd> <kbd>E</kbd> <kbd>X</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>X</kbd> |
 | Get HTML Coverage Report for project                    |                                        |                                           |
+| Import ESP-IDF Project                                  |                                        |                                           |
 | Install ESP-ADF                                         |                                        |                                           |
 | Install ESP-IDF Python Packages                         |                                        |                                           |
 | Install ESP-MDF                                         |                                        |                                           |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -41,6 +41,7 @@
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
   "espIdf.setGcovConfig.title": "ESP-IDF: Configure project sdkconfig for coverage",
+  "espIdf.importProject.title": "Import ESP-IDF Project",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF: Launch",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -41,6 +41,7 @@
   "espIdf.eraseFlash.title": "ESP-IDF: Borrar memoria flash del dispositivo",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Cerrar proceso de servidor de editor de Configuración SDK",
   "espIdf.setGcovConfig.title": "ESP-IDF: Configurar sdkconfig del proyecto para cobertura de codigo fuente",
+  "espIdf.importProject.title": "Importar proyecto ESP-IDF",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "Lanzar ESP-IDF:",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -41,6 +41,7 @@
   "espIdf.eraseFlash.title": "ESP-IDF: Стереть флеш-память с устройства",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Удалить текущий процесс сервера редактора конфигурации SDK",
   "espIdf.setGcovConfig.title": "ESP-IDF: Настроить проект sdkconfig для покрытия",
+  "espIdf.importProject.title": "Импортировать проект ESP-IDF",
   "esp.component-manager.ui.show.title": "Показать реестр компонентов",
   "esp.component-manager.cli.addDependencyError": "Ошибка при добавлении зависимости к компоненту",
   "debug.initConfig.name": "ESP-IDF: Запустить",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -41,6 +41,7 @@
   "espIdf.eraseFlash.title": "ESP-IDF: 从设备中擦除闪存",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: 释放当前SDK配置编辑器服务器进程",
   "espIdf.setGcovConfig.title": "ESP-IDF: 为覆盖范围配置项目sdkconfig",
+  "espIdf.importProject.title": "导入ESP-IDF项目",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF：启动",

--- a/package.json
+++ b/package.json
@@ -898,6 +898,11 @@
         "command": "esp.component-manager.ui.show",
         "title": "%esp.component-manager.ui.show.title%",
         "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.importProject",
+        "title": "%espIdf.importProject.title%",
+        "category": "ESP-IDF"
       }
     ],
     "breakpoints": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -41,6 +41,7 @@
   "espIdf.eraseFlash.title": "ESP-IDF: Erase flash memory from device",
   "espIdf.disposeConfserverProcess.title": "ESP-IDF: Dispose current SDK Configuration editor server process",
   "espIdf.setGcovConfig.title": "ESP-IDF: Configure project sdkconfig for coverage",
+  "espIdf.importProject.title": "Import ESP-IDF Project",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF: Launch",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -117,6 +117,7 @@
     "espIdf.doctorCommand.title",
     "espIdf.ninja.summary.title",
     "espIdf.setGcovConfig.title",
+    "espIdf.importProject.title",
     "espIdf.eraseFlash.title",
     "debug.initConfig.name",
     "debug.initConfig.description",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1573,6 +1573,79 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  registerIDFCommand("espIdf.importProject", async () => {
+    const srcFolder = await vscode.window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+    });
+    if (!srcFolder || !srcFolder.length) {
+      return;
+    }
+    const isIdfProject = utils.checkIsProjectCmakeLists(srcFolder[0].fsPath);
+    if (!isIdfProject) {
+      Logger.infoNotify(`${srcFolder[0].fsPath} is not an ESP-IDF project.`);
+      return;
+    }
+    const items = [
+      { label: "Choose a container directory...", target: "another" },
+    ];
+    if (workspaceRoot) {
+      items.push({
+        label: `Use current folder (${workspaceRoot.fsPath})`,
+        target: "current",
+      });
+    }
+    const projectDirOption = await vscode.window.showQuickPick(items, {
+      placeHolder: "Select a directory to use",
+    });
+    if (!projectDirOption) {
+      return;
+    }
+    let destFolder: string;
+    if (projectDirOption.target === "another") {
+      const newFolder = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectFiles: false,
+        canSelectMany: false,
+      });
+      if (!newFolder || !newFolder.length) {
+        return;
+      }
+      destFolder = newFolder[0].fsPath;
+    } else if (workspaceRoot) {
+      destFolder = workspaceRoot.fsPath;
+    }
+    if (!destFolder) {
+      return;
+    }
+    const projectName = await vscode.window.showInputBox({
+      placeHolder: "Enter project name",
+      value: "",
+    });
+    if (!projectName) {
+      return;
+    }
+    destFolder = path.join(destFolder, projectName);
+    const doesProjectExists = await pathExists(destFolder);
+    if (doesProjectExists) {
+      Logger.infoNotify(`${destFolder} already exists.`);
+      return;
+    }
+    await utils.copyFromSrcProject(srcFolder[0].fsPath, destFolder);
+    const opt = await vscode.window.showInformationMessage(
+      "Project has been imported",
+      "Open"
+    );
+    if (opt === "Open") {
+      vscode.commands.executeCommand(
+        "vscode.openFolder",
+        vscode.Uri.file(destFolder),
+        true
+      );
+    }
+  });
+
   registerIDFCommand("espIdf.setGcovConfig", async () => {
     PreCheck.perform([openFolderCheck], async () => {
       try {


### PR DESCRIPTION
Fix #457 

Add `Import ESP-IDF Project` command to copy an existing ESP-IDF project with vscode configuration folder in a new location or the current location.

User has to define new project name.