### PR TITLE
add spiffs and fat as data subtypes

### DIFF
--- a/src/test/suite/partitionTable.test.ts
+++ b/src/test/suite/partitionTable.test.ts
@@ -287,7 +287,7 @@ suite("PartitionTable Suite", () => {
     }];
     await assert.equal(JSON.stringify(isValidJSON(invalidRow)), JSON.stringify({ 
       ok: false,
-      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
+      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), \"fat\" (0x81), \"spiffs\" (0x82) or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
       row: 0
     }));
   });
@@ -304,7 +304,7 @@ suite("PartitionTable Suite", () => {
     }];
     await assert.equal(JSON.stringify(isValidJSON(invalidRow)), JSON.stringify({ 
       ok: false,
-      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
+      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), \"fat\" (0x81), \"spiffs\" (0x82) or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
       row: 0
     }));
   });
@@ -321,7 +321,7 @@ suite("PartitionTable Suite", () => {
     }];
     await assert.equal(JSON.stringify(isValidJSON(invalidRow)), JSON.stringify({ 
       ok: false,
-      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
+      error: "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), \"fat\" (0x81), \"spiffs\" (0x82) or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)",
       row: 0
     }));
   });

--- a/src/views/partition-table/components/Row.vue
+++ b/src/views/partition-table/components/Row.vue
@@ -98,7 +98,7 @@ export default class Row extends Vue {
         "test",
       ];
     } else if (this.sType === "data") {
-      return ["ota", "phy", "nvs", "nvs_keys"];
+      return ["fat", "ota", "phy", "nvs", "nvs_keys", "spiffs"];
     }
     return [];
   }

--- a/src/views/partition-table/util.ts
+++ b/src/views/partition-table/util.ts
@@ -51,8 +51,8 @@ export function isValidJSON(
     }
         // For type "data"
     if(row.type.match(/^(0x01|data)$/)) {
-      if(!row.subtype.match(/^(ota|phy|nvs|nvs_keys)$|^(0x)(([0][0-6])|[8][0-2])$/)) {
-        return "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)";
+      if(!row.subtype.match(/^(ota|phy|nvs|nvs_keys|spiffs|coredump|fat)$|^(0x)(([0][0-6])|[8][0-2])$/)) {
+        return "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), \"fat\" (0x81), \"spiffs\" (0x82) or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)";
       }
     }
         // For custom type

--- a/src/views/partition-table/util.ts
+++ b/src/views/partition-table/util.ts
@@ -35,7 +35,11 @@ export function isValidJSON(
     if (!row.type) {
       return "Type is required";
     }
-    if (!row.type.match(/^(0x00|0x01|app|data)$|^((0x)((([4-9a-e]|[A-E])[0-9a-fA-F])|([fF]([0-9a-e]|[A-E]))))$|^([01][0-9][0-9]|2[0-4][0-9]|25[0-4])$/)) {
+    if (
+      !row.type.match(
+        /^(0x00|0x01|app|data)$|^((0x)((([4-9a-e]|[A-E])[0-9a-fA-F])|([fF]([0-9a-e]|[A-E]))))$|^([01][0-9][0-9]|2[0-4][0-9]|25[0-4])$/
+      )
+    ) {
       return "Partition type field can be specified as app (0x00) or data (0x01). Or it can be a number 0-254 (or as hex 0x00-0xFE). Types 0x00-0x3F are reserved for ESP-IDF core functions.";
     }
 
@@ -43,28 +47,39 @@ export function isValidJSON(
     if (!row.subtype) {
       return "SubType is required";
     }
-        // For type "app"
-    if(row.type.match(/^(0x00|app)$/)) {
-      if(!row.subtype.match(/^(factory|test|ota_[0-9]|ota_1[0-5]|test|0x00)$|^(0x)(([1][0-9a-fA-F])|[2][0])$/)) {
+    // For type "app"
+    if (row.type.match(/^(0x00|app)$/)) {
+      if (
+        !row.subtype.match(
+          /^(factory|test|ota_[0-9]|ota_1[0-5]|test|0x00)$|^(0x)(([1][0-9a-fA-F])|[2][0])$/
+        )
+      ) {
         return "When type is \"app\", the subtype field can only be specified as \"factory\" (0x00), \"ota_0\" (0x10) … \"ota_15\" (0x1F) or \"test\" (0x20)";
       }
     }
-        // For type "data"
-    if(row.type.match(/^(0x01|data)$/)) {
-      if(!row.subtype.match(/^(ota|phy|nvs|nvs_keys|spiffs|coredump|fat)$|^(0x)(([0][0-6])|[8][0-2])$/)) {
+    // For type "data"
+    if (row.type.match(/^(0x01|data)$/)) {
+      if (
+        !row.subtype.match(
+          /^(ota|phy|nvs|nvs_keys|spiffs|coredump|fat)$|^(0x)(([0][0-6])|[8][0-2])$/
+        )
+      ) {
         return "When type is \"data\", the subtype field can be specified as \"ota\" (0x00), \"phy\" (0x01), \"nvs\" (0x02), \"nvs_keys\" (0x04), \"fat\" (0x81), \"spiffs\" (0x82) or a range of other component-specific subtypes (0x05, 0x06, 0x80, 0x81, 0x82)";
       }
     }
-        // For custom type
-    if(row.type.match(/^((0x)[4-9a-fA-F]([0-9a-e]|[A-E]))$/)) {
-      if(!row.subtype.match(/^((0x)[0-9a-fA-F]([0-9a-e]|[A-E]))$/)) {
+    // For custom type
+    if (row.type.match(/^((0x)[4-9a-fA-F]([0-9a-e]|[A-E]))$/)) {
+      if (!row.subtype.match(/^((0x)[0-9a-fA-F]([0-9a-e]|[A-E]))$/)) {
         return "If the partition type is any application-defined value (range 0x40-0xFE), then subtype field can be any value chosen by the application (range 0x00-0xFE).";
       }
     }
 
     // Offset
-    if(row.offset !== "" && !row.offset.match(/(^((0x)[0-9a-fA-F]*)$)|^([0-9]*)$|([0-9]*((K|M)$))/)) {
-      return "Offsets can be specified as decimal numbers, hex numbers with the prefix 0x, size multipliers K or M (1024 and 1024*1024 bytes) or left empty."
+    if (
+      row.offset !== "" &&
+      !row.offset.match(/(^((0x)[0-9a-fA-F]*)$)|^([0-9]*)$|([0-9]*((K|M)$))/)
+    ) {
+      return "Offsets can be specified as decimal numbers, hex numbers with the prefix 0x, size multipliers K or M (1024 and 1024*1024 bytes) or left empty.";
     }
 
     // Size


### PR DESCRIPTION
Fix #744

Add `spiffs` and `fat` as data subtypes in the partition table editor