### PR TITLE
add setting to enable ccache

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -12,14 +12,15 @@ These are the configuration settings that ESP-IDF extension contributes to your 
 | ------------------------------- | ----------------------------------------------------------------------------- |
 | `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                |
 | `idf.customExtraVars`           | Variables to be added to system environment variables                         |
+| `idf.gitPath`                   | Path to git executable                                                        |
+| `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                     |
+| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                 |
 | `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                   |
 | `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                        |
 | `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts            |
 | `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows |
 | `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                 |
 | `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                      |
-| `idf.gitPath`                   | Path to git executable                                                        |
-| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                 |
 
 This is how the extension uses them:
 
@@ -42,9 +43,9 @@ These settings are specific to the ESP32 Chip/ Board
 | `idf.customAdapterTargetName`                    | Custom target name for ESP-IDF Debug Adapter                        |
 | `idf.flashBaudRate`                              | Flash Baud rate                                                     |
 | `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder |
-| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 | `idf.port`                                       | Path of selected device port                                        |
 | `idf.portWin`                                    | Path of selected device port in Windows                             |
+| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 
 This is how the extension uses them:
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -94,6 +94,7 @@
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
+  "param.enableCCache.title": "Enable CCache in build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -79,6 +79,7 @@
   "param.enableUpdateSrcsToCMakeListsFile": "Habilitar actualización de archivos fuente en CMakeLists.txt",
   "param.launchMonitorOnDebugSession.title": "Iniciar IDF Monitor junto a la sesión ESP-IDF Debug Adapter",
   "param.enableIdfComponentManager.title": "Habilitar IDF Component Manager en construccion de proyecto",
+  "param.enableCCache.title": "Habilitar CCache en construccion de proyecto",
   "param.qemuTcpPort": "QEMU tcp port para comunicación serial",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -79,6 +79,7 @@
   "param.enableUpdateSrcsToCMakeListsFile": "Включить файлы источников обновлений в CMakeLists.txt",
   "param.launchMonitorOnDebugSession.title": "Запустите IDF Monitor вместе с сеансом ESP-IDF Debug Adapter.",
   "param.enableIdfComponentManager.title": "Включить менеджер компонентов IDF в задаче сборки",
+  "param.enableCCache.title": "Включить CCache в задаче сборки",
   "param.qemuTcpPort": "QEMU tcp порт для последовательной связи",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -79,6 +79,7 @@
   "param.enableUpdateSrcsToCMakeListsFile": "启用CMakeLists.txt中的更新源文件",
   "param.launchMonitorOnDebugSession.title": "启动IDF监视器和ESP-IDF调试适配器会话",
   "param.enableIdfComponentManager.title": "在生成任务中启用IDF组件管理器",
+  "param.enableCCache.title": "在生成任务中启用 CCache",
   "param.qemuTcpPort": "用于串行通信的QEMU tcp端口",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",

--- a/package.json
+++ b/package.json
@@ -652,6 +652,11 @@
             "description": "%param.enableIdfComponentManager.title%",
             "default": false
           },
+          "idf.enableCCache": {
+            "type": "boolean",
+            "description": "%param.enableCCache.title%",
+            "default": false
+          },
           "idf.gitPath": {
             "type": "string",
             "description": "%param.gitPath.title%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -94,6 +94,7 @@
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
+  "param.enableCCache.title": "Enable CCache in build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -191,6 +191,7 @@
     "esp_idf.skipVerifyAppBinBeforeDebug.description",
     "param.launchMonitorOnDebugSession.title",
     "param.enableIdfComponentManager.title",
+    "param.enableCCache.title",
     "param.gitPath.title",
     "param.enableUpdateSrcsToCMakeListsFile",
     "param.qemuTcpPort"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -867,6 +867,14 @@ export function appendIdfAndToolsToPath() {
     modifiedEnv.IDF_COMPONENT_MANAGER = "1";
   }
 
+  let enableCCache = idfConf.readParameter(
+    "idf.enableCCache"
+  ) as boolean;
+
+  if (enableCCache) {
+    modifiedEnv.IDF_CCACHE_ENABLE = "1";
+  }
+
   return modifiedEnv;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -867,9 +867,7 @@ export function appendIdfAndToolsToPath() {
     modifiedEnv.IDF_COMPONENT_MANAGER = "1";
   }
 
-  let enableCCache = idfConf.readParameter(
-    "idf.enableCCache"
-  ) as boolean;
+  let enableCCache = idfConf.readParameter("idf.enableCCache") as boolean;
 
   if (enableCCache) {
     modifiedEnv.IDF_CCACHE_ENABLE = "1";


### PR DESCRIPTION
Fix #512 

Add `idf.enableCCache` to enable CCache on the build task.

It could also be done by adding `IDF_CCACHE_ENABLE` to `idf.customExtraVars`.