### PR TITLE
fix windows paths for gcovr

### DIFF
--- a/src/coverage/coverageService.ts
+++ b/src/coverage/coverageService.ts
@@ -61,15 +61,15 @@ export async function getGcovFilterPaths() {
 
   const idfExists = await dirExistPromise(espIdfPath);
   if (idfExists) {
-    pathsToFilter.push("--filter", join(espIdfPath, "components"));
+    pathsToFilter.push("--filter", join(espIdfPath, "components").replace(/\\/g, "/"));
   }
   const adfExists = await dirExistPromise(espAdfPath);
   if (adfExists) {
-    pathsToFilter.push("--filter", join(espAdfPath, "components"));
+    pathsToFilter.push("--filter", join(espAdfPath, "components").replace(/\\/g, "/"));
   }
   const mdfExists = await dirExistPromise(espMdfPath);
   if (mdfExists) {
-    pathsToFilter.push("--filter", join(espMdfPath, "components"));
+    pathsToFilter.push("--filter", join(espMdfPath, "components").replace(/\\/g, "/"));
   }
   return pathsToFilter;
 }
@@ -83,15 +83,15 @@ export async function buildJson(dirPath: string) {
     "gcovr",
     [
       "--filter",
-      ".",
+      ".*",
       ...componentsDir,
       "--gcov-executable",
       gcovTool,
       "--json",
     ],
-    dirPath
+    dirPath.replace(/\\/g, "/")
   );
-  return JSON.parse(result);
+  return JSON.parse(result); 
 }
 
 export async function buildHtml(dirPath: string) {
@@ -141,20 +141,22 @@ export async function generateCoverageForEditors(
         if (fileParts && fileParts.length > 1) {
           const fileName = fileParts.pop();
           gcovObjFilePath = join(
+            dirPath,
             "build",
             "esp-idf",
             fileParts[fileParts.length - 1],
             "CMakeFiles",
             `__idf_${fileParts[fileParts.length - 1]}.dir`,
             fileName
-          );
+          ).replace(/\\/g, "/");
         }
       }
 
       for (const gcovFile of gcovJsonObj.files) {
+        const gcovFilePath = gcovFile.file as string;
         if (
-          gcovFile.file === gcovObjFilePath ||
-          gcovFile.file === editor.document.fileName
+          gcovFilePath.toLowerCase() === gcovObjFilePath.toLowerCase() ||
+          gcovFilePath.toLowerCase() === editor.document.fileName.replace(/\\/g, "/").toLowerCase()
         ) {
           const coveredEditor: textEditorWithCoverage = {
             allLines: [],

--- a/src/coverage/coverageService.ts
+++ b/src/coverage/coverageService.ts
@@ -61,15 +61,24 @@ export async function getGcovFilterPaths() {
 
   const idfExists = await dirExistPromise(espIdfPath);
   if (idfExists) {
-    pathsToFilter.push("--filter", join(espIdfPath, "components").replace(/\\/g, "/"));
+    pathsToFilter.push(
+      "--filter",
+      join(espIdfPath, "components").replace(/\\/g, "/")
+    );
   }
   const adfExists = await dirExistPromise(espAdfPath);
   if (adfExists) {
-    pathsToFilter.push("--filter", join(espAdfPath, "components").replace(/\\/g, "/"));
+    pathsToFilter.push(
+      "--filter",
+      join(espAdfPath, "components").replace(/\\/g, "/")
+    );
   }
   const mdfExists = await dirExistPromise(espMdfPath);
   if (mdfExists) {
-    pathsToFilter.push("--filter", join(espMdfPath, "components").replace(/\\/g, "/"));
+    pathsToFilter.push(
+      "--filter",
+      join(espMdfPath, "components").replace(/\\/g, "/")
+    );
   }
   return pathsToFilter;
 }
@@ -91,7 +100,7 @@ export async function buildJson(dirPath: string) {
     ],
     dirPath.replace(/\\/g, "/")
   );
-  return JSON.parse(result); 
+  return JSON.parse(result);
 }
 
 export async function buildHtml(dirPath: string) {
@@ -155,8 +164,12 @@ export async function generateCoverageForEditors(
       for (const gcovFile of gcovJsonObj.files) {
         const gcovFilePath = gcovFile.file as string;
         if (
-          gcovFilePath.toLowerCase() === gcovObjFilePath.toLowerCase() ||
-          gcovFilePath.toLowerCase() === editor.document.fileName.replace(/\\/g, "/").toLowerCase()
+          gcovObjFilePath.toLowerCase().indexOf(gcovFilePath.toLowerCase()) !==
+            -1 ||
+          editor.document.fileName
+            .replace(/\\/g, "/")
+            .toLowerCase()
+            .indexOf(gcovFilePath.toLowerCase()) !== -1
         ) {
           const coveredEditor: textEditorWithCoverage = {
             allLines: [],

--- a/src/espIdf/debugAdapter/verifyApp.ts
+++ b/src/espIdf/debugAdapter/verifyApp.ts
@@ -26,6 +26,15 @@ export async function verifyAppBinary(workspaceFolder: string) {
   const modifiedEnv = appendIdfAndToolsToPath();
   const serialPort = readParameter("idf.port");
   const flashBaudRate = readParameter("idf.flashBaudRate");
+  const idfPath = readParameter("idf.espIdfPath");
+  const pythonBinPath = readParameter("idf.pythonBinPath") as string;
+  const esptoolPath = join(
+    idfPath,
+    "components",
+    "esptool_py",
+    "esptool",
+    "esptool.py"
+  );
   const flasherArgsJsonPath = join(
     workspaceFolder,
     "build",
@@ -39,8 +48,9 @@ export async function verifyAppBinary(workspaceFolder: string) {
 
   try {
     const cmdResult = await spawn(
-      "esptool.py",
+      pythonBinPath,
       [
+        esptoolPath,
         "-p",
         serialPort,
         "verify_flash",
@@ -53,9 +63,13 @@ export async function verifyAppBinary(workspaceFolder: string) {
       }
     );
     Logger.info(cmdResult.toString());
-    if (cmdResult.toString().indexOf("verify FAILED (digest mismatch)") !== -1) {
+    if (
+      cmdResult.toString().indexOf("verify FAILED (digest mismatch)") !== -1
+    ) {
       return false;
-    } else if (cmdResult.toString().indexOf("verify OK (digest matched)") !== -1) {
+    } else if (
+      cmdResult.toString().indexOf("verify OK (digest matched)") !== -1
+    ) {
       return true;
     }
     return false;

--- a/src/espIdf/partition-table/partitionFlasher.ts
+++ b/src/espIdf/partition-table/partitionFlasher.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { basename } from "path";
+import { basename, join } from "path";
 import { Progress, ProgressLocation, window, workspace } from "vscode";
 import { readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
@@ -36,10 +36,19 @@ export async function flashBinaryToPartition(offset: string, binPath: string) {
           : "";
         const modifiedEnv = appendIdfAndToolsToPath();
         const serialPort = readParameter("idf.port");
+        const idfPath = readParameter("idf.espIdfPath");
+        const pythonBinPath = readParameter("idf.pythonBinPath") as string;
+        const esptoolPath = join(
+          idfPath,
+          "components",
+          "esptool_py",
+          "esptool",
+          "esptool.py"
+        );
 
         await spawn(
-          "esptool.py",
-          ["-p", serialPort, "write_flash", offset, binPath],
+          pythonBinPath,
+          [esptoolPath, "-p", serialPort, "write_flash", offset, binPath],
           {
             cwd: workspaceFolder,
             env: modifiedEnv,

--- a/src/espIdf/partition-table/tree.ts
+++ b/src/espIdf/partition-table/tree.ts
@@ -212,24 +212,23 @@ export class PartitionTreeDataProvider
   public CSV2JSON(csv: String): PartitionItem[] {
     const rows = new Array<PartitionItem>();
     const lines = csv.split(EOL);
-    const comment = lines.shift();
-    if (!comment.includes("# ESP-IDF Partition Table")) {
+    const matches = csv.match(/#\s*Name,\s*Type,\s*SubType,\s*Offset,\s*Size,\s*Flags/g);
+    if (!matches || !matches.length) {
       console.log("Not a partition table csv, skipping...");
       return rows;
     }
-    const headers = lines.shift();
     lines.forEach((line) => {
-      if (line === "") {
+      if (line === "" || line.startsWith("#")) {
         return;
       }
       const cols = line.split(",");
       rows.push({
-        name: cols.shift(),
-        type: cols.shift(),
-        subtype: cols.shift(),
-        offset: cols.shift(),
-        size: cols.shift(),
-        flag: cols.shift() === "encrypted" ? true : false,
+        name: cols.shift().trim(),
+        type: cols.shift().trim(),
+        subtype: cols.shift().trim(),
+        offset: cols.shift().trim(),
+        size: cols.shift().trim(),
+        flag: cols.shift().trim() === "encrypted" ? true : false,
         error: undefined,
       });
     });

--- a/src/views/partition-table/util.ts
+++ b/src/views/partition-table/util.ts
@@ -103,24 +103,25 @@ export function JSON2CSV(rows: PartitionTable.Row[]): String {
 export function CSV2JSON(csv: String): PartitionTable.Row[] {
   const rows = new Array<PartitionTable.Row>();
   const lines = csv.split(EOL);
-  const comment = lines.shift();
-  if (!comment.includes("# ESP-IDF Partition Table")) {
+  const matches = csv.match(
+    /#\s*Name,\s*Type,\s*SubType,\s*Offset,\s*Size,\s*Flags/g
+  );
+  if (!matches || !matches.length) {
     console.log("Not a partition table csv, skipping...");
     return rows;
   }
-  const headers = lines.shift();
   lines.forEach((line) => {
-    if (line === "") {
+    if (line === "" || line.startsWith("#")) {
       return;
     }
     const cols = line.split(",");
     rows.push({
-      name: cols.shift(),
-      type: cols.shift(),
-      subtype: cols.shift(),
-      offset: cols.shift(),
-      size: cols.shift(),
-      flag: cols.shift() === "encrypted" ? true : false,
+      name: cols.shift().trim(),
+      type: cols.shift().trim(),
+      subtype: cols.shift().trim(),
+      offset: cols.shift().trim(),
+      size: cols.shift().trim(),
+      flag: cols.shift().trim() === "encrypted" ? true : false,
       error: undefined,
     });
   });


### PR DESCRIPTION
`gcovr` only supports forward paths. Fix these on Windows and ignore cases on Windows drives.