### PR TITLE
Fix cppdbg configuration (VSC-778)

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -113,6 +113,7 @@ The user can also use [Microsoft C/C++ Extension](https://marketplace.visualstud
       "environment": [{ "name": "PATH", "value": "${config:idf.customExtraPaths}" }],
       "setupCommands": [
         { "text": "target remote :3333" },
+        { "text": "set remote hardware-watchpoint-limit 2"},
         { "text": "mon reset halt" },
         { "text": "thb app_main" },
         { "text": "flushregs" }


### PR DESCRIPTION
The cppdbg config lacked the hardware watchpoint limit command that while helpfully listed in the required command listing nevertheless was missing from the actual config code.

Tested and it works.

Note that the espidf config is still broken and does not work.