### PR TITLE
Add double quotes around constraints file path (VSC-957)

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -184,7 +184,7 @@ export async function installExtensionPyReqs(
   const constrainsFileExists = await pathExists(constrainsFile);
   let constraintArg = "";
   if (constrainsFileExists) {
-    constraintArg = `--constraint ${constrainsFile} `;
+    constraintArg = `--constraint "${constrainsFile}" `;
   } else {
     const extensionConstraintsFile = path.join(
       utils.extensionContext.extensionPath,
@@ -194,7 +194,7 @@ export async function installExtensionPyReqs(
       extensionConstraintsFile
     );
     if (extensionConstraintsFileExists) {
-      constraintArg = `--constraint ${extensionConstraintsFile} `;
+      constraintArg = `--constraint "${extensionConstraintsFile}" `;
     }
   }
   await execProcessWithLog(


### PR DESCRIPTION
## Description

Without the quotes setup fails on Windows if there are spaces in the user profile name. This is due to VSCode usually downloading extensions to 'C:\Users\User Name\.vscode'

Fix #787 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
Setup failed on VSCode using the unmodified esp-idf extension v1.5.0

Added double quotes around --constraints {v} in extension.js, reran setup and it installed correctly

**Test Configuration**:
* ESP-IDF Version: 4.4.2
* OS (Windows,Linux and macOS): Windows 10 x64

## Dependent components impacted by this PR:

None?

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
