### PR TITLE
check core requirements first

### DIFF
--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -242,7 +242,16 @@ export async function checkPyVenv(pyVenvPath: string, espIdfPath: string) {
   if (!pyExists) {
     return false;
   }
-  const requirements = path.join(espIdfPath, "requirements.txt");
+  let requirements: string;
+  requirements = path.join(espIdfPath, "requirements.core.txt"); 
+  const coreRequirementsExists = await pathExists(requirements);
+  if (!coreRequirementsExists) {
+    requirements = path.join(espIdfPath, "requirements.txt");
+    const requirementsExists = await pathExists(requirements);
+    if (!requirementsExists) {
+      return false;
+    }
+  }
   const reqsResults = await utils.startPythonReqsProcess(
     pyVenvPath,
     espIdfPath,


### PR DESCRIPTION
Check for `requirements.core.txt` first  (introduced in ESP-IDF v5.0) and fallback to `requirements.txt`