### PR TITLE
clean terminal output before build task start

### DIFF
--- a/.github/actions/idf/Dockerfile
+++ b/.github/actions/idf/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
  libnss3 \
  libsecret-1-0 \
  libxss1 \
- libxtst6\
+ libxtst6 \
+ gnome-keyring \
  xvfb
 
 ENV LC_ALL=C.UTF-8

--- a/.github/actions/idf/ui-entrypoint.sh
+++ b/.github/actions/idf/ui-entrypoint.sh
@@ -16,7 +16,7 @@ export PY_VERSION=$( echo "$a" | echo $(python --version) | sed -nre 's/^[^0-9]*
 export PIP_VERSION=$( echo "$a" | echo $(python -m pip --version) | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
 export PY_PKGS=$(python -m pip list --format json)
 
-rm -rf out test-resources
+rm -rf node_modules out test-resources
 yarn
 yarn lint
 Xvfb -ac :99 -screen 0 1920x1080x16 & sleep 2 & yarn ci-test

--- a/.github/actions/idf/ui-entrypoint.sh
+++ b/.github/actions/idf/ui-entrypoint.sh
@@ -19,4 +19,9 @@ export PY_PKGS=$(python -m pip list --format json)
 rm -rf node_modules out test-resources
 yarn
 yarn lint
+export NO_AT_BRIDGE=1; # Don't use dbus accessibility bridge
+eval $(dbus-launch --sh-syntax);
+eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login);
+eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start);
+/usr/bin/python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');";
 Xvfb -ac :99 -screen 0 1920x1080x16 & sleep 2 & yarn ci-test

--- a/.github/actions/idf/ui-entrypoint.sh
+++ b/.github/actions/idf/ui-entrypoint.sh
@@ -21,7 +21,7 @@ yarn
 yarn lint
 export NO_AT_BRIDGE=1; # Don't use dbus accessibility bridge
 eval $(dbus-launch --sh-syntax);
-eval $(echo -n "" | /usr/bin/gnome-keyring-daemon --login);
-eval $(/usr/bin/gnome-keyring-daemon --components=secrets --start);
+/usr/bin/gnome-keyring-daemon --login
+/usr/bin/gnome-keyring-daemon --components=secrets --start
 /usr/bin/python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');";
 Xvfb -ac :99 -screen 0 1920x1080x16 & sleep 2 & yarn ci-test

--- a/.github/actions/idf/ui-entrypoint.sh
+++ b/.github/actions/idf/ui-entrypoint.sh
@@ -19,9 +19,4 @@ export PY_PKGS=$(python -m pip list --format json)
 rm -rf node_modules out test-resources
 yarn
 yarn lint
-export NO_AT_BRIDGE=1; # Don't use dbus accessibility bridge
-eval $(dbus-launch --sh-syntax);
-/usr/bin/gnome-keyring-daemon --login
-/usr/bin/gnome-keyring-daemon --components=secrets --start
-/usr/bin/python -c "import gnomekeyring;gnomekeyring.create_sync('login', '');";
 Xvfb -ac :99 -screen 0 1920x1080x16 & sleep 2 & yarn ci-test

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -157,6 +157,12 @@ export class BuildTask {
         }
       }
       const compileExecution = this.getShellExecution(compilerArgs, options);
+      const compilePresentationOptions = {
+        reveal: showTaskOutput,
+        showReuseMessage: false,
+        clear: true,
+        panel: vscode.TaskPanelKind.Shared
+      } as vscode.TaskPresentationOptions;
       TaskManager.addTask(
         {
           type: "esp-idf",
@@ -167,8 +173,7 @@ export class BuildTask {
         "ESP-IDF Compile",
         compileExecution,
         ["idfRelative", "idfAbsolute"],
-        showTaskOutput,
-        true
+        compilePresentationOptions
       );
     }
 
@@ -177,14 +182,19 @@ export class BuildTask {
         string
       >) || [];
     const buildExecution = this.getNinjaShellExecution(buildArgs, options);
+    const buildPresentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: cmakeCacheExists,
+      panel: vscode.TaskPanelKind.Shared
+    } as vscode.TaskPresentationOptions;
     TaskManager.addTask(
       { type: "esp-idf", command: "ESP-IDF Build", taskId: "idf-build-task" },
       vscode.TaskScope.Workspace,
       "ESP-IDF Build",
       buildExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput,
-      cmakeCacheExists
+      buildPresentationOptions
     );
   }
 
@@ -207,6 +217,12 @@ export class BuildTask {
       : vscode.TaskRevealKind.Silent;
 
     const writeExecution = this.dfuShellExecution(options);
+    const buildPresentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: false,
+      panel: vscode.TaskPanelKind.Shared
+    } as vscode.TaskPresentationOptions;
     TaskManager.addTask(
       {
         type: "esp-idf",
@@ -217,7 +233,7 @@ export class BuildTask {
       "ESP-IDF Write DFU.bin",
       writeExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput
+      buildPresentationOptions
     );
   }
 }

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -167,7 +167,8 @@ export class BuildTask {
         "ESP-IDF Compile",
         compileExecution,
         ["idfRelative", "idfAbsolute"],
-        showTaskOutput
+        showTaskOutput,
+        true
       );
     }
 
@@ -182,7 +183,8 @@ export class BuildTask {
       "ESP-IDF Build",
       buildExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput
+      showTaskOutput,
+      cmakeCacheExists
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,8 @@ export namespace ESP {
 
   export namespace URL {
     export const IDF_GITHUB_ASSETS = "https://dl.espressif.com/github_assets";
+    export const IDF_VERSIONS =
+      "https://dl.espressif.com/dl/esp-idf/idf_versions.txt";
     export namespace IDF_EMBED_GIT {
       export const IDF_EMBED_GIT_URL = `https://dl.espressif.com/dl/idf-git/idf-git-2.30.1-win64.zip`;
       export const VERSION = "2.30.1";

--- a/src/customTasks/customTaskProvider.ts
+++ b/src/customTasks/customTaskProvider.ts
@@ -19,6 +19,8 @@
 import {
   ShellExecution,
   ShellExecutionOptions,
+  TaskPanelKind,
+  TaskPresentationOptions,
   TaskRevealKind,
   TaskScope,
   Uri,
@@ -93,6 +95,12 @@ export class CustomTask {
       ? TaskRevealKind.Always
       : TaskRevealKind.Silent;
     const customExecution = this.getProcessExecution(cmd, options);
+    const customTaskPresentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: false,
+      panel: TaskPanelKind.Dedicated
+    } as TaskPresentationOptions;
     TaskManager.addTask(
       {
         type: "esp-idf",
@@ -103,7 +111,7 @@ export class CustomTask {
       `ESP-IDF ${taskName}`,
       customExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput
+      customTaskPresentationOptions
     );
   }
 

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -21,6 +21,8 @@ import { join } from "path";
 import {
   ShellExecution,
   ShellExecutionOptions,
+  TaskPanelKind,
+  TaskPresentationOptions,
   TaskRevealKind,
   TaskScope,
   Uri,
@@ -63,7 +65,11 @@ export class IdfSizeTask {
       this.curWorkspace.fsPath,
       this.buildDirName
     );
-    return join(this.curWorkspace.fsPath, this.buildDirName, `${projectName}.map`);
+    return join(
+      this.curWorkspace.fsPath,
+      this.buildDirName,
+      `${projectName}.map`
+    );
   }
 
   public async getSizeInfo() {
@@ -81,14 +87,19 @@ export class IdfSizeTask {
     const showTaskOutput = isSilentMode
       ? TaskRevealKind.Always
       : TaskRevealKind.Silent;
-
+    const sizePresentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: true,
+      panel: TaskPanelKind.Dedicated,
+    } as TaskPresentationOptions;
     TaskManager.addTask(
       { type: "esp-idf", command: "ESP-IDF Size", taskId: "idf-size-task" },
       TaskScope.Workspace,
       "ESP-IDF Size",
       sizeExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput
+      sizePresentationOptions
     );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1529,11 +1529,14 @@ export async function activate(context: vscode.ExtensionContext) {
             );
             modifiedEnv.IDF_TARGET = undefined;
             const enableCCache = idfConf.readParameter(
-              "idf.enableCCache"
+              "idf.enableCCache",
+              workspaceFolder.uri
             ) as boolean;
             const setTargetArgs: string[] = [idfPy];
             if (enableCCache) {
-              setTargetArgs.push("--ccache");
+              modifiedEnv.IDF_CCACHE_ENABLE = "1";
+            } else {
+              modifiedEnv.IDF_CCACHE_ENABLE = undefined;
             }
             setTargetArgs.push("set-target", selectedTarget.target);
             const pythonBinPath = idfConf.readParameter(

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -108,13 +108,19 @@ export class FlashTask {
           break;
       }
     }
+    const flashPresentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: false,
+      panel: vscode.TaskPanelKind.Shared,
+    } as vscode.TaskPresentationOptions;
     TaskManager.addTask(
       { type: "esp-idf", command: "ESP-IDF Flash", taskId: "idf-flash-task" },
       vscode.TaskScope.Workspace,
       "ESP-IDF Flash",
       flashExecution,
       ["idfRelative", "idfAbsolute"],
-      showTaskOutput
+      flashPresentationOptions
     );
   }
 

--- a/src/qemu/mergeFlashBin.ts
+++ b/src/qemu/mergeFlashBin.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 30th June 2021 9:47:52 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,8 @@ import {
   CancellationToken,
   ProcessExecution,
   ProcessExecutionOptions,
+  TaskPanelKind,
+  TaskPresentationOptions,
   TaskRevealKind,
   TaskScope,
   Uri,
@@ -114,6 +116,12 @@ export async function mergeFlashBinaries(
     flashModel,
     wsFolder
   );
+  const mergePresentationOptions = {
+    reveal: showTaskOutput,
+    showReuseMessage: false,
+    clear: false,
+    panel: TaskPanelKind.Shared,
+  } as TaskPresentationOptions;
   TaskManager.addTask(
     {
       type: "esp-idf",
@@ -124,7 +132,7 @@ export async function mergeFlashBinaries(
     "Merge flash binaries",
     mergeExecution,
     ["idfRelative", "idfAbsolute"],
-    showTaskOutput
+    mergePresentationOptions
   );
   await TaskManager.runTasks();
   if (cancelToken && !cancelToken.isCancellationRequested) {

--- a/src/setup/espIdfVersionList.ts
+++ b/src/setup/espIdfVersionList.ts
@@ -18,6 +18,7 @@ import { Logger } from "../logger/logger";
 import { readFile } from "fs-extra";
 import { OutputChannel } from "../logger/outputChannel";
 import { IEspIdfLink } from "../views/setup/types";
+import { ESP } from "../config";
 
 export async function getEspIdfVersions(extensionPath: string) {
   const downloadManager = new DownloadManager(extensionPath);
@@ -39,9 +40,8 @@ export async function downloadEspIdfVersionList(
 ) {
   try {
     const idfVersionList = path.join(tmpdir(), "idf_versions.txt");
-    const versionsUrl = "https://dl.espressif.com/dl/esp-idf/idf_versions.txt";
     const downloadMessage = await downloadManager.downloadFile(
-      versionsUrl,
+      ESP.URL.IDF_VERSIONS,
       0,
       tmpdir()
     );
@@ -76,7 +76,7 @@ export function createEspIdfLinkList(data: Buffer, splitString: string) {
   const versionZip =
     "https://github.com/espressif/esp-idf/releases/download/IDFZIPFileVersion/esp-idf-IDFZIPFileVersion.zip";
   const mirrorZip =
-    `https://dl.espressif.com/github_assets/espressif/esp-idf/releases/download/IDFZIPFileVersion/esp-idf-IDFZIPFileVersion.zip`;
+    `${ESP.URL.IDF_GITHUB_ASSETS}/espressif/esp-idf/releases/download/IDFZIPFileVersion/esp-idf-IDFZIPFileVersion.zip`;
   const versionRegex = /\b(IDFZIPFileVersion)\b/g;
   const espIdfMasterZip =
     "https://github.com/espressif/esp-idf/archive/master.zip";

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -37,7 +37,8 @@ export class TaskManager {
       | vscode.ProcessExecution
       | vscode.CustomExecution,
     problemMatchers: string | string[],
-    revealTask: vscode.TaskRevealKind
+    revealTask: vscode.TaskRevealKind,
+    clearTerminal: Boolean = false
   ) {
     const newTask: vscode.Task = new vscode.Task(
       taskDefinition,
@@ -50,7 +51,8 @@ export class TaskManager {
     newTask.presentationOptions = {
       reveal: revealTask,
       showReuseMessage: false,
-    };
+      clear: clearTerminal
+    } as vscode.TaskPresentationOptions;
     TaskManager.tasks.push(newTask);
     return new Promise<void>((resolve, reject) => {
       vscode.tasks.onDidEndTask((e) => {

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -37,8 +37,7 @@ export class TaskManager {
       | vscode.ProcessExecution
       | vscode.CustomExecution,
     problemMatchers: string | string[],
-    revealTask: vscode.TaskRevealKind,
-    clearTerminal: Boolean = false
+    presentationOptions: vscode.TaskPresentationOptions
   ) {
     const newTask: vscode.Task = new vscode.Task(
       taskDefinition,
@@ -48,11 +47,7 @@ export class TaskManager {
       execution,
       problemMatchers
     );
-    newTask.presentationOptions = {
-      reveal: revealTask,
-      showReuseMessage: false,
-      clear: clearTerminal,
-    } as vscode.TaskPresentationOptions;
+    newTask.presentationOptions = presentationOptions;
     TaskManager.tasks.push(newTask);
     return new Promise<void>((resolve, reject) => {
       vscode.tasks.onDidEndTask((e) => {

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -51,7 +51,7 @@ export class TaskManager {
     newTask.presentationOptions = {
       reveal: revealTask,
       showReuseMessage: false,
-      clear: clearTerminal
+      clear: clearTerminal,
     } as vscode.TaskPresentationOptions;
     TaskManager.tasks.push(newTask);
     return new Promise<void>((resolve, reject) => {

--- a/src/ui-test/configure-test.ts
+++ b/src/ui-test/configure-test.ts
@@ -32,6 +32,10 @@ describe("Configure extension", () => {
   before(async function () {
     this.timeout(100000);
     await new Promise((res) => setTimeout(res, 2000));
+    const notifications  = await new Workbench().getNotifications();
+    for (let n of notifications) {
+      await n.dismiss();
+    }
     await new Workbench().executeCommand("espIdf.setup.start");
     await new Promise((res) => setTimeout(res, 12000));
     view = new WebView();


### PR DESCRIPTION
Fix #665 
Fix #678

* Clean terminal output before build task starts.
* Disable CCache if not enabled in the extension for setting IDF_TARGET task.
* idf_versions.txt URL refactor to config to unifiy hard coded strings url.
* Move presentation options as addTask argument, idf-size to use a dedicated terminal