### PR TITLE
fix docs links and show prerequisites link in setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,16 @@ Make sure to review our [documentation](./docs/ONBOARDING.md) first to properly 
 
 # Prerequisites
 
-There are few dependencies required in your system and available in environment variable PATH before installing this extension:
+There are few dependencies required in your system and available in environment variable PATH before installing this extension. Please review [ESP-IDF Prerequisites](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-1-install-prerequisites) documentation.
 
 | Linux                                                        | MacOS                                                        | Windows                                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [Python 3.5](https://www.python.org/download/releases/3.5/)+ | [Python 3.5](https://www.python.org/download/releases/3.5/)+ | [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools) |
-| [PIP](https://pip.pypa.io/en/stable/installing/)             | [PIP](https://pip.pypa.io/en/stable/installing/)             |                                                                              |
+| [Python 3.5](https://www.python.org/downloads/)+             | [Python 3.5](https://www.python.org/downloads/)+             | [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools) |
+| [PIP](https://pip.pypa.io/en/stable/installation/)           | [PIP](https://pip.pypa.io/en/stable/installation/)           |                                                                              |
 | [Git](https://git-scm.com/downloads)                         | [Git](https://git-scm.com/downloads)                         |                                                                              |
 | [CMake](https://cmake.org/download)                          | [CMake](https://cmake.org/download)                          |                                                                              |
 | [Ninja-build](https://github.com/ninja-build/ninja/releases) | [Ninja-build](https://github.com/ninja-build/ninja/releases) |                                                                              |
 
-Please review [ESP-IDF Prerequisites](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-1-install-prerequisites).
 
 All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using the **ESP-IDF: Configure ESP-IDF extension** setup wizard or following the steps in the [setup documentation](./docs/SETUP.md).
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,9 @@ Make sure to review our [documentation](./docs/ONBOARDING.md) first to properly 
 
 There are few dependencies required in your system and available in environment variable PATH before installing this extension. Please review [ESP-IDF Prerequisites](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-1-install-prerequisites) documentation.
 
-| Linux                                                        | MacOS                                                        | Windows                                                                      |
-| ------------------------------------------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [Python 3.5](https://www.python.org/downloads/)+             | [Python 3.5](https://www.python.org/downloads/)+             | [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools) |
-| [PIP](https://pip.pypa.io/en/stable/installation/)           | [PIP](https://pip.pypa.io/en/stable/installation/)           |                                                                              |
-| [Git](https://git-scm.com/downloads)                         | [Git](https://git-scm.com/downloads)                         |                                                                              |
-| [CMake](https://cmake.org/download)                          | [CMake](https://cmake.org/download)                          |                                                                              |
-| [Ninja-build](https://github.com/ninja-build/ninja/releases) | [Ninja-build](https://github.com/ninja-build/ninja/releases) |                                                                              |
-
+* Requirements for [Linux](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html#install-prerequisites)
+* Requirements for [MacOS](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html#install-prerequisites)
+* For Windows the [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools) might be required.
 
 All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using the **ESP-IDF: Configure ESP-IDF extension** setup wizard or following the steps in the [setup documentation](./docs/SETUP.md).
 
@@ -62,10 +57,7 @@ All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using
 
   > **NOTE:** Please take a look at [SETUP](./docs/SETUP.md) documentation or the [Install](./docs/tutorial/install.md) tutorial for details about extension configuration.
 
-- Press <kbd>F1</kbd> and type 
-  * **ESP-IDF: Show Examples Projects** to create from ESP-IDF examples.
-  * **ESP-IDF: Create project from extension template** to generate a template ESP-IDF project
-  * **ESP-IDF: New Project** to open the new project wizard and choose one of the examples as template or a boilerplate project.
+- Press <kbd>F1</kbd> and type **ESP-IDF: Show Examples Projects** to create a new project from ESP-IDF examples.
 
 - Configure the `.vscode/c_cpp_properties.json` as explained in [C/C++ Configuration](./docs/C_CPP_CONFIGURATION.md). There is a default configuration that should work but you might want to modify it to your needs.
 
@@ -78,7 +70,7 @@ All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using
 - Flash to your device by pressing <kbd>F1</kbd> and typing **ESP-IDF: Flash your device** then selecting Flash allows you to flash the device.
 - You can later start a monitor by pressing <kbd>F1</kbd> and typing **ESP-IDF: Monitor your device** which will log the device activity in a Visual Studio Code terminal.
 - To make sure you can debug your device, select the your board by pressing <kbd>F1</kbd> and typing **ESP-IDF: Select OpenOCD Board Configuration** or manually define the openOCD configuration files with `idf.openOcdConfigs` configuration in your settings.json.
-- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly). 
+- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly).
 
 # Available commands
 

--- a/README.md
+++ b/README.md
@@ -62,18 +62,23 @@ All the other dependencies like ESP-IDF and ESP-IDF Tools can be installed using
 
   > **NOTE:** Please take a look at [SETUP](./docs/SETUP.md) documentation or the [Install](./docs/tutorial/install.md) tutorial for details about extension configuration.
 
-- Press <kbd>F1</kbd> and type **ESP-IDF: Create project from extension template** to generate a template ESP-IDF project or **ESP-IDF: Show Examples Projects** to create from ESP-IDF examples.
+- Press <kbd>F1</kbd> and type 
+  * **ESP-IDF: Show Examples Projects** to create from ESP-IDF examples.
+  * **ESP-IDF: Create project from extension template** to generate a template ESP-IDF project
+  * **ESP-IDF: New Project** to open the new project wizard and choose one of the examples as template or a boilerplate project.
 
-- Configure the `.vscode/c_cpp_properties.json` as explained in [C/C++ Configuration](./docs/C_CPP_CONFIGURATION.md).
+- Configure the `.vscode/c_cpp_properties.json` as explained in [C/C++ Configuration](./docs/C_CPP_CONFIGURATION.md). There is a default configuration that should work but you might want to modify it to your needs.
 
-  > **Note:** If you want to get code navigation and ESP-IDF function references, the [Microsoft C/C++ Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) can be used to resolve header/source links. By default, projects created with **ESP-IDF: Create project from extension template** or **ESP-IDF: Show Examples Projects** tries to resolve headers by manually recursing ESP-IDF directory sources with the Tag Parser engine. This can be optimized by building the project first and configure your project to use `build/compile_commands.json` as explained in [C/C++ Configuration](./docs/C_CPP_CONFIGURATION.md).
+  > **Note:** If you want to get code navigation and ESP-IDF function references, the [Microsoft C/C++ Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) can be used to resolve header/source links. By default, projects created with **ESP-IDF: Create project from extension template** or **ESP-IDF: Show Examples Projects** tries to resolve headers by manually recursing ESP-IDF directory sources with the `Tag Parser` engine. This can be optimized by building the project first and configure your project to use `build/compile_commands.json` as explained in [C/C++ Configuration](./docs/C_CPP_CONFIGURATION.md).
 
 - Do some coding!
 - Check you set the correct port of your device by pressing <kbd>F1</kbd>, typing **ESP-IDF: Select port to use:** and choosing the serial port your device is connected.
-- Select an Espressif target (esp32, esp32s2, etc.) with the **ESP-IDF: Set Espressif device target** command.
-- When you are ready, build your project. Then flash to your device by pressing <kbd>F1</kbd> and typing **ESP-IDF: Flash your device** then selecting Flash allows you to flash the device.
-- You can later start a monitor by pressing <kbd>F1</kbd> and typing **ESP-IDF: Monitor your device** which will log the activity in a Visual Studio Code terminal.
-- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly). To make sure you can debug your device, set the proper `idf.openOcdConfigs` settings in your settings.json or by pressing <kbd>F1</kbd> and typing **ESP-IDF: Device configuration**.
+- Select an Espressif target (esp32, esp32s2, etc.) with the **ESP-IDF: Set Espressif device target** command. If you are using one of our boards, use the **ESP-IDF: Select OpenOCD Board Configuration** to choose the openOCD configuration files for the extension openOCD server.
+- When you are ready, build your project by pressing <kbd>F1</kbd> and typing **ESP-IDF: Build your project**.
+- Flash to your device by pressing <kbd>F1</kbd> and typing **ESP-IDF: Flash your device** then selecting Flash allows you to flash the device.
+- You can later start a monitor by pressing <kbd>F1</kbd> and typing **ESP-IDF: Monitor your device** which will log the device activity in a Visual Studio Code terminal.
+- To make sure you can debug your device, select the your board by pressing <kbd>F1</kbd> and typing **ESP-IDF: Select OpenOCD Board Configuration** or manually define the openOCD configuration files with `idf.openOcdConfigs` configuration in your settings.json.
+- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly). 
 
 # Available commands
 
@@ -133,11 +138,11 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 
 2. You can also use the **ESP-IDF: Create project from extension template** command with `arduino-as-component` template to create a new project directory that includes Arduino-ESP32 as an ESP-IDF component.
 
-3. The **Install ESP-ADF** will clone ESP-ADF to a selected directory and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows) configuration setting.
+3. The **Install ESP-ADF** will clone ESP-ADF inside the selected directory and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows) configuration setting.
 
-4. The **Install ESP-MDF** will clone ESP-MDF to a selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
+4. The **Install ESP-MDF** will clone ESP-MDF inside the selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
 
-5. The **Show Examples Projects** command allows you create a new project using one of the examples in ESP-IDF, ESP-ADF or ESP-MDF directory if related configuration settings are set.
+5. The **Show Examples Projects** command allows you create a new project using one of the examples in ESP-IDF, ESP-ADF or ESP-MDF directory if related configuration settings are correctly defined.
 
 # Commands for tasks.json and launch.json
 
@@ -174,6 +179,8 @@ Note that for OpenOCD tasks you need to define `OPENOCD_SCRIPTS` in your system 
 # Troubleshooting
 
 If something is not working please check for any error on one of these:
+
+> **NOTE:** Use `idf.openOcdDebugLevel` to 3 or more to show debug logging in OpenOCD server output.
 
 1. In Visual Studio Code select menu "View" -> Output -> ESP-IDF, ESP-IDF Debug Adapter, Heap Trace, OpenOCD and SDK Configuration Editor.
 2. Use the `ESP-IDF: Doctor command` to generate a report of your configuration and it will be copied in your clipboard to paste anywhere.

--- a/docs/C_CPP_CONFIGURATION.md
+++ b/docs/C_CPP_CONFIGURATION.md
@@ -41,7 +41,7 @@ An example configuration that should work with most projects is shown below.
 }
 ```
 
-  > **NOTE:** When you create a project using the extension commands such as `Show Examples Projects`, `New Project`, `Create project from extension template` or you add the configuration files to an existing project using the `Add vscode configuration folder`, this file is created with the compilerPath of the configured toolchain for your current `idf.adapterTargetName`.
+> **NOTE:** When you create a project using the extension commands such as `Show Examples Projects`, `New Project`, `Create project from extension template` or you add the configuration files to an existing project using the `Add vscode configuration folder`, this file is created with the compilerPath of the configured toolchain for your current `idf.adapterTargetName`.
 
 ## Configuration with compile_commands.json
 

--- a/docs/C_CPP_CONFIGURATION.md
+++ b/docs/C_CPP_CONFIGURATION.md
@@ -18,7 +18,7 @@ An example configuration that should work with most projects is shown below.
 {
   "configurations": [
     {
-      "name": "Linux",
+      "name": "ESP-IDF",
       "cStandard": "c11",
       "cppStandard": "c++17",
       "includePath": [
@@ -33,12 +33,15 @@ An example configuration that should work with most projects is shown below.
           "${workspaceFolder}"
         ],
         "limitSymbolsToIncludedHeaders": false
-      }
+      },
+      "compilerPath": "/path/to/toolchain-gcc"
     }
   ],
   "version": 4
 }
 ```
+
+  > **NOTE:** When you create a project using the extension commands such as `Show Examples Projects`, `New Project`, `Create project from extension template` or you add the configuration files to an existing project using the `Add vscode configuration folder`, this file is created with the compilerPath of the configured toolchain for your current `idf.adapterTargetName`.
 
 ## Configuration with compile_commands.json
 
@@ -48,7 +51,7 @@ For this configuration, you must build your project beforehand in order to gener
 {
   "configurations": [
     {
-      "name": "Linux",
+      "name": "ESP-IDF",
       "cStandard": "c11",
       "cppStandard": "c++17",
       "compileCommands": "${workspaceFolder}/build/compile_commands.json"

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -69,7 +69,7 @@ Example launch.json for ESP-IDF Debug Adapter:
       "debugPort": 9998,
       "logLevel": 2,
       "mode": "manual",
-      "skipVerifyAppBinBeforeDebug": false,
+      "skipVerifyAppBinBeforeDebug": true,
       "initGdbCommands": [
         "target remote :3333",
         "symbol-file /path/to/program.elf",

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -25,7 +25,7 @@ To install from `.vsix` file:
 
 - Install [Node.js](https://nodejs.org/en/)
 - Make sure have the [C/C++ Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) from Visual Studio Code Marketplace.
-- Clone this repository `git clone https://github.com/espressif/vscode-esp-idf-extension.git`
+- Clone this repository `git clone --recursive https://github.com/espressif/vscode-esp-idf-extension.git`
 - Install all the dependencies, using `yarn`
 - Press <kbd>F5</kbd> to Run with Debugger, this will launch a new VSCode Extension Development Host to debug the extension.
 - Build the Visual Studio Code extension setup with `yarn package`.
@@ -42,7 +42,7 @@ To install from `.vsix` file:
 - Click Uninstall.
 - Go to your `${VSCODE_EXTENSION_DIR}` and make sure to delete the Espressif IDF plugin folder
 
-`${VSCODE_EXTENSION_DIR}` is the location of the extension
+`${VSCODE_EXTENSION_DIR}` is the location of the extension:
 
 - Windows: `%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\`
 - Linux & MacOSX: `$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/`

--- a/docs/LANG_CONTRIBUTE.md
+++ b/docs/LANG_CONTRIBUTE.md
@@ -1,6 +1,6 @@
 # Language contribution guidelines
 
-Make sure you install the source code version of this extension by following [Source Mode](README.md#Source-Mode).
+Make sure you install the source code version of this extension by following [Source Mode](./INSTALL.md#Build-from-Source-Code).
 
 Inside i18n folder, create a sub-directory using the language code name as specified by [ISO 639-3](https://en.wikipedia.org/wiki/ISO_639-3) convention.
 
@@ -37,4 +37,4 @@ Test your contribution by changing Visual Studio Code locale:
 - Pressing F1 and run the `Configure Display Language` command.
 - Or manually modify `locale.json` in your Visual Studio Code User Settings.
 
-Make a pull request with your contribution, please follow the [Code of Conduct](CODE_OF_CONDUCT.md) while creating a pull request.
+Make a pull request with your contribution, please follow the [Code of Conduct](./CODE_OF_CONDUCT.md) while creating a pull request.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -52,14 +52,14 @@ Setup wizard provides 3 choices:
 
 After choosing any of the previous options, a status page is displayed showing ESP-IDF, tools and python environment setup progress status. When the setup is finished, a message is shown that "All settings have been configured. You can close this window."
 
-> **NOTE:** Check the [troubleshooting](../../README.md#Troubleshooting) section if you have any issue.
+> **NOTE:** Check the [troubleshooting](../README.md#Troubleshooting) section if you have any issue.
 
 # JSON Manual Configuration
 
-The user can manually configure the extension by setting the following configuration settings with corresponding values. Please take a look at [Configuration settings](./docs/SETTINGS.md) for more information.
+The user can manually configure the extension by setting the following configuration settings with corresponding values. Please take a look at [Configuration settings](./SETTINGS.md) for more information.
 
 1. With Visual Studio Code Command Palette (F1 or View Menu -> Command Palette) and type **Preferences: Open Settings (JSON)**. This will open the user global settings for Visual Studio Code.
-   > **NOTE:** The user could choose to modify its workspace settings.json for a workspace limited configuration or a project limited configuration in the project's `.vscode/settings.json`. Please take a look at [Working with multiple projects](./docs/MULTI_PROJECTS.md).
+   > **NOTE:** The user could choose to modify its workspace settings.json for a workspace limited configuration or a project limited configuration in the project's `.vscode/settings.json`. Please take a look at [Working with multiple projects](./MULTI_PROJECTS.md).
 2. Your settings.json should look like:
 
 MacOS/Linux

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -18,7 +18,7 @@ sudo apt-get install git wget flex bison gperf python3-pip python3-venv python3-
 
 > **NOTE:** The user might need to install/update pip in the virtual environment like: `$IDF_TOOLS_PATH/python_env/idfX.X_pyX.X_env/bin/python ./get-pip.py` where X.X are IDF and python major-minor versions respectively.
 
-2. Configure the extension as explained in [SETUP](./SETUP.md) documentation or the [Install](./docs/tutorial/install.md) tutorial.
+2. Configure the extension as explained in [SETUP](./SETUP.md) documentation or the [Install](./tutorial/install.md) tutorial.
 
    > **NOTE:** Running the setup from WSL could override the Windows host machine configuration settings since it is using the User Settings by default. Consider saving settings to a workspace or workspace folder as described in the [working with multiple projects document](./MULTI_PROJECTS.md).
 

--- a/docs/tutorial/cmakelists_editor.md
+++ b/docs/tutorial/cmakelists_editor.md
@@ -9,7 +9,7 @@ You need to choose which kind of CMakeLists.txt file (project or component) to e
 
 > **NOTE:** All inputs are described in the [CMakeLists.txt schema](../../cmakeListsSchema.json).
 
-> **NOTE** This editor doesn't support all CMake functions and syntaxes. This editor should only be used for simple CMakeLists.txt options such as component registration (using idf_component_register) and basic project elements. If you need more customization or advanced CMakeLists.txt, consider reviewing [ESP-IDF Build System](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html). Also review [CMakeLists.txt editor schema](../cmakeListsSchema.json) for a list of supported code.
+> **NOTE** This editor doesn't support all CMake functions and syntaxes. This editor should only be used for simple CMakeLists.txt options such as component registration (using idf_component_register) and basic project elements. If you need more customization or advanced CMakeLists.txt, consider reviewing [ESP-IDF Build System](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html). Also review [CMakeLists.txt editor schema](../../cmakeListsSchema.json) for a list of supported code.
 
 **THIS WILL OVERRIDE ANY EXISTING CODE IN THE FILE WITH THE ONE GENERATED IN THE EDITOR. IF YOU HAVE ANY CODE NOT INCLUDED IN THE [SCHEMA](../../cmakeListsSchema.json) (OR SINGLE LINE COMMENTS) USE A REGULAR TEXT EDITOR INSTEAD**
 

--- a/docs/tutorial/debugging.md
+++ b/docs/tutorial/debugging.md
@@ -24,9 +24,9 @@ Several steps will be automatically done for you but explained for clarity. You 
 
 > **NOTE:** The user can start or stop the openOCD from Visual Studio Code using the **ESP-IDF: OpenOCD Manager** command or from the `OpenOCD Server (Running | Stopped)` button in the visual studio code status bar.
 
-> **NOTE:** The user can modify `openocd.tcl.host` and `openocd.tcl.port` configuration settings to modify these values. Please review [ESP-IDF Settings](../SETTINGS.md) to see how to modify these configuration settings.
+> **NOTE:** The user can modify `openocd.tcl.host` and `openocd.tcl.port` configuration settings to modify these values. You can also set `idf.openOcdDebugLevel` to lower or increase (0-4) the messages from OpenOCD in the OpenOCD output. Please review [ESP-IDF Settings](../SETTINGS.md) to see how to modify these configuration settings.
 
-5. The ESP-IDF Debug adapter server is launched in the background and the output is shown in menu View -> Output -> `ESP-IDF Debug Adapter`. This server is a proxy between Visual Studio Code, configured toolchain GDB and OpenOCD server. It will be launched at port 43474 by default. Please review [DEBUGGING](../DEBUGGING.md) for more information how to customize the debugging behavior like application offset, logging level and set your own gdb startup commands.
+5. The [ESP-IDF Debug adapter](https://github.com/espressif/esp-debug-adapter) server is launched in the background and the output is shown in menu View -> Output -> `ESP-IDF Debug Adapter`. This server is a proxy between Visual Studio Code, configured toolchain GDB and OpenOCD server. It will be launched at port `43474` by default. Please review [DEBUGGING](../DEBUGGING.md) for more information how to customize the debugging behavior like application offset, logging level and set your own gdb startup commands.
 
 6. The debug session will start after the debug adapter server is launched and ready.
 

--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -12,7 +12,7 @@
   <img src="../../media/tutorials/setup/install-extension.png" alt="Setup wizard">
 </p>
 
-6. (OPTIONAL) Press <kbd>F1</kbd> and type **ESP-IDF: Select where to save configuration settings**, which can be User settings, Workspace settings or workspace folder settings. Please take a look at [Working with multiple projects](./MULTI_PROJECTS.md) for more information. Default is User settings.
+6. (OPTIONAL) Press <kbd>F1</kbd> and type **ESP-IDF: Select where to save configuration settings**, which can be User settings, Workspace settings or workspace folder settings. Please take a look at [Working with multiple projects](../MULTI_PROJECTS.md) for more information. Default is User settings.
 7. In Visual Studio Code, select menu "View" and "Command Palette" and type [configure esp-idf extension]. After, choose the **ESP-IDF: Configure ESP-IDF extension** option.
 8. Now the setup wizard window will be shown with several setup options: **Express**, **Advanced** or **Use existing setup**.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,8 @@ function clean(done) {
     "report.json",
     "report.txt",
     "testing.results.log",
+    "esp_idf_vsc_ext.log",
+    "esp_idf_docs_*.json"
   ]);
   done();
 }

--- a/package.json
+++ b/package.json
@@ -664,7 +664,7 @@
             "type": "string",
             "description": "%param.gitPath.title%",
             "scope": "resource",
-            "default": "git"
+            "default": "/usr/bin/git"
           },
           "idf.enableUpdateSrcsToCMakeListsFile": {
             "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1618,6 +1618,11 @@ export async function activate(context: vscode.ExtensionContext) {
         selectedBoard.target.configFiles,
         target
       );
+      await idfConf.writeParameter(
+        "idf.adapterTargetName",
+        selectedBoard.target.target,
+        target
+      );
       Logger.infoNotify("OpenOCD Board configuration files are updated.");
     } catch (error) {
       const errMsg =

--- a/src/setup/espIdfDownload.ts
+++ b/src/setup/espIdfDownload.ts
@@ -106,7 +106,7 @@ export async function downloadInstallIdfVersion(
       pkgProgress,
       cancelToken
     );
-    const downloadedMsg = `Downloaded ${idfVersion.name}.\n`;
+    const downloadedMsg = `Downloaded ${idfVersion.name}. Extracting...\n`;
     OutputChannel.appendLine(downloadedMsg);
     Logger.info(downloadedMsg);
     sendDownloadedZip(downloadedZipPath);

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -61,7 +61,7 @@ export async function checkPreviousInstall(
 
   const espIdfJsonPath = path.join(toolsPath, "esp_idf.json");
   const espIdfJsonExists = await pathExists(espIdfJsonPath);
-  let gitPath = idfConf.readParameter("idf.gitPath") || "git";
+  let gitPath = idfConf.readParameter("idf.gitPath") || "/usr/bin/git";
   if (espIdfJsonExists) {
     const idfInstalled = await getSelectedIdfInstalled(toolsPath);
     if (idfInstalled && idfInstalled.path && idfInstalled.python) {
@@ -78,7 +78,7 @@ export async function checkPreviousInstall(
     }
   }
 
-  const gitVersion = await utils.checkGitExists(toolsPath, gitPath);
+  const gitVersion = await utils.checkGitExists(containerPath, gitPath);
 
   let idfPathVersion = await utils.getEspIdfVersion(espIdfPath, gitPath);
   if (idfPathVersion === "x.x" && process.platform === "win32") {
@@ -274,11 +274,12 @@ export async function getSetupInitialValues(
         process.env
       );
       setupInitArgs.hasPrerequisites =
-        prevInstall.gitVersion !== "" &&
+        prevInstall.gitVersion !== "Not found" &&
         canAccessCMake !== "" &&
-        canAccessNinja !== "";
+        canAccessNinja !== "" &&
+        pythonVersions && pythonVersions.length > 0;
     } else {
-      setupInitArgs.hasPrerequisites = prevInstall.gitVersion !== "";
+      setupInitArgs.hasPrerequisites = prevInstall.gitVersion !== "Not found";
     }
     progress.report({ increment: 20, message: "Preparing setup view..." });
     if (prevInstall) {

--- a/src/support/espIdfVersion.ts
+++ b/src/support/espIdfVersion.ts
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { getEspIdfFromCMake } from "../utils";
 import { execChildProcess } from "./execChildProcess";
 import { reportObj } from "./types";
 
@@ -40,6 +41,11 @@ export async function getEspIdfVersion(reportedResult: reportObj) {
       reportedResult.espIdfVersion.result = "Not found";
     }
   } catch (error) {
+    const espIdfVersionFromCmake = await getEspIdfFromCMake(reportedResult.configurationSettings.espIdfPath);
+    if (espIdfVersionFromCmake) {
+      reportedResult.espIdfVersion.result = espIdfVersionFromCmake;
+      return;
+    }
     reportedResult.espIdfVersion.result = "Not found";
     reportedResult.latestError = error;
   }

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -83,7 +83,7 @@ suite("Doctor command tests", () => {
   test("Wrong version of ESP-IDF", async () => {
     reportObj.configurationSettings.espIdfPath = "/some/non-existing-path";
     await getEspIdfVersion(reportObj);
-    assert.equal(reportObj.espIdfVersion.result, "Not found");
+    assert.equal(reportObj.espIdfVersion.result, "x.x");
   });
 
   test("Wrong access to Python path", () => {

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -20,7 +20,21 @@
     </div>
     <div class="centerize notification" v-if="hasPrerequisites">
       <div class="control centerize home-title">
-        <h1 class="title is-spaced">Welcome to the extension setup</h1>
+        <h1 class="title is-spaced">Welcome.</h1>
+        <p v-if="platform !== 'win32'">
+          First, install the
+          <a
+            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html"
+            v-if="platform === 'darwin'"
+            >ESP-IDF Prerequisites for MacOS</a
+          >
+          <a
+            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html"
+            v-if="platform === 'linux'"
+            >ESP-IDF Prerequisites for Linux</a
+          >,
+        </p>
+        <p>restart Visual Studio Code and run this setup again.</p>
         <h2 class="subtitle">Choose a setup mode.</h2>
       </div>
       <div
@@ -83,6 +97,7 @@ export default class Home extends Vue {
   @State("toolsFolder") private storeToolsFolder: string;
   @State("espIdf") private storeEspIdf: string;
   @State("pathSep") private storePathSep: string;
+  @State("platform") private storePlatform: string;
 
   get espIdf() {
     return this.storeEspIdf;
@@ -94,6 +109,11 @@ export default class Home extends Vue {
 
   get idfVersion() {
     return this.storeIdfVersion;
+  }
+
+  get platform() {
+    console.log(this.storePlatform);
+    return this.storePlatform;
   }
 
   get isNotWinPlatform() {

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -21,7 +21,7 @@
       <div class="control centerize home-title">
         <h1 class="title is-spaced">Welcome.</h1>
         <p v-if="platform !== 'win32'">
-          First, install the
+          Make sure that
           <a
             href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html"
             v-if="platform === 'darwin'"
@@ -31,9 +31,9 @@
             href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html"
             v-if="platform === 'linux'"
             >ESP-IDF Prerequisites for Linux</a
-          >,
+          >
         </p>
-        <p>restart Visual Studio Code and run this wizard again.</p>
+        <p>are installed before choosing the setup mode.</p>
         <h2 class="subtitle">Choose a setup mode.</h2>
       </div>
       <div

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -95,7 +95,6 @@ export default class Home extends Vue {
   @State("toolsResults") private storeToolsResults: IEspIdfTool[];
   @State("toolsFolder") private storeToolsFolder: string;
   @State("espIdf") private storeEspIdf: string;
-  @State("pathSep") private storePathSep: string;
   @State("platform") private storePlatform: string;
 
   get espIdf() {
@@ -111,12 +110,7 @@ export default class Home extends Vue {
   }
 
   get platform() {
-    console.log(this.storePlatform);
     return this.storePlatform;
-  }
-
-  get isNotWinPlatform() {
-    return this.storePathSep.indexOf("/") !== -1;
   }
 
   get isPreviousSetupValid() {

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -1,22 +1,21 @@
 <template>
   <div id="home">
     <div class="centerize" v-if="!hasPrerequisites">
-      <p>
-        Before using this extension,
-        <a href="https://git-scm.com/downloads">Git</a>
-        and
-        <a href="https://www.python.org/downloads">Python</a> are required.
-        <br />Please read
-        <a
-          href="https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#step-1-install-prerequisites"
-          >ESP-IDF Prerequisites.</a
-        >
-      </p>
-      <p v-if="isNotWinPlatform">
-        <a href="https://cmake.org/download/">CMake</a> and
-        <a href="https://github.com/ninja-build/ninja/releases">Ninja</a> are
-        required in environment PATH.
-      </p>
+      <h1 class="title is-spaced">Welcome.</h1>
+        <p v-if="platform !== 'win32'">
+          First, install the
+          <a
+            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html"
+            v-if="platform === 'darwin'"
+            >ESP-IDF Prerequisites for MacOS</a
+          >
+          <a
+            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html"
+            v-if="platform === 'linux'"
+            >ESP-IDF Prerequisites for Linux</a
+          >,
+        </p>
+        <p>restart Visual Studio Code and run this wizard again.</p>
     </div>
     <div class="centerize notification" v-if="hasPrerequisites">
       <div class="control centerize home-title">
@@ -34,7 +33,7 @@
             >ESP-IDF Prerequisites for Linux</a
           >,
         </p>
-        <p>restart Visual Studio Code and run this setup again.</p>
+        <p>restart Visual Studio Code and run this wizard again.</p>
         <h2 class="subtitle">Choose a setup mode.</h2>
       </div>
       <div


### PR DESCRIPTION
Fix many links throughout the documentation.

Show prerequisites link in setup wizard when prerequisites are not found in the system.

Fix #529 by showing link to prerequisites when ESP-IDF prerequisites are not found in environment PATH