### PR TITLE
add space validation doctor cmd setup wizard

### DIFF
--- a/.github/actions/idf/entrypoint.sh
+++ b/.github/actions/idf/entrypoint.sh
@@ -7,6 +7,7 @@ export OLD_PATH=$PATH
 
 cd /github/workspace
 
+pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r esp_debug_adapter/requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Installation of ESP-IDF and ESP-IDF Tools is being done from this extension itse
 
   > **NOTE:** Please take a look at [Working with multiple projects](./docs/MULTI_PROJECTS.md) for more information. Default is User settings.
 
-- On the first time using the extension, press <kbd>F1</kbd> and type **ESP-IDF: Configure ESP-IDF extension** to open the extension configuration wizard. This will install ESP-IDF, ESP-IDF tools, create a virtual python environment with ESP-IDF and this extension python packages and configure the extension settings with these values.
+- On the first time using the extension, press <kbd>F1</kbd> and type **ESP-IDF: Configure ESP-IDF extension** to open the extension configuration wizard. This will install ESP-IDF, ESP-IDF tools, create a virtual python environment with ESP-IDF and this extension python packages and configure the extension settings with these values. **NOTE: Make sure that there is no spaces in any configured path since [ESP-IDF build system doesn't support spaces yet.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html#start-a-project)**. 
 
   > **NOTE:** Please take a look at [SETUP](./docs/SETUP.md) documentation or the [Install](./docs/tutorial/install.md) tutorial for details about extension setup and configuration.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -57,7 +57,7 @@ so make sure that if using an existing python virtual environment that installin
 
 > **NOTE:** Currently the python package `pygdbmi` used by the debug adapter still depends on some Python 2.7 libraries (libpython2.7.so.1.0) so make sure that the Python executable in `idf.pythonBinPath` you use contains these libraries. This will be dropped in later versions of ESP-IDF.
 
-> **NOTE:** Make sure that `IDF_PATH` and `IDF_TOOLS_PATH` doesn't have any spaces to avoid any build issues.
+> **NOTE:** Make sure that `IDF_PATH` and `IDF_TOOLS_PATH` doesn't have any spaces to avoid any build issues since [ESP-IDF build system doesn't support spaces yet.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html#start-a-project).
 
 After choosing any of the previous options, a status page is displayed showing ESP-IDF, tools and python environment setup progress status. When the setup is finished, a message is shown that "All settings have been configured. You can close this window."
 

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -307,7 +307,8 @@ export class SetupPanel {
     const errMsg = error.message ? error.message : "Error during ESP-IDF setup";
     if (
       errMsg.indexOf("ERROR_EXISTING_ESP_IDF") !== -1 ||
-      errMsg.indexOf("IDF_PATH_WITH_SPACES") !== -1
+      errMsg.indexOf("IDF_PATH_WITH_SPACES") !== -1 ||
+      errMsg.indexOf("IDF_TOOLS_PATH_WITH_SPACES") !== -1
     ) {
       SetupPanel.postMessage({
         command: "setEspIdfErrorStatus",

--- a/src/support/checkSpacesInSettings.ts
+++ b/src/support/checkSpacesInSettings.ts
@@ -1,0 +1,67 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Tuesday, 19th July 2022 1:35:38 pm
+ * Copyright 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { delimiter } from "path";
+import { checkSpacesInPath } from "../utils";
+import { reportObj } from "./types";
+
+export function checkSpacesInSettings(reportedResult: reportObj) {
+  reportedResult.configurationSpacesValidation.espAdfPath = checkSpacesInPath(
+    reportedResult.configurationSettings.espAdfPath
+  );
+
+  reportedResult.configurationSpacesValidation.espIdfPath = checkSpacesInPath(
+    reportedResult.configurationSettings.espIdfPath
+  );
+
+  reportedResult.configurationSpacesValidation.espMatterPath = checkSpacesInPath(
+    reportedResult.configurationSettings.espMatterPath
+  );
+
+  reportedResult.configurationSpacesValidation.espMdfPath = checkSpacesInPath(
+    reportedResult.configurationSettings.espMdfPath
+  );
+
+  reportedResult.configurationSpacesValidation.pythonBinPath = checkSpacesInPath(
+    reportedResult.configurationSettings.pythonBinPath
+  );
+
+  reportedResult.configurationSpacesValidation.toolsPath = checkSpacesInPath(
+    reportedResult.configurationSettings.toolsPath
+  );
+  reportedResult.configurationSpacesValidation.gitPath = checkSpacesInPath(
+    reportedResult.configurationSettings.gitPath
+  );
+
+  reportedResult.configurationSpacesValidation.customExtraPaths = {};
+  if (
+    reportedResult.configurationSettings.customExtraPaths &&
+    reportedResult.configurationSettings.customExtraPaths.length
+  ) {
+    const toolPathsArray = reportedResult.configurationSettings.customExtraPaths.split(
+      delimiter
+    );
+    for (const tool of toolPathsArray) {
+      reportedResult.configurationSpacesValidation.customExtraPaths[
+        tool
+      ] = checkSpacesInPath(tool);
+    }
+  }
+  reportedResult.configurationSpacesValidation.systemEnvPath = checkSpacesInPath(
+    reportedResult.configurationSettings.systemEnvPath
+  );
+}

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 30th December 2020 4:02:17 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,14 +16,15 @@
  * limitations under the License.
  */
 import { reportObj } from "./types";
-import * as vscode from "vscode";
+import { Uri, workspace } from "vscode";
 
 export function getConfigurationSettings(
   reportedResult: reportObj,
-  scope?: vscode.ConfigurationScope
+  scope?: Uri
 ) {
   const winFlag = process.platform === "win32" ? "Win" : "";
-  const conf = vscode.workspace.getConfiguration("", scope);
+  const conf = workspace.getConfiguration("", scope);
+  reportedResult.workspaceFolder = scope.fsPath;
   reportedResult.configurationSettings = {
     espAdfPath: conf.get("idf.espAdfPath" + winFlag),
     espIdfPath: conf.get("idf.espIdfPath" + winFlag),

--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 23rd December 2020 4:35:32 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,6 +34,7 @@ import {
 import { writeTextReport } from "./writeReport";
 import { checkSystemInfo } from "./checkSystemInfo";
 import { checkCCppPropertiesJson, checkLaunchJson } from "./checkVscodeFiles";
+import { checkSpacesInSettings } from "./checkSpacesInSettings";
 
 export async function generateConfigurationReport(
   context: vscode.ExtensionContext,
@@ -43,6 +44,7 @@ export async function generateConfigurationReport(
   getConfigurationSettings(reportedResult, currentWorkspace);
   await checkSystemInfo(reportedResult);
   await getConfigurationAccess(reportedResult, context);
+  checkSpacesInSettings(reportedResult);
   await getGitVersion(reportedResult, context);
   await getEspIdfVersion(reportedResult);
   await getPythonVersion(reportedResult, context);

--- a/src/support/initReportObj.ts
+++ b/src/support/initReportObj.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 30th December 2020 5:20:44 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,6 +45,17 @@ export function initializeReportObject() {
     cmakeInEnv: undefined,
     ninjaInEnv: undefined,
     toolsPath: undefined,
+  };
+  report.configurationSpacesValidation = {
+    customExtraPaths: undefined,
+    espAdfPath: undefined,
+    espIdfPath: undefined,
+    espMatterPath: undefined,
+    espMdfPath: undefined,
+    gitPath: undefined,
+    pythonBinPath: undefined,
+    toolsPath: undefined,
+    systemEnvPath: undefined,
   };
   report.debugAdapterRequirements = {
     output: undefined,
@@ -94,5 +105,6 @@ export function initializeReportObject() {
     systemName: undefined,
     vscodeVersion: undefined,
   };
+  report.workspaceFolder = undefined;
   return report;
 }

--- a/src/support/types.ts
+++ b/src/support/types.ts
@@ -43,6 +43,18 @@ export class Configuration {
   gitPath: string;
 }
 
+export class ConfigurationSpacesValidation {
+  systemEnvPath: boolean;
+  espIdfPath: boolean;
+  espAdfPath: boolean;
+  espMdfPath: boolean;
+  espMatterPath: boolean;
+  customExtraPaths: { [key: string]: boolean };
+  pythonBinPath: boolean;
+  toolsPath: boolean;
+  gitPath: boolean;
+}
+
 export class SystemInfo {
   architecture: string;
   envIdfPythonEnvPath: string;
@@ -76,6 +88,7 @@ export class execResult {
 export class reportObj {
   configurationSettings: Configuration;
   configurationAccess: ConfigurationAccess;
+  configurationSpacesValidation: ConfigurationSpacesValidation;
   espIdfToolsVersions: idfToolResult[];
   espIdfVersion: execResult;
   gitVersion: execResult;
@@ -90,4 +103,5 @@ export class reportObj {
   debugAdapterRequirements: execResult;
   formatedOutput: string;
   systemInfo: SystemInfo;
+  workspaceFolder: string;
 }

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 30th December 2020 5:07:59 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ export async function writeTextReport(
   output += `Visual Studio Code language ${reportedResult.systemInfo.language} ${EOL}`;
   output += `Visual Studio Code shell ${reportedResult.systemInfo.shell} ${EOL}`;
   output += `ESP-IDF Extension version ${reportedResult.systemInfo.extensionVersion} ${EOL}`;
+  output += `Workspace folder ${reportedResult.workspaceFolder} ${EOL}`;
   output += `---------------------------------------------------- Extension configuration settings ------------------------------------------------------${EOL}`;
   output += `ESP-ADF Path (idf.espAdfPath) ${reportedResult.configurationSettings.espAdfPath}${EOL}`;
   output += `ESP-IDF Path (idf.espIdfPath) ${reportedResult.configurationSettings.espIdfPath}${EOL}`;
@@ -60,6 +61,18 @@ export async function writeTextReport(
   output += `Access to CMake in environment PATH ${reportedResult.configurationAccess.cmakeInEnv}${EOL}`;
   output += `Access to Ninja in environment PATH ${reportedResult.configurationAccess.ninjaInEnv}${EOL}`;
   output += `Access to ESP-IDF Tools Path (idf.toolsPath) ${reportedResult.configurationAccess.toolsPath}${EOL}`;
+  output += `-------------------------------------------------------- Configurations has spaces -------------------------------------------------------------${EOL}`;
+  output += `Spaces in system environment Path ${reportedResult.configurationSpacesValidation.systemEnvPath}${EOL}`;
+  output += `Spaces in ESP-ADF Path (idf.espAdfPath) ${reportedResult.configurationSpacesValidation.espAdfPath}${EOL}`;
+  output += `Spaces in ESP-IDF Path (idf.espIdfPath) ${reportedResult.configurationSpacesValidation.espIdfPath}${EOL}`;
+  output += `Spaces in ESP-MDF Path (idf.espMdfPath) ${reportedResult.configurationSpacesValidation.espMdfPath}${EOL}`;
+  output += `Spaces in ESP-Matter Path (idf.espMatterPath) ${reportedResult.configurationSpacesValidation.espMatterPath}${EOL}`;
+  output += `Spaces in ESP-IDF Custom extra paths${EOL}`;
+  for (let key in reportedResult.configurationSpacesValidation.customExtraPaths) {
+    output += `Spaces in ${key}: ${reportedResult.configurationSpacesValidation.customExtraPaths[key]}${EOL}`;
+  }
+  output += `Spaces in Virtual env Python Path (idf.pythonBinPath) ${reportedResult.configurationSpacesValidation.pythonBinPath}${EOL}`;
+  output += `Spaces in ESP-IDF Tools Path (idf.toolsPath) ${reportedResult.configurationSpacesValidation.toolsPath}${EOL}`;
   output += `----------------------------------------------------------- Executables Versions -----------------------------------------------------------${EOL}`;
   output += `Git version ${
     reportedResult.gitVersion.result

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 7th April 2021 4:04:27 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -150,7 +150,10 @@ suite("Doctor command tests", () => {
     const settingsJsonObj = await readJSON(
       join(__dirname, "../../testFiles/testWorkspace/.vscode/settings.json")
     );
-    getConfigurationSettings(reportObj);
+    getConfigurationSettings(
+      reportObj,
+      vscode.Uri.file(join(__dirname, "../../testFiles/testWorkspace"))
+    );
     assert.equal(
       reportObj.configurationSettings.espAdfPath,
       settingsJsonObj["idf.espAdfPath"]
@@ -240,7 +243,7 @@ suite("Doctor command tests", () => {
         assert.equal(
           reportObj.configurationAccess.espIdfToolsPaths[toolPath],
           true
-        ); 
+        );
       }
     }
   });

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 7th April 2021 4:04:27 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -297,6 +297,7 @@ suite("Doctor command tests", () => {
     expectedOutput += `Visual Studio Code language ${vscode.env.language} ${os.EOL}`;
     expectedOutput += `Visual Studio Code shell ${vscode.env.shell} ${os.EOL}`;
     expectedOutput += `ESP-IDF Extension version ${extensionObj.packageJSON.version} ${os.EOL}`;
+    expectedOutput += `Workspace folder ${reportObj.workspaceFolder} ${os.EOL}`;
     expectedOutput += `---------------------------------------------------- Extension configuration settings ------------------------------------------------------${os.EOL}`;
     expectedOutput += `ESP-ADF Path (idf.espAdfPath) ${reportObj.configurationSettings.espAdfPath}${os.EOL}`;
     expectedOutput += `ESP-IDF Path (idf.espIdfPath) ${process.env.IDF_PATH}${os.EOL}`;

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -274,7 +274,7 @@ suite("Doctor command tests", () => {
   test("Match python packages", async () => {
     reportObj.configurationSettings.pythonBinPath = `${process.env.IDF_PYTHON_ENV_PATH}/bin/python`;
     console.log(process.env.PY_PKGS);
-    const expectedPyPkgs = JSON.parse(process.env.PY_PKGS.trim());
+    const expectedPyPkgs = JSON.parse(JSON.stringify(process.env.PY_PKGS).trim());
     await getPythonPackages(reportObj, mockUpContext);
     console.log(reportObj.configurationSettings.pythonPackages);
     assert.deepEqual(

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -273,9 +273,9 @@ suite("Doctor command tests", () => {
 
   test("Match python packages", async () => {
     reportObj.configurationSettings.pythonBinPath = `${process.env.IDF_PYTHON_ENV_PATH}/bin/python`;
+    console.log(process.env.PY_PKGS);
     const expectedPyPkgs = JSON.parse(process.env.PY_PKGS);
     await getPythonPackages(reportObj, mockUpContext);
-    console.log(expectedPyPkgs);
     console.log(reportObj.configurationSettings.pythonPackages);
     assert.deepEqual(
       reportObj.configurationSettings.pythonPackages,

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -274,7 +274,7 @@ suite("Doctor command tests", () => {
   test("Match python packages", async () => {
     reportObj.configurationSettings.pythonBinPath = `${process.env.IDF_PYTHON_ENV_PATH}/bin/python`;
     console.log(process.env.PY_PKGS);
-    const expectedPyPkgs = JSON.parse(process.env.PY_PKGS);
+    const expectedPyPkgs = JSON.parse(process.env.PY_PKGS.trim());
     await getPythonPackages(reportObj, mockUpContext);
     console.log(reportObj.configurationSettings.pythonPackages);
     assert.deepEqual(

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -273,10 +273,8 @@ suite("Doctor command tests", () => {
 
   test("Match python packages", async () => {
     reportObj.configurationSettings.pythonBinPath = `${process.env.IDF_PYTHON_ENV_PATH}/bin/python`;
-    console.log(process.env.PY_PKGS);
-    const expectedPyPkgs = JSON.parse(JSON.stringify(process.env.PY_PKGS).trim());
+    const expectedPyPkgs = JSON.parse(process.env.PY_PKGS);
     await getPythonPackages(reportObj, mockUpContext);
-    console.log(reportObj.configurationSettings.pythonPackages);
     assert.deepEqual(
       reportObj.configurationSettings.pythonPackages,
       expectedPyPkgs

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -275,6 +275,8 @@ suite("Doctor command tests", () => {
     reportObj.configurationSettings.pythonBinPath = `${process.env.IDF_PYTHON_ENV_PATH}/bin/python`;
     const expectedPyPkgs = JSON.parse(process.env.PY_PKGS);
     await getPythonPackages(reportObj, mockUpContext);
+    console.log(expectedPyPkgs);
+    console.log(reportObj.configurationSettings.pythonPackages);
     assert.deepEqual(
       reportObj.configurationSettings.pythonPackages,
       expectedPyPkgs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -533,6 +533,10 @@ export function isStringNotEmpty(str: string) {
   return !!str.trim();
 }
 
+export function checkSpacesInPath(pathStr: string) {
+  return /\s+/g.test(pathStr);
+}
+
 export async function getElfFilePath(
   workspaceURI: vscode.Uri
 ): Promise<string> {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fix #742
Fix #751 

## Type of change

Add validation of spaces in path in both the setup wizard and the doctor command.

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual testing observing result in doctor command and the Setup Wizard with wrong and good paths.

**Test Configuration**:
* ESP-IDF Version: v5.0
* OS (Windows,Linux and macOS): MacOS

## Dependent components impacted by this PR:

No components impacted.

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
