### PR TITLE
add wsl enable flag

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -46,9 +46,9 @@ These settings are specific to the ESP32 Chip/ Board
 | `idf.flashBaudRate`                              | Flash Baud rate                                                     |
 | `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder |
 | `idf.openOcdDebugLevel`                          | Set openOCD debug level (0-4) Default: 2                            |
-| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 | `idf.port`                                       | Path of selected device port                                        |
 | `idf.portWin`                                    | Path of selected device port in Windows                             |
+| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`   |
 
 This is how the extension uses them:
 
@@ -77,16 +77,17 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
 ## Extension Behaviour Settings
 
-| Setting ID                             | Description                                                       |
-| -------------------------------------- | ----------------------------------------------------------------- |
-| `idf.flashType`                        | Preferred flash method. UART or JTAG                              |
-| `idf.notificationSilentMode`           | Silent all notifications messages (excluding error notifications) |
-| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)        |
-| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation         |
-| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                         |
-| `idf.saveScope`                        | Where to save extension settings                                  |
-| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session           |
-| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)     |
+| Setting ID                             | Description                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------- |
+| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)          |
+| `idf.flashType`                        | Preferred flash method. UART or JTAG                                   |
+| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                |
+| `idf.notificationSilentMode`           | Silent all notifications messages (excluding error notifications)      |
+| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation              |
+| `idf.saveScope`                        | Where to save extension settings                                       |
+| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)             |
+| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                              |
+| `idf.wslEnable`                        | Enable use of powershell executable for flash and monitor tasks in WSL |
 
 The `idf.saveScope` allows the user to specify where to save settings when using commands such as `Configure Paths`, `Device configuration`, `Set Espressif device target` and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. For more information please take a look at [Working with multiple projects](./MULTI_PROJECTS.md). Use the `Select where to save configuration settings` command to choose where to save settings when using this extension commands.
 

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -6,7 +6,7 @@ Please review [Debugging using WSL](https://code.visualstudio.com/api/advanced-t
 
 This extension was tested in Windows 10 Build 19041 with the Microsoft's Ubuntu 20.04 distribution for WSL 2.
 
-Currently in WSL 2, there is no access to serial ports. Calling `powershell.exe` from distribution's shell we obtain serial ports and perform flash and monitor tasks when `WSL_DISTRO_NAME` environment variable is defined.
+Currently in WSL 2, there is no access to serial ports. Calling `powershell.exe` from distribution's shell we obtain serial ports and perform flash and monitor tasks when `WSL_DISTRO_NAME` environment variable is defined and `idf.wslEnable` is true.
 
 ## WSL 2 extension setup
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -54,6 +54,7 @@
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",
   "param.customAdapterTargetName": "Custom target name for ESP-IDF Debug Adapter",
+  "param.wslEnable": "Enable use of powershell for WSL flash and monitor tasks",
   "param.openOcdConfigFilesList": "List of configuration files inside OpenOCD Scripts directory",
   "param.port": "Path of selected device port",
   "param.flashBaudRate": "ESP-IDF Flash Baud rate",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -80,6 +80,7 @@
   "param.enableIdfComponentManager.title": "Habilitar IDF Component Manager en construccion de proyecto",
   "param.enableCCache.title": "Habilitar CCache en construccion de proyecto",
   "param.qemuTcpPort": "QEMU tcp port para comunicación serial",
+  "param.wslEnable": "Habilitar el uso de powershell para tareas de flash y monitoreo en WSL",
   "param.openOcdDebugLevel": "Nivel de depuracion para servidor OpenOCD",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -80,6 +80,7 @@
   "param.enableIdfComponentManager.title": "Включить менеджер компонентов IDF в задаче сборки",
   "param.enableCCache.title": "Включить CCache в задаче сборки",
   "param.qemuTcpPort": "QEMU tcp порт для последовательной связи",
+  "param.wslEnable": "Включение использования PowerShell для WSL flash и задач мониторинга",
   "param.openOcdDebugLevel": "Уровень отладки OpenOCD Server",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -54,6 +54,7 @@
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF 调试适配器的目标名称",
   "param.customAdapterTargetName": "ESP-IDF 调试适配器的自定义目标名称",
+  "param.wslEnable": "允许将powershell用于WSL闪存和监视器任务",
   "param.openOcdConfigFilesList": "OpenOCD 脚本目录中的配置文件列表",
   "param.flashBaudRate": "ESP-IDF 烧录波特率",
   "param.port": "选中的烧录端口路径",

--- a/package.json
+++ b/package.json
@@ -681,6 +681,12 @@
             "scope": "resource",
             "default": "https://components.espressif.com"
           },
+          "idf.wslEnable": {
+            "type": "boolean",
+            "description": "%param.wslEnable%",
+            "scope": "resource",
+            "default": true
+          },
           "idf.openOcdDebugLevel": {
             "type": "number",
             "default": 2,

--- a/package.nls.json
+++ b/package.nls.json
@@ -77,6 +77,7 @@
   "param.uncoveredDarkTheme": "Background color for uncovered lines in Dark theme for ESP-IDF Coverage.",
   "param.enableUpdateSrcsToCMakeListsFile": "Enable update source files in CMakeLists.txt",
   "param.qemuTcpPort": "QEMU tcp port for serial communication",
+  "param.wslEnable": "Enable use of powershell for WSL flash and monitor tasks",
   "param.openOcdDebugLevel": "OpenOCD Server debug level",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -195,6 +195,7 @@
     "param.gitPath.title",
     "param.enableUpdateSrcsToCMakeListsFile",
     "param.qemuTcpPort",
+    "param.wslEnable",
     "param.openOcdDebugLevel"
   ]
 }

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Friday, 7th May 2021 3:58:36 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 import { join } from "path";
-import { release } from "os";
 import { commands, env, Uri, Terminal, window } from "vscode";
 import { FlashTask } from "../../flash/flashTask";
 import { readParameter } from "../../idfConfiguration";

--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 5th June 2019 2:03:34 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,13 +16,11 @@
  * limitations under the License.
  */
 
-import { release } from "os";
 import * as vscode from "vscode";
 import * as idfConf from "../../idfConfiguration";
 import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
 import {
-  compareVersion,
   execChildProcess,
   extensionContext,
   isRunningInWsl,

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Friday, 27th September 2019 9:59:57 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,12 @@
 
 import { constants } from "fs";
 import { join } from "path";
-import { release } from "os";
 import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
 import { FlashModel } from "./flashModel";
 import {
   appendIdfAndToolsToPath,
   canAccessFile,
-  compareVersion,
   execChildProcess,
   extensionContext,
   isBinInPath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -915,7 +915,9 @@ export function getWebViewFavicon(extensionPath: string): vscode.Uri {
 }
 
 export function isRunningInWsl() {
+  const wslEnable = idfConf.readParameter("idf.wslEnable") as boolean;
   return (
+    wslEnable &&
     typeof process.env.WSL_DISTRO_NAME === "string" &&
     process.env.WSL_DISTRO_NAME !== ""
   );


### PR DESCRIPTION
Fix #583 with `idf.wslEnable` configuration setting to use powershell for flash and monitor tasks. WSL_DISTRO_NAME should also be defined as environment variable (this is done by latest WSL 2 distributions)