### PR TITLE
More CCache fixes

### DIFF
--- a/src/component-manager/utils.ts
+++ b/src/component-manager/utils.ts
@@ -38,7 +38,7 @@ export async function addDependency(
     if (enableCCache) {
       addDependencyArgs.push("--ccache")
     }
-    addDependencyArgs.push("add-dependency", `--component=${component}`, dependency, "reconfigue");
+    addDependencyArgs.push("add-dependency", `--component=${component}`, dependency, "reconfigure");
     const addDependencyResult = await spawn(
       pythonBinPath,
       addDependencyArgs,

--- a/src/component-manager/utils.ts
+++ b/src/component-manager/utils.ts
@@ -33,9 +33,15 @@ export async function addDependency(
     const idfPy = join(idfPathDir, "tools", "idf.py");
     const modifiedEnv = appendIdfAndToolsToPath();
     const pythonBinPath = readParameter("idf.pythonBinPath") as string;
+    const enableCCache = readParameter("idf.enableCCache") as boolean;
+    const addDependencyArgs: string[] = [idfPy];
+    if (enableCCache) {
+      addDependencyArgs.push("--ccache")
+    }
+    addDependencyArgs.push("add-dependency", `--component=${component}`, dependency, "reconfigue");
     const addDependencyResult = await spawn(
       pythonBinPath,
-      [idfPy, "add-dependency", `--component=${component}`, dependency],
+      addDependencyArgs,
       {
         cwd: workspace.fsPath,
         env: modifiedEnv,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1447,12 +1447,18 @@ export async function activate(context: vscode.ExtensionContext) {
             const idfPy = path.join(idfPathDir, "tools", "idf.py");
             const modifiedEnv = utils.appendIdfAndToolsToPath();
             modifiedEnv.IDF_TARGET = undefined;
+            const enableCCache = idfConf.readParameter("idf.enableCCache") as boolean;
+            const setTargetArgs: string[] = [idfPy];
+            if (enableCCache) {
+              setTargetArgs.push("--ccache")
+            }
+            setTargetArgs.push("set-target", selectedTarget.target);
             const pythonBinPath = idfConf.readParameter(
               "idf.pythonBinPath"
             ) as string;
             const setTargetResult = await utils.spawn(
               pythonBinPath,
-              [idfPy, "set-target", selectedTarget.target],
+              setTargetArgs,
               {
                 cwd: workspaceRoot.fsPath,
                 env: modifiedEnv,


### PR DESCRIPTION
- When adding components form the Component Registry, run `reconfigure` also so it uses the components on the next build
- Use `--ccache' arg, if enabled, when adding components and setting target board