### PR TITLE
update compiler path when IDF_TARGET changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1460,6 +1460,7 @@ export async function activate(context: vscode.ExtensionContext) {
             );
             Logger.info(setTargetResult.toString());
             OutputChannel.append(setTargetResult.toString());
+            utils.setCCppPropertiesJsonCompilerPath(workspaceRoot.fsPath);
           } catch (err) {
             if (err.message && err.message.indexOf("are satisfied") > -1) {
               Logger.info(err.message.toString());

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -204,12 +204,21 @@ export async function createVscodeFolder(curWorkspaceFsPath: string) {
       await copy(fSrcPath, fPath);
     }
   }
+  await setCCppPropertiesJsonCompilerPath(curWorkspaceFsPath);
+}
+
+export async function setCCppPropertiesJsonCompilerPath(
+  curWorkspaceFsPath: string
+) {
   const cCppPropertiesJsonPath = path.join(
     curWorkspaceFsPath,
     ".vscode",
     "c_cpp_properties.json"
   );
-  const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
+  const doesPathExists = await pathExists(cCppPropertiesJsonPath);
+  if (!doesPathExists) {
+    return;
+  }
   const modifiedEnv = appendIdfAndToolsToPath();
   const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
   const gccTool =
@@ -221,16 +230,17 @@ export async function createVscodeFolder(curWorkspaceFsPath: string) {
     curWorkspaceFsPath,
     modifiedEnv
   );
+  const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
   if (
     cCppPropertiesJson &&
     cCppPropertiesJson.configurations &&
     cCppPropertiesJson.configurations.length
   ) {
     cCppPropertiesJson.configurations[0].compilerPath = compilerPath;
+    await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
+      spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+    });
   }
-  await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
-    spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
-  });
 }
 
 export function chooseTemplateDir() {


### PR DESCRIPTION
Fix #608 

Using `ESP-IDF: Set Espressif device target` will now update the `compilerPath` field to the proper compiler toolchain path.