### PR TITLE
openocd debug level fix esp idf version no git

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -43,9 +43,10 @@ These settings are specific to the ESP32 Chip/ Board
 | `idf.customAdapterTargetName`                    | Custom target name for ESP-IDF Debug Adapter                        |
 | `idf.flashBaudRate`                              | Flash Baud rate                                                     |
 | `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder |
+| `idf.openOcdDebugLevel`                          | Set openOCD debug level (0-4) Default: 2                            |
+| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 | `idf.port`                                       | Path of selected device port                                        |
 | `idf.portWin`                                    | Path of selected device port in Windows                             |
-| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 
 This is how the extension uses them:
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -78,6 +78,7 @@
   "param.uncoveredDarkTheme": "Background color for uncovered lines in Dark theme for ESP-IDF Coverage.",
   "param.enableUpdateSrcsToCMakeListsFile": "Enable update source files in CMakeLists.txt",
   "param.qemuTcpPort": "QEMU tcp port for serial communication",
+  "param.openOcdDebugLevel": "OpenOCD Server debug level",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -81,6 +81,7 @@
   "param.enableIdfComponentManager.title": "Habilitar IDF Component Manager en construccion de proyecto",
   "param.enableCCache.title": "Habilitar CCache en construccion de proyecto",
   "param.qemuTcpPort": "QEMU tcp port para comunicación serial",
+  "param.openOcdDebugLevel": "Nivel de depuracion para servidor OpenOCD",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -81,6 +81,7 @@
   "param.enableIdfComponentManager.title": "Включить менеджер компонентов IDF в задаче сборки",
   "param.enableCCache.title": "Включить CCache в задаче сборки",
   "param.qemuTcpPort": "QEMU tcp порт для последовательной связи",
+  "param.openOcdDebugLevel": "Уровень отладки OpenOCD Server",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -81,6 +81,7 @@
   "param.enableIdfComponentManager.title": "在生成任务中启用IDF组件管理器",
   "param.enableCCache.title": "在生成任务中启用 CCache",
   "param.qemuTcpPort": "用于串行通信的QEMU tcp端口",
+  "param.openOcdDebugLevel": "OpenOCD 服务器调试级别",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -677,6 +677,26 @@
             "description": "%esp.component-manager.url.description%",
             "scope": "resource",
             "default": "https://components.espressif.com"
+          },
+          "idf.openOcdDebugLevel": {
+            "type": "number",
+            "default": 2,
+            "enum": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "enumDescriptions": [
+              "Error",
+              "Warning",
+              "Info",
+              "Debug",
+              "Verbose"
+            ],
+            "scope": "resource",
+            "description": "%param.openOcdDebugLevel%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -78,6 +78,7 @@
   "param.uncoveredDarkTheme": "Background color for uncovered lines in Dark theme for ESP-IDF Coverage.",
   "param.enableUpdateSrcsToCMakeListsFile": "Enable update source files in CMakeLists.txt",
   "param.qemuTcpPort": "QEMU tcp port for serial communication",
+  "param.openOcdDebugLevel": "OpenOCD Server debug level",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -194,6 +194,7 @@
     "param.enableCCache.title",
     "param.gitPath.title",
     "param.enableUpdateSrcsToCMakeListsFile",
-    "param.qemuTcpPort"
+    "param.qemuTcpPort",
+    "param.openOcdDebugLevel"
   ]
 }

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -172,6 +172,11 @@ export class OpenOCDManager extends EventEmitter {
     }
 
     const openOcdArgs = [];
+    const openOcdDebugLevel = idfConf.readParameter(
+      "idf.openOcdDebugLevel"
+    ) as string;
+    openOcdArgs.push(`-d${openOcdDebugLevel}`);
+
     this.openOcdConfigFilesList.forEach((configFile) => {
       openOcdArgs.push("-f");
       openOcdArgs.push(configFile);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2656,7 +2656,7 @@ function creatCmdsStatusBarItems() {
   );
   createStatusBarItem(
     "$(gear)",
-    "ESP-IDF Launch GUI Configuration tool",
+    "ESP-IDF SDK Configuration Editor",
     "espIdf.menuconfig.start",
     100
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -619,15 +619,7 @@ export async function getEspIdfVersion(workingDir: string, gitPath: string) {
     }
     const gitVersion = await checkGitExists(workingDir, gitPath);
     if (!gitVersion || gitVersion === "Not found") {
-      const espIdfVersionFromCmake = await getEspIdfFromCMake(workingDir);
-      if (espIdfVersionFromCmake) {
-        return espIdfVersionFromCmake;
-      }
-      Logger.errorNotify(
-        "Git is not found in current environment",
-        Error("git is not found")
-      );
-      return "x.x";
+      throw new Error("Git is not found in current environment");
     }
     const rawEspIdfVersion = await execChildProcess(
       `${gitPath} describe --tags`,
@@ -648,6 +640,10 @@ export async function getEspIdfVersion(workingDir: string, gitPath: string) {
       return "x.x";
     }
   } catch (error) {
+    const espIdfVersionFromCmake = await getEspIdfFromCMake(workingDir);
+    if (espIdfVersionFromCmake) {
+      return espIdfVersionFromCmake;
+    }
     Logger.info(error);
     return "x.x";
   }


### PR DESCRIPTION
Fix ESP-IDF version when git history is not available in IDF_PATH

Add openOCD debug level as configuration setting.