### PR TITLE
fix openocd config files as string array

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ If something is not working please check for any error on one of these:
 
 5. Make sure that your extension is properly configured as described in [JSON Manual Configuration](./docs/SETUP.md#JSON-Manual-Configuration). Visual Studio Code allows the user to configure settings at different levels: Global (User Settings), Workspace and WorkspaceFolder. The doctor command might give the values from user settings instead of the workspace folder settings.
 
+6. Review the [OpenOCD troubleshooting FAQ](https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ) related to the `OpenOCD` output, for application tracing, debug or any OpenOCD related issues.
+
 If there is any Python package error, please try to reinstall the required python packages with the **ESP-IDF: Install ESP-IDF Python Packages** command.
 
 If the user can't resolve the error, please search in the [github repository issues](http://github.com/espressif/vscode-esp-idf-extension/issues) for existing errors or open a new issue [here](https://github.com/espressif/vscode-esp-idf-extension/issues/new/choose).

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -251,7 +251,7 @@ export class OpenOCDManager extends EventEmitter {
   }
 
   private configureServerWithDefaultParam() {
-    const openOcdConfigFilesList = idfConf.readParameter("idf.openOcdConfigs");
+    const openOcdConfigFilesList = idfConf.readParameter("idf.openOcdConfigs") as string[];
     const host = idfConf.readParameter("openocd.tcl.host");
     const port = idfConf.readParameter("openocd.tcl.port");
 

--- a/src/newProject/utils.ts
+++ b/src/newProject/utils.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Tuesday, 27th July 2021 4:35:42 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ export async function setCurrentSettingsInTemplate(
   if (mdfPathDir) {
     settingsJson["idf.espMdfPath" + isWin] = mdfPathDir;
   }
-  settingsJson["idf.openOcdConfigs"] = openOcdConfigs;
+  settingsJson["idf.openOcdConfigs"] = openOcdConfigs.split(",");
   if (port.indexOf("no port") === -1) {
     settingsJson["idf.port" + isWin] = port;
   }


### PR DESCRIPTION
Fix wrong value of `idf.openOcdConfigs` on `New project wizard` values.