### PR TITLE
add verify app binary in chip before debug

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -43,6 +43,7 @@ The ESP-IDF Debug Adapter settings for launch.json are:
   > **NOTE:** If set to `manual`, openOCD and ESP-IDF Debug Adapter have to be manually executed by the user and the extension will just try to connect to existing servers at configured ports.
 - `name`: The name of the debug launch configuration. This will be shown in the Run view (Menu View -> Run).
 - `type`: Type of debug configuration. It **must** be `espidf`.
+- `skipVerifyAppBinBeforeDebug`: By default before starting the debug session, the extension will verify that the current workspace folder `build/${project-name}.bin` is the same of the target device application. `${project-name}` is the name of the project (i.e blink) and is obtained from the `build/project_description.json`. Set this to `true` to skip application binary validation before debug session.
 
 If `gdbinitFile` or `initGdbCommands` are defined in launch.json, make sure to include the following commands for debug session to properly work as shown in [JTAG Debugging debugging with command line](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/using-debugger.html#command-line).
 
@@ -68,6 +69,7 @@ Example launch.json for ESP-IDF Debug Adapter:
       "debugPort": 9998,
       "logLevel": 2,
       "mode": "manual",
+      "skipVerifyAppBinBeforeDebug": false,
       "initGdbCommands": [
         "target remote :3333",
         "symbol-file /path/to/program.elf",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -107,5 +107,6 @@
   "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "One or more GDB commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
-  "esp_idf.debuggers.text.description": "The command to execute"
+  "esp_idf.debuggers.text.description": "The command to execute",
+  "esp_idf.skipVerifyAppBinBeforeDebug.description": "Skip verify app binaries before debug"
 }

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -107,5 +107,6 @@
   "esp_idf.appOffset.description": "Sobrescribir offset de inicio de programa (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "Uno o varios comandos GDB a ejecutar para iniciar el depurador. Ejemplo: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "ruta del archivo gdbinit para el ESP-IDF Debug Adapter",
-  "esp_idf.debuggers.text.description": "Comando a ejecutar"
+  "esp_idf.debuggers.text.description": "Comando a ejecutar",
+  "esp_idf.skipVerifyAppBinBeforeDebug.description": "Saltar verificación de binarios antes de depurar la aplicación"
 }

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -107,5 +107,6 @@
   "esp_idf.appOffset.description": "Отменить смещение начального адреса программы сборки (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "Одна или несколько команд GDB для настройки отладчика. Пример: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "Путь к файлу gdbinit для адаптера отладки ESP-IDF",
-  "esp_idf.debuggers.text.description": "Команда для выполнения"
+  "esp_idf.debuggers.text.description": "Команда для выполнения",
+  "esp_idf.skipVerifyAppBinBeforeDebug.description": "Пропустить проверку двоичных файлов приложения перед отладкой"
 }

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -107,5 +107,6 @@
   "esp_idf.appOffset.description": "重写生成程序开始地址偏移量 (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "要执行的一个或多个GDB命令，以便设置底层调试器。例子: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"].",
   "esp_idf.gdbinitFile.description": "ESP-IDF调试适配器的gdbinit文件路径",
-  "esp_idf.debuggers.text.description": "要执行的命令"
+  "esp_idf.debuggers.text.description": "要执行的命令",
+  "esp_idf.skipVerifyAppBinBeforeDebug.description": "调试前跳过验证应用程序二进制文件"
 }

--- a/package.json
+++ b/package.json
@@ -975,6 +975,11 @@
                 "type": "string",
                 "description": "%esp_idf.gdbinitFile.description%",
                 "default": ""
+              },
+              "skipVerifyAppBinBeforeDebug": {
+                "type": "boolean",
+                "description": "%esp_idf.skipVerifyAppBinBeforeDebug.description%",
+                "default": false
               }
             }
           }

--- a/package.nls.json
+++ b/package.nls.json
@@ -107,5 +107,6 @@
   "esp_idf.appOffset.description": "Override build program start address offset (ESP32_APP_FLASH_OFF)",
   "esp_idf.initGdbCommands.description": "One or more GDB commands to execute in order to setup the underlying debugger. Example: \"initGdbCommands\": [ \"target remote /dev/ttyUSB0\"]",
   "esp_idf.gdbinitFile.description": "gdbinit file path for ESP-IDF Debug Adapter",
-  "esp_idf.debuggers.text.description": "The command to execute"
+  "esp_idf.debuggers.text.description": "The command to execute",
+  "esp_idf.skipVerifyAppBinBeforeDebug.description": "Skip verify app binaries before debug"
 }

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -181,6 +181,7 @@
     "esp_idf.initGdbCommands.description",
     "esp_idf.debuggers.text.description",
     "esp_idf.gdbinitFile.description",
+    "esp_idf.skipVerifyAppBinBeforeDebug.description",
     "param.launchMonitorOnDebugSession.title",
     "param.enableIdfComponentManager.title",
     "param.gitPath.title",

--- a/src/espIdf/debugAdapter/verifyApp.ts
+++ b/src/espIdf/debugAdapter/verifyApp.ts
@@ -52,10 +52,10 @@ export async function verifyAppBinary(workspaceFolder: string) {
         env: modifiedEnv,
       }
     );
-    console.log(cmdResult);
-    if (cmdResult.indexOf("verify FAILED (digest mismatch)") !== -1) {
+    Logger.info(cmdResult.toString());
+    if (cmdResult.toString().indexOf("verify FAILED (digest mismatch)") !== -1) {
       return false;
-    } else if (cmdResult.indexOf("verify OK (digest matched)") !== -1) {
+    } else if (cmdResult.toString().indexOf("verify OK (digest matched)") !== -1) {
       return true;
     }
     return false;

--- a/src/espIdf/debugAdapter/verifyApp.ts
+++ b/src/espIdf/debugAdapter/verifyApp.ts
@@ -1,0 +1,79 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Friday, 16th July 2021 4:23:24 pm
+ * Copyright 2021 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path";
+import { createFlashModel } from "../../flash/flashModelBuilder";
+import { readParameter } from "../../idfConfiguration";
+import { Logger } from "../../logger/logger";
+import { appendIdfAndToolsToPath, spawn } from "../../utils";
+
+export async function verifyAppBinary(workspaceFolder: string) {
+  const modifiedEnv = appendIdfAndToolsToPath();
+  const serialPort = readParameter("idf.port");
+  const flashBaudRate = readParameter("idf.flashBaudRate");
+  const flasherArgsJsonPath = join(
+    workspaceFolder,
+    "build",
+    "flasher_args.json"
+  );
+  const model = await createFlashModel(
+    flasherArgsJsonPath,
+    serialPort,
+    flashBaudRate
+  );
+
+  try {
+    const cmdResult = await spawn(
+      "esptool.py",
+      [
+        "-p",
+        serialPort,
+        "verify_flash",
+        model.app.address,
+        `build/${model.app.binFilePath}`,
+      ],
+      {
+        cwd: workspaceFolder,
+        env: modifiedEnv,
+      }
+    );
+    console.log(cmdResult);
+    if (cmdResult.indexOf("verify FAILED (digest mismatch)") !== -1) {
+      return false;
+    } else if (cmdResult.indexOf("verify OK (digest matched)") !== -1) {
+      return true;
+    }
+    return false;
+  } catch (error) {
+    if (
+      error &&
+      error.error &&
+      error.error.message &&
+      error.error.message.indexOf("verify FAILED (digest mismatch)") !== -1
+    ) {
+      return false;
+    }
+    const msg = error.error.message
+      ? error.error.message
+      : error.message
+      ? error.message
+      : "Something wrong while verifying app binary.";
+    Logger.errorNotify(msg, error);
+    return false;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2674,11 +2674,13 @@ class IdfDebugConfigurationProvider
           `${elfFilePath} doesn't exist. Build this project first.`
         );
       }
-      const isSameAppBinary = await verifyAppBinary(workspaceRoot.fsPath);
-      if (!isSameAppBinary) {
-        throw new Error(
-          `Current app binary is different from your project. Flash first.`
-        );
+      if (!config.skipVerifyAppBinBeforeDebug) {
+        const isSameAppBinary = await verifyAppBinary(workspaceRoot.fsPath);
+        if (!isSameAppBinary) {
+          throw new Error(
+            `Current app binary is different from your project. Flash first.`
+          );
+        }
       }
       config.elfFilePath = elfFilePath;
     } catch (error) {


### PR DESCRIPTION
Before debug session start, verify that `build/<project-name>.bin` is the same as the one in the target device.

If any error or `verify FAILED (digest mismatch)` is found, show the user the option to run build and flash command.