### PR TITLE
add existing project tutorial

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -19,6 +19,7 @@
 13. [New project wizard](./tutorial/new_project_wizard.md)
 14. [Developing on Docker Container](./tutorial/using-docker-container.md)
 15. [Developing on WSL](./tutorial/wsl.md)
+16. [Open existing ESP-IDF project](./existing_idf_project.md)
 
 ## Documentation
 

--- a/docs/tutorial/existing_idf_project.md
+++ b/docs/tutorial/existing_idf_project.md
@@ -1,4 +1,4 @@
-# Opening an existing ESP-IDF project 
+# Opening an existing ESP-IDF project
 
 An ESP-IDF project follow the tree directory structure as shown in [ESP-IDF Example project](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-project) is:
 
@@ -32,4 +32,4 @@ As shown in [working with multiple projects](../MULTI_PROJECTS.md), there are ma
 
 2. You can already use the existing setup to build, flash and monitor the existing project. To debug, you need the `esp-idf` launch.json which can be added by running the `ESP-IDF: Add vscode configuration folder` command.
 
-3. If you want to open the project within the ESP-IDF Docker container, use the `ESP-IDF: Add docker container configuration` and use the `Remote - Containers: Open folder in remote container`.
+3. If you want to open the project within the ESP-IDF Docker container, use the `ESP-IDF: Add docker container configuration` command to add the `.devcontainer` directory which allows the user to use the `Remote - Containers: Open folder in remote container` to open the existing project into a container.

--- a/docs/tutorial/existing_idf_project.md
+++ b/docs/tutorial/existing_idf_project.md
@@ -1,0 +1,35 @@
+# Opening an existing ESP-IDF project 
+
+An ESP-IDF project follow the tree directory structure as shown in [ESP-IDF Example project](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-project) is:
+
+```
+- myProject/
+             - CMakeLists.txt
+             - sdkconfig
+             - components/ - component1/ - CMakeLists.txt
+                                         - Kconfig
+                                         - src1.c
+                           - component2/ - CMakeLists.txt
+                                         - Kconfig
+                                         - src1.c
+                                         - include/ - component2.h
+             - main/       - CMakeLists.txt
+                           - src1.c
+                           - src2.c
+
+             - build/
+```
+
+When you open a directory in Visual Studio Code with menu `File` -> `Open Folder` which contains a **CMakeLists.txt** file in the root directory (myProject) that follows the ESP-IDF structure.
+
+If you need to add Visual Studio Code configuration files, use the `ESP-IDF: Add vscode configuration folder` command to add these files to the existing folder.
+
+If you want to use a project in a Docker container with Visual Studio Code [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension you can use the `ESP-IDF: Add docker container configuration` command to add required `Dockerfile` and `.devcontainer` json files.
+
+As shown in [working with multiple projects](../MULTI_PROJECTS.md), there are many places where configuration settings could be saved based on `idf.saveScope` and how to work with multiple debug and tasks configuration.
+
+1. Open an example ESP-IDF project, like the [blink example](https://github.com/espressif/esp-idf/tree/master/examples/get-started/blink) with `File` -> `Open Folder`.
+
+2. You can already use the existing setup to build, flash and monitor the existing project. To debug, you need the `esp-idf` launch.json which can be added by running the `ESP-IDF: Add vscode configuration folder` command.
+
+3. If you want to open the project within the ESP-IDF Docker container, use the `ESP-IDF: Add docker container configuration` and use the `Remote - Containers: Open folder in remote container`.

--- a/docs/tutorial/toc.md
+++ b/docs/tutorial/toc.md
@@ -17,3 +17,4 @@
 13. [New project wizard](./new_project_wizard.md)
 14. [Developing on Docker Container](./using-docker-container.md)
 15. [Developing on WSL](./wsl.md)
+16. [Open existing ESP-IDF project](./existing_idf_project.md)

--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -31,7 +31,7 @@ RUN wget --no-verbose ${QEMU_URL} \
 
 ENV PATH=/opt/qemu/bin:${PATH}
 
-RUN echo $($IDF_PATH/tools/idf_tools.py export) >> $HOME/.bashrc
+RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
 
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
 

--- a/templates/.devcontainer/devcontainer.json
+++ b/templates/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 		"terminal.integrated.defaultProfile.linux": "bash",
 		"idf.espIdfPath": "/opt/esp/idf",
 		"idf.customExtraPaths": "",
-		"idf.pythonBinPath": "${env:IDF_PYTHON_ENV_PATH}/bin/python",
+		"idf.pythonBinPath": "/opt/esp/python_env/idf5.0_py3.8_env/bin/python",
 		"idf.toolsPath": "/opt/esp",
 		"idf.gitPath": "/usr/bin/git"
 	},

--- a/templates/.devcontainer/devcontainer.json
+++ b/templates/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 		"terminal.integrated.defaultProfile.linux": "bash",
 		"idf.espIdfPath": "/opt/esp/idf",
 		"idf.customExtraPaths": "",
-		"idf.pythonBinPath": "/opt/esp/python_env/idf5.0_py3.8_env/bin/python",
+		"idf.pythonBinPath": "${env:IDF_PYTHON_ENV_PATH}/bin/python",
 		"idf.toolsPath": "/opt/esp",
 		"idf.gitPath": "/usr/bin/git"
 	},


### PR DESCRIPTION
## Description

Add using existing ESP-IDF project and add vscode specific settings.

## Type of change

- Documentation of using existing ESP-IDF project.

## How has this been tested?

Adding documentation

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
