### PR TITLE
rm managed components on full clean cmd

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -89,17 +89,18 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
 ## Extension Behaviour Settings
 
-| Setting ID                             | Description                                                              | Scope                     |
-| -------------------------------------- | ------------------------------------------------------------------------ | ------------------------- |
-| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)            | User, Remote or Workspace |
-| `idf.flashType`                        | Preferred flash method. DFU, UART or JTAG                                |                           |
-| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                  |                           |
-| `idf.notificationSilentMode`           | Silent all notifications messages and show tasks output (default `true`) | User, Remote or Workspace |
-| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation                | User, Remote or Workspace |
-| `idf.saveScope`                        | Where to save extension settings                                         | User, Remote or Workspace |
-| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)               |                           |
-| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                |                           |
-| `idf.telemetry`                        | Enable Telemetry                                                         | User, Remote or Workspace |
+| Setting ID                             | Description                                                                 | Scope                     |
+| -------------------------------------- | --------------------------------------------------------------------------- | ------------------------- |
+| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)               | User, Remote or Workspace |
+| `idf.flashType`                        | Preferred flash method. DFU, UART or JTAG                                   |                           |
+| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                     |                           |
+| `idf.notificationSilentMode`           | Silent all notifications messages and show tasks output (default `true`)    | User, Remote or Workspace |
+| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation                   | User, Remote or Workspace |
+| `idf.saveScope`                        | Where to save extension settings                                            | User, Remote or Workspace |
+| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)                  |                           |
+| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                   |                           |
+| `idf.telemetry`                        | Enable Telemetry                                                            | User, Remote or Workspace |
+| `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`) | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -93,6 +93,7 @@
   "param.customTask": "Custom task",
   "param.buildDirectoryName": "Name of CMake build directory",
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
+  "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -96,6 +96,7 @@
   "param.customTask": "Tarea personalizada",
   "param.buildDirectoryName": "Nombre del directorio de construcción de CMake",
   "param.svdFile": "Archivo SVD para la vista de perifericos en ventana de depuracion",
+  "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -96,6 +96,7 @@
   "param.customTask": "Специальная задача",
   "param.buildDirectoryName": "Имя каталога сборки CMake",
   "param.svdFile": "Файл SVD для разрешения периферийного представления ESP-IDF в представлении отладки",
+  "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -96,6 +96,7 @@
   "param.customTask": "自定义任务",
   "param.buildDirectoryName": "CMake生成目录的名称",
   "param.svdFile": "用于在调试视图中解析ESP-IDF外围视图的奇异值分解文件",
+  "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -797,6 +797,12 @@
             "default": "${workspaceFolder}/esp32.svd",
             "scope": "resource",
             "description": "%param.svdFile%"
+          },
+          "idf.deleteComponentsOnFullClean": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "description": "%param.deleteComponentsOnFullClean%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -92,6 +92,7 @@
   "param.preFlashTask": "Pre flash custom task",
   "param.postFlashTask": "Post flash custom task",
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
+  "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "param.buildDirectoryName": "Name of CMake build directory",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -211,6 +211,7 @@
     "param.postBuildTask",
     "param.preFlashTask",
     "param.postFlashTask",
-    "param.svdFile"
+    "param.svdFile",
+    "param.deleteComponentsOnFullClean"
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -572,6 +572,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
       try {
         await del(buildDir, { force: true });
+        const delComponentsOnFullClean = (await idfConf.readParameter(
+          "idf.deleteComponentsOnFullClean",
+          workspaceRoot
+        )) as boolean;
+        if (delComponentsOnFullClean) {
+          const managedComponents = path.join(
+            workspaceRoot.fsPath,
+            "managed_components"
+          );
+          const componentDirExists = await pathExists(managedComponents);
+          if (componentDirExists) {
+            await del(managedComponents, { force: true });
+          }
+        }
       } catch (error) {
         Logger.errorNotify(error.message, error);
       }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes #785

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Remove the `managed_components` workspace directory when `idf.deleteComponentsOnFullClean` is enabled (default is false.

- Manual testing

**Test Configuration**:
* ESP-IDF Version: v5.0
* OS (Windows,Linux and macOS): MacOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
