### PR TITLE
add git executable before python venv

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -779,17 +779,16 @@ export function appendIdfAndToolsToPath() {
   } else {
     pathNameInEnv = "PATH";
   }
+  if (pathToGitDir) {
+    modifiedEnv[pathNameInEnv] =
+      pathToGitDir + path.delimiter + modifiedEnv[pathNameInEnv];
+  }
   modifiedEnv[pathNameInEnv] =
     path.dirname(modifiedEnv.PYTHON) +
     path.delimiter +
     path.join(modifiedEnv.IDF_PATH, "tools") +
     path.delimiter +
     modifiedEnv[pathNameInEnv];
-
-  if (pathToGitDir) {
-    modifiedEnv[pathNameInEnv] =
-      pathToGitDir + path.delimiter + modifiedEnv[pathNameInEnv];
-  }
 
   if (
     modifiedEnv[pathNameInEnv] &&


### PR DESCRIPTION
Need to add git executable container directory before python to avoid using system-wide python in OS X/Linux