### PR TITLE
use relative elf in wsl monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -632,11 +632,11 @@
             "scope": "resource"
           },
           "idf.selectedDfuDevicePath": {
-            "type":"string",
+            "type": "string",
             "default": ""
           },
           "idf.listDfuDevices": {
-            "type":"array",
+            "type": "array",
             "default": "[]"
           },
           "openocd.tcl.host": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2791,6 +2791,7 @@ function registerTreeProvidersForIDFExplorer(context: vscode.ExtensionContext) {
 function creatCmdsStatusBarItems() {
   const port = idfConf.readParameter("idf.port", workspaceRoot);
   let idfTarget = idfConf.readParameter("idf.adapterTargetName", workspaceRoot);
+  let flashType = idfConf.readParameter("idf.flashType", workspaceRoot);
   if (idfTarget === "custom") {
     idfTarget = idfConf.readParameter(
       "idf.customAdapterTargetName",
@@ -2836,7 +2837,7 @@ function creatCmdsStatusBarItems() {
     95
   );
   statusBarItems["flash"] = createStatusBarItem(
-    "$(zap)",
+    `$(zap) ${flashType}`,
     "ESP-IDF Flash device",
     "espIdf.selectFlashMethodAndFlash",
     94
@@ -2895,7 +2896,7 @@ const build = () => {
         progress: vscode.Progress<{ message: string; increment: number }>,
         cancelToken: vscode.CancellationToken
       ) => {
-        const buildType = idfConf.readParameter("idf.flashType");
+        const buildType = idfConf.readParameter("idf.flashType", workspaceRoot);
         await buildCommand(workspaceRoot, cancelToken, buildType);
       }
     );
@@ -2916,7 +2917,7 @@ const flash = () => {
         const idfPathDir = idfConf.readParameter("idf.espIdfPath");
         const port = idfConf.readParameter("idf.port");
         const flashBaudRate = idfConf.readParameter("idf.flashBaudRate");
-        const selectedFlashType = idfConf.readParameter("idf.flashType");
+        const selectedFlashType = idfConf.readParameter("idf.flashType", workspaceRoot);
         if (monitorTerminal) {
           monitorTerminal.sendText(ESP.CTRL_RBRACKET);
         }
@@ -2970,7 +2971,7 @@ const buildFlashAndMonitor = async (runMonitor: boolean = true) => {
         cancelToken: vscode.CancellationToken
       ) => {
         progress.report({ message: "Building project...", increment: 20 });
-        const buildType = idfConf.readParameter("idf.flashType");
+        const buildType = idfConf.readParameter("idf.flashType", workspaceRoot);
         let canContinue = await buildCommand(
           workspaceRoot,
           cancelToken,
@@ -3014,8 +3015,11 @@ async function selectFlashMethod(cancelToken) {
         "Select flash method, you can modify the choice later from settings 'idf.flashType'",
     }
   );
-  const target = idfConf.readParameter("idf.saveScope");
-  await idfConf.writeParameter("idf.flashType", flashType, target);
+  await idfConf.writeParameter(
+    "idf.flashType",
+    flashType,
+    vscode.ConfigurationTarget.WorkspaceFolder
+  );
 
   if (!flashType) {
     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3036,7 +3036,9 @@ async function selectFlashMethod(cancelToken) {
     const buildPath = path.join(workspaceRoot.fsPath, "build");
     return await jtagFlashCommand(buildPath);
   } else {
-    const arrDfuDevices = idfConf.readParameter("idf.listDfuDevices") as string[];
+    const arrDfuDevices = idfConf.readParameter(
+      "idf.listDfuDevices"
+    ) as string[];
     if (flashType === "DFU" && arrDfuDevices.length > 1) {
       await selectDfuDevice(arrDfuDevices);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2917,7 +2917,10 @@ const flash = () => {
         const idfPathDir = idfConf.readParameter("idf.espIdfPath");
         const port = idfConf.readParameter("idf.port");
         const flashBaudRate = idfConf.readParameter("idf.flashBaudRate");
-        const selectedFlashType = idfConf.readParameter("idf.flashType", workspaceRoot);
+        const selectedFlashType = idfConf.readParameter(
+          "idf.flashType",
+          workspaceRoot
+        );
         if (monitorTerminal) {
           monitorTerminal.sendText(ESP.CTRL_RBRACKET);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3036,8 +3036,8 @@ async function selectFlashMethod(cancelToken) {
     const buildPath = path.join(workspaceRoot.fsPath, "build");
     return await jtagFlashCommand(buildPath);
   } else {
-    const arrDfuDevices = idfConf.readParameter("idf.listDfuDevices");
-    if (arrDfuDevices.length > 1) {
+    const arrDfuDevices = idfConf.readParameter("idf.listDfuDevices") as string[];
+    if (flashType === "DFU" && arrDfuDevices.length > 1) {
       await selectDfuDevice(arrDfuDevices);
     }
     return await flashCommand(

--- a/src/flash/dfu.ts
+++ b/src/flash/dfu.ts
@@ -75,7 +75,7 @@ export async function listAvailableDfuDevices(text) {
   }
 }
 
-export async function selectDfuDevice(arrDfuDevices) {
+export async function selectDfuDevice(arrDfuDevices: string[]) {
   const target = readParameter("idf.saveScope");
   let options = [];
   for (let i = 0; i < arrDfuDevices.length; i++) {

--- a/src/flash/flashCmd.ts
+++ b/src/flash/flashCmd.ts
@@ -81,7 +81,7 @@ export async function verifyCanFlash(
       new Error("NOT_SELECTED_BAUD_RATE")
     );
   }
-  const selectedFlashType = idfConf.readParameter("idf.flashType");
+  const selectedFlashType = idfConf.readParameter("idf.flashType", workspace);
   if (selectedFlashType === "DFU") {
     const data = await getDfuList();
     const listDfu = await listAvailableDfuDevices(data);

--- a/src/flash/uartFlash.ts
+++ b/src/flash/uartFlash.ts
@@ -74,8 +74,8 @@ export async function flashCommand(
     if (error.message === "ALREADY_FLASHING") {
       return Logger.errorNotify("Already one flash process is running!", error);
     }
+    FlashTask.isFlashing = false;
     if (error.message === "Task ESP-IDF Flash exited with code 74") {
-      FlashTask.isFlashing = false;
       return Logger.errorNotify(
         "No DFU capable USB device available found",
         error


### PR DESCRIPTION
Use relative path of elf file for WSL 2 monitor task.

Fix using DFU select device on UART flash type.

Fix #615