### PR TITLE
Add ninja args to build task

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,7 +31,7 @@ The **Add Arduino-ESP32 as ESP-IDF Component** command will add [Arduino-ESP32](
 
 ## Build
 
-**ESP-IDF: Build your project** is provided by this extension to build your project using `CMake` and `Ninja-build` as explained in [ESP-IDF Build system using Cmake directly](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#using-cmake-directly).
+**ESP-IDF: Build your project** is provided by this extension to build your project using `CMake` and `Ninja-build` as explained in [ESP-IDF Build system using Cmake directly](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#using-cmake-directly). You could modify the behavior of the build task with `idf.cmakeCompilerArgs` for Cmake configure step and `idf.ninjaArgs` for Ninja step. For example, using  `[-j N]` where N is the number of jobs run in parallel.
 
 ## Debugging
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,7 +31,7 @@ The **Add Arduino-ESP32 as ESP-IDF Component** command will add [Arduino-ESP32](
 
 ## Build
 
-**ESP-IDF: Build your project** is provided by this extension to build your project using `CMake` and `Ninja-build` as explained in [ESP-IDF Build system using Cmake directly](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#using-cmake-directly). You could modify the behavior of the build task with `idf.cmakeCompilerArgs` for Cmake configure step and `idf.ninjaArgs` for Ninja step. For example, using  `[-j N]` where N is the number of jobs run in parallel.
+**ESP-IDF: Build your project** is provided by this extension to build your project using `CMake` and `Ninja-build` as explained in [ESP-IDF Build system using Cmake directly](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#using-cmake-directly). You could modify the behavior of the build task with `idf.cmakeCompilerArgs` for Cmake configure step and `idf.ninjaArgs` for Ninja step. For example, using `[-j N]` where N is the number of jobs run in parallel.
 
 ## Debugging
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -67,7 +67,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | Setting ID                | Description                                                                   |
 | ------------------------- | ----------------------------------------------------------------------------- |
 | `idf.cmakeCompilerArgs`   | Arguments for CMake compilation task                                          |
-| `idf.cmakeBuildArgs`      | Arguments for CMake build task                                                |
+| `idf.ninjaArgs`           | Arguments for Ninja build task                                                |
 | `idf.coveredLightTheme`   | Background color for covered lines in light theme for gcov coverage           |
 | `idf.coveredDarkTheme`    | Background color for covered lines in dark theme for gcov coverage            |
 | `idf.partialLightTheme`   | Background color for partially covered lines in light theme for gcov coverage |

--- a/docs/tutorial/basic_use.md
+++ b/docs/tutorial/basic_use.md
@@ -28,7 +28,7 @@ You have several options to create a project:
 
 6. Configure the `.vscode/c_cpp_properties.json` as explained in [C/C++ Configuration](../C_CPP_CONFIGURATION.md).
 
-7. Now to build the project, use the **ESP-IDF: Build your project** command (<kbd>CTRL</kbd> <kbd>E</kbd> <kbd>B</kbd> keyboard shortcut). The user will see a new terminal being launched with the build output and a notification bar with Building Project message until it is done then a Build done message when finished.
+7. Now to build the project, use the **ESP-IDF: Build your project** command (<kbd>CTRL</kbd> <kbd>E</kbd> <kbd>B</kbd> keyboard shortcut). The user will see a new terminal being launched with the build output and a notification bar with Building Project message until it is done then a Build done message when finished. You could modify the behavior of the build task with `idf.cmakeCompilerArgs` for Cmake configure step and `idf.ninjaArgs` for Ninja step. For example, using  `[-j N]` where N is the number of jobs run in parallel.
 
 > **NOTE:** There is a `idf.notificationSilentMode` configuration setting if the user does not wants to see the output automatically. Please review [ESP-IDF Settings](../SETTINGS.md)) to see how to modify this configuration setting.
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -68,7 +68,7 @@
   "param.useIDFKConfigStyle": "Enable/Disable ESP-IDF style validation for Kconfig files",
   "param.showOnboardingOnInit": "Show ESP-IDF Configuration window on extension activation",
   "param.cmakeCompilerArgs": "Arguments for CMake compilation task",
-  "param.cmakeBuildArgs": "Arguments for CMake build task",
+  "param.ninjaArgs": "Arguments for Ninja build task",
   "param.coveredLightTheme": "Background color for covered lines in Light theme for ESP-IDF Coverage.",
   "param.coveredDarkTheme": "Background color for covered lines in Dark theme for ESP-IDF Coverage.",
   "param.partialLightTheme": "Background color for partially covered lines in Light theme for ESP-IDF Coverage.",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -66,7 +66,7 @@
   "param.espAdfPath": "Ruta del entorno de trabajo ESP-ADF (ADF_PATH)",
   "param.espMdfPath": "Ruta del entorno de trabajo ESP-MDF (MDF_PATH)",
   "param.cmakeCompilerArgs": "Argumentos para la tarea de compilación CMake",
-  "param.cmakeBuildArgs": "Argumentos para la tarea de construcción CMake",
+  "param.ninjaArgs": "Argumentos para la tarea de construcción Ninja",
   "param.useIDFKConfigStyle": "Habilitar/Deshabilitar validación de estilo ESP-IDF para archivos Kconfig",
   "param.showOnboardingOnInit": "Mostrar ventana de configuración ESP-IDF al activar la extensión",
   "param.coveredLightTheme": "Color de fondo para lineas cubiertas en temas claros por ESP-IDF Coverage.",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -68,7 +68,7 @@
   "param.useIDFKConfigStyle": "Включить/отключить проверки стиля ESP-IDF для файлов Kconfig",
   "param.showOnboardingOnInit": "Показывать окно конфигурации ESP-IDF при активации расширения",
   "param.cmakeCompilerArgs": "Аргументы для задачи компиляции CMake",
-  "param.cmakeBuildArgs": "Аргументы для задачи сборки CMake",
+  "param.ninjaArgs": "Аргументы для задачи сборки Ninja",
   "param.coveredLightTheme": "Цвет фона для покрытых линий в светлой теме для покрытия кода ESP-IDF.",
   "param.coveredDarkTheme": "Цвет фона для покрытых линий в темной теме для покрытия кода ESP-IDF.",
   "param.partialLightTheme": "Цвет фона для частично покрытых линий в светлой теме для покрытия кода ESP-IDF.",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -68,7 +68,7 @@
   "param.useIDFKConfigStyle": "启用/禁用 ESP-IDF Kconfig 文件的样式验证",
   "param.showOnboardingOnInit": "在扩展激活时显示 ESP-IDF 配置窗口",
   "param.cmakeCompilerArgs": "CMake 编译任务的参数",
-  "param.cmakeBuildArgs": "CMake 构建任务的参数",
+  "param.ninjaArgs": "Ninja 构建任务的参数",
   "param.coveredLightTheme": "ESP-IDF 覆盖浅色主题覆盖线的背景色",
   "param.coveredDarkTheme": "ESP-IDF 覆盖深色主题覆盖线的背景色",
   "param.partialLightTheme": "ESP-IDF 覆盖浅色主题部分覆盖线的背景色.",

--- a/package.json
+++ b/package.json
@@ -460,13 +460,10 @@
             "description": "%param.cmakeCompilerArgs%",
             "scope": "resource"
           },
-          "idf.cmakeBuildArgs": {
+          "idf.ninjaArgs": {
             "type": "array",
-            "default": [
-              "--build",
-              "."
-            ],
-            "description": "%param.cmakeBuildArgs%",
+            "default": [],
+            "description": "%param.ninjaArgs%",
             "scope": "resource"
           },
           "idf.customAdapterTargetName": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -68,7 +68,7 @@
   "param.useIDFKConfigStyle": "Enable/Disable ESP-IDF style validation for Kconfig files",
   "param.showOnboardingOnInit": "Show ESP-IDF Configuration window on extension activation",
   "param.cmakeCompilerArgs": "Arguments for CMake compilation task",
-  "param.cmakeBuildArgs": "Arguments for CMake build task",
+  "param.ninjaArgs": "Arguments for Ninja build task",
   "param.coveredLightTheme": "Background color for covered lines in Light theme for ESP-IDF Coverage.",
   "param.coveredDarkTheme": "Background color for covered lines in Dark theme for ESP-IDF Coverage.",
   "param.partialLightTheme": "Background color for partially covered lines in Light theme for ESP-IDF Coverage.",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -143,7 +143,7 @@
     "param.useIDFKConfigStyle",
     "param.showOnboardingOnInit",
     "param.cmakeCompilerArgs",
-    "param.cmakeBuildArgs",
+    "param.ninjaArgs",
     "param.coveredLightTheme",
     "param.coveredDarkTheme",
     "param.partialLightTheme",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -50,6 +50,13 @@ export class BuildTask {
     return new vscode.ShellExecution(`cmake ${args.join(" ")}`, options);
   }
 
+  public getNinjaShellExecution(
+    args: string[],
+    options?: vscode.ShellExecutionOptions
+  ) {
+    return new vscode.ShellExecution(`ninja ${args.join(" ")}`, options);
+  }
+
   public async build() {
     try {
       await this.saveBeforeBuild();
@@ -120,10 +127,10 @@ export class BuildTask {
       );
     }
 
-    const buildArgs = (idfConf.readParameter("idf.cmakeBuildArgs") as Array<
+    const buildArgs = (idfConf.readParameter("idf.ninjaArgs") as Array<
       string
-    >) || ["--build", "."];
-    const buildExecution = this.getShellExecution(buildArgs, options);
+    >) || [];
+    const buildExecution = this.getNinjaShellExecution(buildArgs, options);
     TaskManager.addTask(
       { type: "esp-idf", command: "ESP-IDF Build" },
       vscode.TaskScope.Workspace,

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -137,6 +137,11 @@ export class DebugAdapterManager extends EventEmitter {
       const pythonBinPath = idfConf.readParameter(
         "idf.pythonBinPath"
       ) as string;
+
+      const toolchainPrefix =
+        this.target === "esp32c3"
+          ? "riscv32-esp-elf-gcc"
+          : `xtensa-${this.target}-elf-gcc`;
       const adapterArgs = [
         this.debugAdapterPath,
         "-d",
@@ -151,6 +156,8 @@ export class DebugAdapterManager extends EventEmitter {
         this.target,
         "-a",
         this.appOffset,
+        "-t",
+        toolchainPrefix
       ];
       if (this.isPostMortemDebugMode) {
         adapterArgs.push("-pm");

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -140,8 +140,8 @@ export class DebugAdapterManager extends EventEmitter {
 
       const toolchainPrefix =
         this.target === "esp32c3"
-          ? "riscv32-esp-elf-gcc"
-          : `xtensa-${this.target}-elf-gcc`;
+          ? "riscv32-esp-elf-"
+          : `xtensa-${this.target}-elf-`;
       const adapterArgs = [
         this.debugAdapterPath,
         "-d",
@@ -157,7 +157,7 @@ export class DebugAdapterManager extends EventEmitter {
         "-a",
         this.appOffset,
         "-t",
-        toolchainPrefix
+        toolchainPrefix,
       ];
       if (this.isPostMortemDebugMode) {
         adapterArgs.push("-pm");


### PR DESCRIPTION
Use ninja directly for build step in build task and allow to pass arguments to ninja such as parallels jobs with `-j 4`

Fix #561