### PR TITLE
IDF_TARGET serialPort as workspace folder settings

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -96,13 +96,18 @@ export class SerialPort {
   }
 
   private async updatePortListStatus(l: string) {
-    const target = idfConf.readParameter("idf.saveScope");
-    await idfConf.writeParameter("idf.port", l, target);
+    const settingsSavedLocation = await idfConf.writeParameter(
+      "idf.port",
+      l,
+      vscode.ConfigurationTarget.WorkspaceFolder
+    );
     const portHasBeenSelectedMsg = this.locDic.localize(
       "serial.portHasBeenSelectedMessage",
       "Port has been updated to "
     );
-    Logger.infoNotify(portHasBeenSelectedMsg + l);
+    Logger.infoNotify(
+      `${portHasBeenSelectedMsg}${l} in ${settingsSavedLocation}`
+    );
   }
 
   private list(): Thenable<SerialPortDetails[]> {

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ConfigurationTarget, Progress, window, WorkspaceFolder } from "vscode";
+import {
+  ConfigurationTarget,
+  Progress,
+  window,
+  workspace,
+  WorkspaceFolder,
+} from "vscode";
 import { IdfToolsManager, IEspIdfTool } from "../idfToolsManager";
 import * as utils from "../utils";
 import { getEspIdfVersions } from "./espIdfVersionList";
@@ -277,7 +283,8 @@ export async function getSetupInitialValues(
         prevInstall.gitVersion !== "Not found" &&
         canAccessCMake !== "" &&
         canAccessNinja !== "" &&
-        pythonVersions && pythonVersions.length > 0;
+        pythonVersions &&
+        pythonVersions.length > 0;
     } else {
       setupInitArgs.hasPrerequisites = prevInstall.gitVersion !== "Not found";
     }
@@ -355,37 +362,37 @@ export async function saveSettings(
     "idf.espIdfPath",
     espIdfPath,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   await idfConf.writeParameter(
     "idf.pythonBinPath",
     pythonBinPath,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   await idfConf.writeParameter(
     "idf.toolsPath",
     toolsPath,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   await idfConf.writeParameter(
     "idf.customExtraPaths",
     exportedPaths,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   await idfConf.writeParameter(
     "idf.customExtraVars",
     exportedVars,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   await idfConf.writeParameter(
     "idf.gitPath",
     gitPath,
     confTarget,
-    workspaceFolder
+    workspaceFolder ? workspaceFolder.uri : undefined
   );
   window.showInformationMessage("ESP-IDF has been configured");
 }

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -85,14 +85,14 @@ export function getProjectName(workspacePath: string): Promise<string> {
 }
 
 export async function getIdfTargetFromSdkconfig(
-  workspacePath: string,
+  workspacePath: vscode.Uri,
   statusItem: vscode.StatusBarItem
 ) {
   const doesSdkconfigExists = await pathExists(
-    path.join(workspacePath, "sdkconfig")
+    path.join(workspacePath.fsPath, "sdkconfig")
   );
   const doesSdkconfigDefaultExists = await pathExists(
-    path.join(workspacePath, "sdkconfig.defaults")
+    path.join(workspacePath.fsPath, "sdkconfig.defaults")
   );
   if (!doesSdkconfigExists && !doesSdkconfigDefaultExists) {
     return;
@@ -106,15 +106,19 @@ export async function getIdfTargetFromSdkconfig(
     const idfTarget = utils
       .getConfigValueFromSDKConfig(
         "CONFIG_IDF_TARGET",
-        workspacePath,
+        workspacePath.fsPath,
         sdkconfigToUse
       )
       .replace(/\"/g, "");
     if (!idfTarget) {
       return;
     }
-    const target = readParameter("idf.saveScope");
-    await writeParameter("idf.adapterTargetName", idfTarget, target);
+    await writeParameter(
+      "idf.adapterTargetName",
+      idfTarget,
+      vscode.ConfigurationTarget.WorkspaceFolder,
+      workspacePath
+    );
     statusItem.text = "$(circuit-board) " + idfTarget;
   }
 }


### PR DESCRIPTION
Set serial port and IDF_TARGET as workspace folder specific settings.

Dispose conserver process before running `idf.py set-target`

Fix #559 

Fix #554