### PR TITLE
add save scope in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using
   - Either open Visual Studio Code and create a workspace folder.
   - Run `code ${YOUR_PROJECT_DIR}` from the command line.
 - Check you have installed the [Prerequisites](#Prerequisites)
+- (OPTIONAL) Press <kbd>F1</kbd> and type **ESP-IDF: Select where to save configuration settings**, which can be User settings, Workspace settings or workspace folder settings. Please take a look at [Working with multiple projects](./MULTI_PROJECTS.md) for more information. Default is User settings.
 - On the first time using the extension, press <kbd>F1</kbd> and type **ESP-IDF: Configure ESP-IDF extension** to open the extension configuration wizard. This will install ESP-IDF and tools and configure the extension.
 
   > **NOTE:** Please take a look at [SETUP](./docs/SETUP.md) documentation or the [Install](./docs/tutorial/install.md) tutorial for details about extension configuration.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -32,6 +32,7 @@ To install from `.vsix` file:
 
 ## Configure the extension
 
+- (OPTIONAL) Press <kbd>F1</kbd> and type **ESP-IDF: Select where to save configuration settings**, which can be User settings, Workspace settings or workspace folder settings. Please take a look at [Working with multiple projects](./MULTI_PROJECTS.md) for more information. Default is User settings.
 - Please take a look at [SETUP](./SETUP.md) for details about extension configuration.
 
 ## Uninstalling the plugin

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,10 +1,10 @@
-## ESP IDF Settings
+# ESP IDF Settings
 
 This extension contributes the following settings that can be later updated in settings.json or from VSCode Settings Preference menu (menu View -> Command Palette -> Preferences: Open Settings (UI)).
 
 > **NOTE:** Please consider that `~`, `%VARNAME%` and `$VARNAME` are not recognized when set on ANY of this extension configuration settings. You can instead set any environment variable in the path using a `${env:VARNAME}` such as `${env:HOME}` or you can refer to other configuration parameter path with `${config:SETTINGID}` such as `${config:idf.espIdfPath}`.
 
-### ESP-IDF Specific Settings
+## ESP-IDF Specific Settings
 
 These are the configuration settings that ESP-IDF extension contributes to your Visual Studio Code editor settings.
 
@@ -32,7 +32,7 @@ This is how the extension uses them:
 
 > **NOTE**: From Visual Studio Code extension context, we can't modify your system PATH or any other environment variable. We use a modified process environment in all of this extension tasks and child processes which should not affect any other system process or extension. Please review the content of `idf.customExtraPaths` and `idf.customExtraVars` in case you have issues with other extensions.
 
-### Board/ Chip Specific Settings
+## Board/ Chip Specific Settings
 
 These settings are specific to the ESP32 Chip/ Board
 
@@ -58,7 +58,7 @@ This is how the extension uses them:
 4. `idf.openOcdConfigs` is used to store an array of openOCD scripts directory relative path config files to use with OpenOCD server. (Example: ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"]). More information [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target).
 5. `idf.port` (or `idf.portWin` in Windows) is used as the serial port value for the extension commands.
 
-### Code coverage Specific Settings
+## Code coverage Specific Settings
 
 These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
@@ -73,7 +73,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.uncoveredLightTheme` | Background color for uncovered lines in light theme for gcov coverage         |
 | `idf.uncoveredDarkTheme`  | Background color for uncovered lines in dark theme for gcov coverage          |
 
-### Extension Behaviour Settings
+## Extension Behaviour Settings
 
 | Setting ID                             | Description                                                       |
 | -------------------------------------- | ----------------------------------------------------------------- |
@@ -85,11 +85,11 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
 | `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)     |
 
-The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md).
+The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md). Use the `Select where to save configuration settings` command to choose where to save settings when using this extension commands.
 
-### Log Tracing Specific Settings
+## Log Tracing Specific Settings
 
-These settings are specific to the Log Tracing
+These settings are specific to [Application Log Tracing](./HEAP_TRACING.md).
 
 | Setting             | Description                              |
 | ------------------- | ---------------------------------------- |
@@ -99,7 +99,7 @@ These settings are specific to the Log Tracing
 | `trace.wait4halt`   | wait4halt will be set for the apptrace   |
 | `trace.skip_size`   | skip_size will be set for the apptrace   |
 
-### Other frameworks Specific Settings
+## Other frameworks Specific Settings
 
 These settings allow to support additional frameworks together with ESP-IDF
 
@@ -115,7 +115,7 @@ The **Install ESP-MDF** command will clone ESP-MDF and set `idf.espMdfPath` (`id
 
 The **Show Examples Projects** command allows you create a new project using one of the examples in ESP-IDF, ESP-ADF or ESP-MDF directory if related configuration settings are set.
 
-### Use of environment variables in ESP-IDF settings.json and tasks.json
+## Use of environment variables in ESP-IDF settings.json and tasks.json
 
 Environment (env) variables and other ESP-IDF settings (config) current values strings can be used in other ESP-IDF setting as `${env:VARNAME}` and `${config:ESPIDFSETTING}`, respectively.
 

--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -12,8 +12,9 @@
   <img src="../../media/tutorials/setup/install-extension.png" alt="Setup wizard">
 </p>
 
-6. In Visual Studio Code, select menu "View" and "Command Palette" and type [configure esp-idf extension]. After, choose the **ESP-IDF: Configure ESP-IDF extension** option.
-7. Now the setup wizard window will be shown with several setup options: **Express**, **Advanced** or **Use existing setup**.
+6. (OPTIONAL) Press <kbd>F1</kbd> and type **ESP-IDF: Select where to save configuration settings**, which can be User settings, Workspace settings or workspace folder settings. Please take a look at [Working with multiple projects](./MULTI_PROJECTS.md) for more information. Default is User settings.
+7. In Visual Studio Code, select menu "View" and "Command Palette" and type [configure esp-idf extension]. After, choose the **ESP-IDF: Configure ESP-IDF extension** option.
+8. Now the setup wizard window will be shown with several setup options: **Express**, **Advanced** or **Use existing setup**.
 
 > **NOTE**: **Use existing setup** setup mode option is only shown if:
 >
@@ -25,8 +26,8 @@
   <img src="../../media/tutorials/setup/select-mode.png" alt="Select extension mode" width="950">
 </p>
 
-8. Choose **Express** for the fastest option (or **Use existing setup** if ESP-IDF is already installed)
-9. If you choose **Express** setup mode:
+9. Choose **Express** for the fastest option (or **Use existing setup** if ESP-IDF is already installed)
+10. If you choose **Express** setup mode:
     - Pick an ESP-IDF version to download (or find ESP-IDF in your system) and the python executable to create the virtual environment.
     - Choose the location for ESP-IDF Tools and python virtual environment (also known as `IDF_TOOLS_PATH`) which is `$HOME\.espressif` on MacOS/Linux and `%USERPROFILE%\.espressif` on Windows by default.
     > **NOTE:** Windows users don't need to select a python executable since it is part of the setup.
@@ -35,13 +36,13 @@
   <img src="../../media/tutorials/setup/select-esp-idf.png" alt="Select ESP-IDF" width="950">
 </p>
 
-10. The user will see a page showing the setup progress status showing ESP-IDF download progress, ESP-IDF Tools download and install progress as well as the creation of a python virtual environment.
+11. The user will see a page showing the setup progress status showing ESP-IDF download progress, ESP-IDF Tools download and install progress as well as the creation of a python virtual environment.
 
 <p>
   <img src="../../media/tutorials/setup/install-status.png" alt="Install status" width="950">
 </p>
 
-11. (OPTIONAL) If the user have chosen the **Advanced** option, after ESP-IDF is downloaded and extracted, select to either download ESP-IDF Tools or manually provide each ESP-IDF tool absolute path and required environment variables.
+12. (OPTIONAL) If the user have chosen the **Advanced** option, after ESP-IDF is downloaded and extracted, select to either download ESP-IDF Tools or manually provide each ESP-IDF tool absolute path and required environment variables.
     > **NOTE:** Consider that `IDF_PATH` requires each ESP-IDF tool to be of the version described in `IDF_PATH`/tools/tools.json.
     > If it is desired to use a different ESP-IDF tool version, check [JSON Manual Configuration](../SETUP.md#JSON-Manual-Configuration)
 
@@ -49,14 +50,14 @@
   <img src="../../media/tutorials/setup/advanced.png" alt="Select ESP-IDF Tools" width="950">
 </p>
 
-12. (OPTIONAL) If the user has chosen the **Advanced** mode and selected to manually provide each ESP-IDF tool absolute path, please enter the executable container directory for each binary as shown below:
+13. (OPTIONAL) If the user has chosen the **Advanced** mode and selected to manually provide each ESP-IDF tool absolute path, please enter the executable container directory for each binary as shown below:
     > **NOTE:** Check [JSON Manual Configuration](../SETUP.md#JSON-Manual-Configuration) for more information.
 
 <p>
   <img src="../../media/tutorials/setup/advanced-manual.png" alt="Enter ESP-IDF Tools paths manually" width="950">
 </p>
 
-12. If everything is installed correctly, the user will see a message that all settings have been configured. You can start using the extension.
+14. If everything is installed correctly, the user will see a message that all settings have been configured. You can start using the extension.
 
 <p>
   <img src="../../media/tutorials/setup/install-complete.png" alt="Install complete">
@@ -64,6 +65,6 @@
 
 > **NOTE**: The advance mode allows the user to choose to use existing ESP-IDF tools by manually entering each ESP-IDF tool absolute path.
 
-13. Now that the extension setup is finally done, check the [basic use](./basic_use.md) to learn how to use the SDK Configuration editor, build, flash and monitor your Espressif device.
+15. Now that the extension setup is finally done, check the [basic use](./basic_use.md) to learn how to use the SDK Configuration editor, build, flash and monitor your Espressif device.
 
   > **NOTE**: Visual Studio Code has many places where to set configuration settings. This extension uses the `idf.saveScope` configuration setting to determine where to save settings, Global (User Settings), Workspace and WorkspaceFolder. Please review [vscode settings precedence](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).


### PR DESCRIPTION
Fix #487

Add in the documentation that the user should select where to save settings before using any extension commands that modify configuration settings.