### PR TITLE
fix idf config  update conf parameter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -794,7 +794,8 @@ export async function activate(context: vscode.ExtensionContext) {
             paramName,
             msg,
             currentValue,
-            option.label
+            option.label,
+            workspaceRoot
           );
         }
       } catch (error) {
@@ -891,7 +892,8 @@ export async function activate(context: vscode.ExtensionContext) {
           paramName,
           msg,
           currentValue,
-          option.label
+          option.label,
+          workspaceRoot
         );
       }
     } catch (error) {

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -122,10 +122,11 @@ export async function writeParameter(
 }
 
 export async function updateConfParameter(
-  confParamName,
-  confParamDescription,
-  currentValue,
-  label
+  confParamName: string,
+  confParamDescription: string,
+  currentValue: any,
+  label: string,
+  workspaceFolderUri: vscode.Uri
 ) {
   const newValue = await vscode.window.showInputBox({
     placeHolder: confParamDescription,
@@ -141,32 +142,17 @@ export async function updateConfParameter(
     throw new Error(msg);
   }
   const typeOfConfig = checkTypeOfConfiguration(confParamName);
-  let valueToWrite;
+  let valueToWrite: any;
   if (typeOfConfig === "array") {
     valueToWrite = parseStrToArray(newValue);
   } else {
     valueToWrite = newValue;
   }
-  const target = readParameter("idf.saveScope");
-  if (
-    !PreCheck.isWorkspaceFolderOpen() &&
-    target !== vscode.ConfigurationTarget.Global
-  ) {
-    const noWsOpenMSg = `Open a workspace or folder first.`;
-    Logger.warnNotify(noWsOpenMSg);
-    throw new Error(noWsOpenMSg);
-  }
-  let workspaceFolder: vscode.WorkspaceFolder;
-  if (target === vscode.ConfigurationTarget.WorkspaceFolder) {
-    workspaceFolder = await vscode.window.showWorkspaceFolderPick({
-      placeHolder: `Pick Workspace Folder to which settings should be applied`,
-    });
-  }
   await writeParameter(
     confParamName,
     valueToWrite,
-    target,
-    workspaceFolder.uri
+    vscode.ConfigurationTarget.WorkspaceFolder,
+    workspaceFolderUri
   );
   const updateMessage = locDic.localize(
     "idfConfiguration.hasBeenUpdated",

--- a/src/views/setup/App.vue
+++ b/src/views/setup/App.vue
@@ -99,7 +99,7 @@ export default class App extends Vue {
 
   get openOCDRulesPath() {
     return this.storeOpenOCDRulesPath !== ""
-      ? `sudo cp ${this.storeOpenOCDRulesPath} /etc/udev/rules.d`
+      ? `sudo cp -n ${this.storeOpenOCDRulesPath} /etc/udev/rules.d`
       : "";
   }
 }


### PR DESCRIPTION
* Fix idfConfiguration updateConfParameter to use the currently selected workspace folder to save manually define settings such as those from `ESP-IDF: Device Configuration` and `ESP-IDF: Configure Paths`.
* Add `-n` to openOCD rules copy command at the end of the `ESP-IDF: Configure ESP-IDF extension` setup wizard.

Fix #690
Fix #691
Fix #698