### PR TITLE
add idf.gitPathWin to avoid wsl container issues

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -19,6 +19,7 @@ These are the configuration settings that ESP-IDF extension contributes to your 
 | `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                |
 | `idf.customExtraVars`           | Variables to be added to system environment variables                         |
 | `idf.gitPath`                   | Path to git executable                                                        |
+| `idf.gitPathWin`                | Path to git executable in Windows                                             |
 | `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                     |
 | `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                 |
 | `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                   |
@@ -36,7 +37,7 @@ This is how the extension uses them:
 2. `idf.customExtraVars` stores any custom environment variable such as OPENOCD_SCRIPTS, which is the openOCD scripts directory used in openocd server startup. These variables are loaded to this extension commands process environment variables, choosing the extension variable if available, else extension commands will try to use what is already in your system PATH. **This doesn't modify your system environment outside Visual Studio Code.**
 3. `idf.espIdfPath` (or `idf.espIdfPathWin` in Windows) is used to store ESP-IDF directory path within our extension. We override Visual Studio Code process IDF_PATH if this value is available. **This doesn't modify your system environment outside Visual Studio Code.**
 4. `idf.pythonBinPath` (or `idf.espIdfPathWin` in Windows) is used to executed python scripts within the extension. In **ESP-IDF: Configure ESP-IDF extension** we first select a system-wide python executable from which to create a python virtual environment and we save the executable from this virtual environment in `idf.pythonBinPath`. All required python packages by ESP-IDF are installed in this virtual environment, if using **ESP-IDF: Configure ESP-IDF extension**
-5. `idf.gitPath` is used in the extension to clone ESP-IDF master version or the additional supported frameworks such as ESP-ADF, ESP-MDF and Arduino-ESP32.
+5. `idf.gitPath` (or `idf.gitPathWin` in Windows) is used in the extension to clone ESP-IDF master version or the additional supported frameworks such as ESP-ADF, ESP-MDF and Arduino-ESP32.
 
 > **NOTE**: From Visual Studio Code extension context, we can't modify your system PATH or any other environment variable. We use a modified process environment in all of this extension tasks and child processes which should not affect any other system process or extension. Please review the content of `idf.customExtraPaths` and `idf.customExtraVars` in case you have issues with other extensions.
 

--- a/package.json
+++ b/package.json
@@ -694,6 +694,12 @@
             "scope": "resource",
             "default": "/usr/bin/git"
           },
+          "idf.gitPathWin": {
+            "type": "string",
+            "description": "%param.gitPath.title%",
+            "scope": "resource",
+            "default": "${env:programfiles}\\Git\\cmd\\git.exe"
+          },
           "idf.enableUpdateSrcsToCMakeListsFile": {
             "type": "boolean",
             "description": "%param.enableUpdateSrcsToCMakeListsFile%",

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,16 @@ export namespace ESP {
     DFU = "DFU",
   }
 
+  export const platformDepConfigurations: string[] = [
+    "idf.espIdfPath",
+    "idf.espAdfPath",
+    "idf.espMdfPath",
+    "idf.gitPath",
+    "idf.pythonBinPath",
+    "idf.port",
+    "idf.toolsPath",
+  ];
+
   export namespace Rainmaker {
     export let store: RainmakerStore;
     export namespace OAuth {

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -19,8 +19,6 @@ import { ESP } from "./config";
 
 const locDic = new LocDictionary(__filename);
 
-
-
 export function addWinIfRequired(param: string) {
   const winFlag = process.platform === "win32" ? "Win" : "";
   for (const platDepConf of ESP.platformDepConfigurations) {

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -15,22 +15,15 @@
 import * as vscode from "vscode";
 import { LocDictionary } from "./localizationDictionary";
 import { Logger } from "./logger/logger";
-import { PreCheck } from "./utils";
+import { ESP } from "./config";
 
 const locDic = new LocDictionary(__filename);
 
-const platformDepConfigurations: string[] = [
-  "idf.espIdfPath",
-  "idf.espAdfPath",
-  "idf.espMdfPath",
-  "idf.pythonBinPath",
-  "idf.port",
-  "idf.toolsPath",
-];
+
 
 export function addWinIfRequired(param: string) {
   const winFlag = process.platform === "win32" ? "Win" : "";
-  for (const platDepConf of platformDepConfigurations) {
+  for (const platDepConf of ESP.platformDepConfigurations) {
     if (param.indexOf(platDepConf) >= 0) {
       return param + winFlag;
     }

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -39,6 +39,6 @@ export function getConfigurationSettings(
     toolsPath: conf.get("idf.toolsPath" + winFlag),
     systemEnvPath:
       process.platform === "win32" ? process.env.Path : process.env.PATH,
-    gitPath: conf.get("idf.gitPath")
+    gitPath: conf.get("idf.gitPath" + winFlag)
   };
 }


### PR DESCRIPTION
The need for a separated `idf.gitPathWin` and `idf.gitPath` is necessary to avoid setup issues as found in the Setup Wizard in WSL or Docker container scenarios. This was mentioned in [here](https://github.com/espressif/vscode-esp-idf-extension/issues/602#issuecomment-1077558246)