### PR TITLE
move ccache flag in build task

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,6 +453,8 @@
             "default": [
               "-G",
               "Ninja",
+              "-DPYTHON_DEPS_CHECKED=1",
+              "-DESP_PLATFORM=1",
               ".."
             ],
             "description": "%param.cmakeCompilerArgs%",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -95,7 +95,20 @@ export class BuildTask {
     if (!cmakeCacheExists) {
       const compilerArgs = (idfConf.readParameter(
         "idf.cmakeCompilerArgs"
-      ) as Array<string>) || ["-G", "Ninja", ".."];
+      ) as Array<string>) || [
+        "-G",
+        "Ninja",
+        "-DPYTHON_DEPS_CHECKED=1",
+        "-DESP_PLATFORM=1",
+        "..",
+      ];
+      const enableCCache = idfConf.readParameter("idf.enableCCache") as boolean;
+      if (enableCCache && compilerArgs && compilerArgs.length) {
+        const indexOfCCache = compilerArgs.indexOf("-DCCACHE_ENABLE=1");
+        if (indexOfCCache === -1) {
+          compilerArgs.splice(compilerArgs.length - 1, 0, "-DCCACHE_ENABLE=1");
+        }
+      }
       const compileExecution = this.getShellExecution(compilerArgs, options);
       TaskManager.addTask(
         { type: "esp-idf", command: "ESP-IDF Compile" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ import { OutputChannel } from "./logger/outputChannel";
 import * as utils from "./utils";
 import { PreCheck } from "./utils";
 import {
+  getIdfTargetFromSdkconfig,
   getProjectName,
   initSelectedWorkspace,
   updateIdfComponentsTree,
@@ -250,6 +251,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (PreCheck.isWorkspaceFolderOpen()) {
     workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+    await getIdfTargetFromSdkconfig(
+      workspaceRoot.fsPath,
+      statusBarItems["target"]
+    );
     const coverageOptions = getCoverageOptions();
     covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
   }
@@ -299,6 +304,10 @@ export async function activate(context: vscode.ExtensionContext) {
       for (const ws of e.removed) {
         if (workspaceRoot && ws.uri === workspaceRoot) {
           workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+          await getIdfTargetFromSdkconfig(
+            workspaceRoot.fsPath,
+            statusBarItems["target"]
+          );
           const coverageOptions = getCoverageOptions();
           covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
           break;
@@ -306,6 +315,10 @@ export async function activate(context: vscode.ExtensionContext) {
       }
       if (typeof workspaceRoot === undefined) {
         workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+        await getIdfTargetFromSdkconfig(
+          workspaceRoot.fsPath,
+          statusBarItems["target"]
+        );
         const coverageOptions = getCoverageOptions();
         covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
       }
@@ -614,6 +627,10 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
         workspaceRoot = option.uri;
+        await getIdfTargetFromSdkconfig(
+          workspaceRoot.fsPath,
+          statusBarItems["target"]
+        );
         const projDescPath = path.join(
           workspaceRoot.fsPath,
           "build",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -840,6 +840,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   vscode.workspace.onDidChangeConfiguration((e) => {
+    const winFlag = process.platform === "win32" ? "Win" : "";
     if (e.affectsConfiguration("idf.openOcdConfigs")) {
       const openOcdConfigFilesList = idfConf.readParameter(
         "idf.openOcdConfigs"
@@ -860,13 +861,13 @@ export async function activate(context: vscode.ExtensionContext) {
       } as IDebugAdapterConfig;
       debugAdapterManager.configureAdapter(debugAdapterConfig);
       statusBarItems["target"].text = "$(circuit-board) " + idfTarget;
-    } else if (e.affectsConfiguration("idf.espIdfPath")) {
+    } else if (e.affectsConfiguration("idf.espIdfPath" + winFlag)) {
       ESP.URL.Docs.IDF_INDEX = undefined;
     } else if (e.affectsConfiguration("idf.qemuTcpPort")) {
       qemuManager.configure({
         tcpPort: idfConf.readParameter("idf.qemuTcpPort"),
       } as IQemuOptions);
-    } else if (e.affectsConfiguration("idf.port")) {
+    } else if (e.affectsConfiguration("idf.port" + winFlag)) {
       statusBarItems["port"].text =
         "$(plug) " + idfConf.readParameter("idf.port");
     } else if (e.affectsConfiguration("idf.customAdapterTargetName")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,9 +280,10 @@ export async function copyFromSrcProject(
 
 export function getConfigValueFromSDKConfig(
   key: string,
-  workspacePath: string
+  workspacePath: string,
+  sdkconfigFileName: string = "sdkconfig"
 ): string {
-  const sdkconfigFilePath = path.join(workspacePath, "sdkconfig");
+  const sdkconfigFilePath = path.join(workspacePath, sdkconfigFileName);
   if (!canAccessFile(sdkconfigFilePath, fs.constants.R_OK)) {
     throw new Error("sdkconfig file doesn't exists or can't be read");
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -863,12 +863,6 @@ export function appendIdfAndToolsToPath() {
     modifiedEnv.IDF_COMPONENT_MANAGER = "1";
   }
 
-  let enableCCache = idfConf.readParameter("idf.enableCCache") as boolean;
-
-  if (enableCCache) {
-    modifiedEnv.IDF_CCACHE_ENABLE = "1";
-  }
-
   return modifiedEnv;
 }
 


### PR DESCRIPTION
Using `IDF_CCACHE_ENABLE` only works if calling `idf.py build`. Since we are calling CMake directly, we need to pass `-DCCACHE_ENABLE=1` as an argument.

Fix #512 