### PR TITLE
fixes for save scope on setup using workspace folder

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -43,7 +43,7 @@ The ESP-IDF Debug Adapter settings for launch.json are:
   > **NOTE:** If set to `manual`, openOCD and ESP-IDF Debug Adapter have to be manually executed by the user and the extension will just try to connect to existing servers at configured ports.
 - `name`: The name of the debug launch configuration. This will be shown in the Run view (Menu View -> Run).
 - `type`: Type of debug configuration. It **must** be `espidf`.
-- `skipVerifyAppBinBeforeDebug`: By default before starting the debug session, the extension will verify that the current workspace folder `build/${project-name}.bin` is the same of the target device application. `${project-name}` is the name of the project (i.e blink) and is obtained from the `build/project_description.json`. Set this to `true` to skip application binary validation before debug session.
+- `skipVerifyAppBinBeforeDebug`: (Default `true`) If disabled the extension will verify that the current workspace folder `build/${project-name}.bin` is the same of the target device application. `${project-name}` is the name of the project (i.e blink) and is obtained from the `build/project_description.json`. Set this to `false` to add application binary validation before debug session.
 
 If `gdbinitFile` or `initGdbCommands` are defined in launch.json, make sure to include the following commands for debug session to properly work as shown in [JTAG Debugging debugging with command line](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/using-debugger.html#command-line).
 

--- a/package.json
+++ b/package.json
@@ -553,7 +553,6 @@
               "Workspace",
               "WorkspaceFolder"
             ],
-            "scope": "resource",
             "description": "%param.saveScope%"
           },
           "idf.telemetry": {
@@ -652,26 +651,31 @@
           "idf.enableIdfComponentManager": {
             "type": "boolean",
             "description": "%param.enableIdfComponentManager.title%",
+            "scope": "resource",
             "default": false
           },
           "idf.enableCCache": {
             "type": "boolean",
             "description": "%param.enableCCache.title%",
+            "scope": "resource",
             "default": false
           },
           "idf.gitPath": {
             "type": "string",
             "description": "%param.gitPath.title%",
+            "scope": "resource",
             "default": "git"
           },
           "idf.enableUpdateSrcsToCMakeListsFile": {
             "type": "boolean",
             "description": "%param.enableUpdateSrcsToCMakeListsFile%",
+            "scope": "resource",
             "default": true
           },
           "idf.qemuTcpPort": {
             "type": "number",
             "description": "%param.qemuTcpPort%",
+            "scope": "resource",
             "default": 5555
           },
           "esp.component-manager.url": {
@@ -1063,7 +1067,7 @@
               "skipVerifyAppBinBeforeDebug": {
                 "type": "boolean",
                 "description": "%esp_idf.skipVerifyAppBinBeforeDebug.description%",
-                "default": false
+                "default": true
               }
             }
           }

--- a/src/espIdf/nvs/partitionTable/panel.ts
+++ b/src/espIdf/nvs/partitionTable/panel.ts
@@ -17,7 +17,7 @@
  */
 import { basename, dirname, join } from "path";
 import * as vscode from "vscode";
-import { constants, readFile, writeFile } from "fs-extra";
+import { constants, pathExists, readFile, writeFile } from "fs-extra";
 import { Logger } from "../../../logger/logger";
 import * as idfConf from "../../../idfConfiguration";
 import { canAccessFile, execChildProcess } from "../../../utils";
@@ -93,6 +93,10 @@ export class NVSPartitionTable {
 
   private async getCSVFromFile(filePath: string) {
     try {
+      const fileExists = await pathExists(filePath);
+      if (!fileExists) {
+        return;
+      }
       let csvContent: string = "";
       if (filePath && filePath.endsWith(".csv")) {
         csvContent = await readFile(filePath, "utf-8");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2342,6 +2342,7 @@ export async function activate(context: vscode.ExtensionContext) {
                   type: "espidf",
                   request: "launch",
                   sessionID: "core-dump.debug.session.ws",
+                  skipVerifyAppBinBeforeDebug: true
                 });
                 vscode.debug.onDidTerminateDebugSession((session) => {
                   if (
@@ -2380,6 +2381,7 @@ export async function activate(context: vscode.ExtensionContext) {
             type: "espidf",
             request: "launch",
             sessionID: "gdbstub.debug.session.ws",
+            skipVerifyAppBinBeforeDebug: true
           });
           vscode.debug.onDidTerminateDebugSession((session) => {
             if (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2342,7 +2342,7 @@ export async function activate(context: vscode.ExtensionContext) {
                   type: "espidf",
                   request: "launch",
                   sessionID: "core-dump.debug.session.ws",
-                  skipVerifyAppBinBeforeDebug: true
+                  skipVerifyAppBinBeforeDebug: true,
                 });
                 vscode.debug.onDidTerminateDebugSession((session) => {
                   if (
@@ -2381,7 +2381,7 @@ export async function activate(context: vscode.ExtensionContext) {
             type: "espidf",
             request: "launch",
             sessionID: "gdbstub.debug.session.ws",
-            skipVerifyAppBinBeforeDebug: true
+            skipVerifyAppBinBeforeDebug: true,
           });
           vscode.debug.onDidTerminateDebugSession((session) => {
             if (

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -56,7 +56,6 @@ export function readParameter(
 }
 
 export async function chooseConfigurationTarget() {
-  const previousTarget = readParameter("idf.saveScope");
   const confTarget = await vscode.window.showQuickPick(
     [
       {
@@ -78,9 +77,13 @@ export async function chooseConfigurationTarget() {
     { placeHolder: "Where to save the configuration?" }
   );
   if (!confTarget) {
-    return previousTarget || vscode.ConfigurationTarget.Global;
+    return;
   }
-  await writeParameter("idf.saveScope", confTarget.target, previousTarget);
+  await writeParameter(
+    "idf.saveScope",
+    confTarget.target,
+    vscode.ConfigurationTarget.Global
+  );
   return confTarget.target;
 }
 
@@ -148,7 +151,13 @@ export async function updateConfParameter(
     Logger.warnNotify(noWsOpenMSg);
     throw new Error(noWsOpenMSg);
   }
-  await writeParameter(confParamName, valueToWrite, target);
+  let workspaceFolder: vscode.WorkspaceFolder;
+  if (target === vscode.ConfigurationTarget.WorkspaceFolder) {
+    workspaceFolder = await vscode.window.showWorkspaceFolderPick({
+      placeHolder: `Pick Workspace Folder to which settings should be applied`,
+    });
+  }
+  await writeParameter(confParamName, valueToWrite, target, workspaceFolder);
   const updateMessage = locDic.localize(
     "idfConfiguration.hasBeenUpdated",
     " has been updated"

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ConfigurationTarget, Progress, window } from "vscode";
+import { ConfigurationTarget, Progress, window, WorkspaceFolder } from "vscode";
 import { IdfToolsManager, IEspIdfTool } from "../idfToolsManager";
 import * as utils from "../utils";
 import { getEspIdfVersions } from "./espIdfVersionList";
@@ -344,15 +344,47 @@ export async function saveSettings(
   const confTarget = idfConf.readParameter(
     "idf.saveScope"
   ) as ConfigurationTarget;
-  await idfConf.writeParameter("idf.espIdfPath", espIdfPath, confTarget);
-  await idfConf.writeParameter("idf.pythonBinPath", pythonBinPath, confTarget);
-  await idfConf.writeParameter("idf.toolsPath", toolsPath, confTarget);
+  let workspaceFolder: WorkspaceFolder;
+  if (confTarget === ConfigurationTarget.WorkspaceFolder) {
+    workspaceFolder = await window.showWorkspaceFolderPick({
+      placeHolder: `Pick Workspace Folder to which settings should be applied`,
+    });
+  }
+  await idfConf.writeParameter(
+    "idf.espIdfPath",
+    espIdfPath,
+    confTarget,
+    workspaceFolder
+  );
+  await idfConf.writeParameter(
+    "idf.pythonBinPath",
+    pythonBinPath,
+    confTarget,
+    workspaceFolder
+  );
+  await idfConf.writeParameter(
+    "idf.toolsPath",
+    toolsPath,
+    confTarget,
+    workspaceFolder
+  );
   await idfConf.writeParameter(
     "idf.customExtraPaths",
     exportedPaths,
-    confTarget
+    confTarget,
+    workspaceFolder
   );
-  await idfConf.writeParameter("idf.customExtraVars", exportedVars, confTarget);
-  await idfConf.writeParameter("idf.gitPath", gitPath, confTarget);
+  await idfConf.writeParameter(
+    "idf.customExtraVars",
+    exportedVars,
+    confTarget,
+    workspaceFolder
+  );
+  await idfConf.writeParameter(
+    "idf.gitPath",
+    gitPath,
+    confTarget,
+    workspaceFolder
+  );
   window.showInformationMessage("ESP-IDF has been configured");
 }

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -110,6 +110,9 @@ export async function getIdfTargetFromSdkconfig(
         sdkconfigToUse
       )
       .replace(/\"/g, "");
+    if (!idfTarget) {
+      return;
+    }
     const target = readParameter("idf.saveScope");
     await writeParameter("idf.adapterTargetName", idfTarget, target);
     statusItem.text = "$(circuit-board) " + idfTarget;


### PR DESCRIPTION
Fixes for `idf.saveScope` calling multiple times when setup wizard is saving settings using workspace folder scope target.

IF sdkconfig doesn't have IDF_TARGET ignore.

Fix idf.gitPath scope issue and `skipVerifyAppBinBeforeDebug ` as true for default.