### PR TITLE
fix nostub flash rm skdconfig process on del build

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -521,6 +521,12 @@ export async function activate(context: vscode.ExtensionContext) {
           `There is no build directory to clean, exiting!`
         );
       }
+      if (ConfserverProcess.exists()) {
+        OutputChannel.init().appendLine(
+          `Trying to delete the build folder. Closing existing SDK Configuration editor process...`
+        );
+        ConfserverProcess.dispose();
+      }
       const cmakeCacheFile = path.join(buildDir, "CMakeCache.txt");
       const doesCmakeCacheExists = utils.canAccessFile(
         cmakeCacheFile,

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -211,7 +211,7 @@ export class FlashTask {
     if (this.model.chip) {
       flasherArgs.push("--chip", this.model.chip);
     }
-    if (!!this.model.stub && !this.model.stub) {
+    if (typeof this.model.stub !== undefined && !this.model.stub) {
       flasherArgs.push("--no-stub");
     }
     flasherArgs.push(


### PR DESCRIPTION
Fix #694 

* Fix flashing with esptool `--no-stub`. Model was not  receive false stub values from flasher_args.json`
* Add SDK Configuration process server dispose on Full Clean command.