### PR TITLE
use absolute build path over workspace relative

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -12,23 +12,23 @@ The `idf.saveScope` allows the user to specify where to save settings when using
 
 These are the configuration settings that ESP-IDF extension contributes to your Visual Studio Code editor settings.
 
-| Setting ID                      | Description                                                                   |
-| ------------------------------- | ----------------------------------------------------------------------------- |
-| `idf.buildDirectoryName`        | Custom build directory name for extension commands. (Default: build)          |
-| `idf.cmakeCompilerArgs`         | Arguments for CMake compilation task                                          |
-| `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                |
-| `idf.customExtraVars`           | Variables to be added to system environment variables                         |
-| `idf.gitPath`                   | Path to git executable                                                        |
-| `idf.gitPathWin`                | Path to git executable in Windows                                             |
-| `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                     |
-| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                 |
-| `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                   |
-| `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                        |
-| `idf.ninjaArgs`                 | Arguments for Ninja build task                                                |
-| `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts            |
-| `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows |
-| `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                 |
-| `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                      |
+| Setting ID                      | Description                                                                              |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `idf.buildDirectoryName`        | Custom build directory name for extension commands. (Default: \${workspaceFolder}/build) |
+| `idf.cmakeCompilerArgs`         | Arguments for CMake compilation task                                                     |
+| `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                           |
+| `idf.customExtraVars`           | Variables to be added to system environment variables                                    |
+| `idf.gitPath`                   | Path to git executable                                                                   |
+| `idf.gitPathWin`                | Path to git executable in Windows                                                        |
+| `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                                |
+| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                            |
+| `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                              |
+| `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                                   |
+| `idf.ninjaArgs`                 | Arguments for Ninja build task                                                           |
+| `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts                       |
+| `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows            |
+| `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                            |
+| `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                                 |
 
 This is how the extension uses them:
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -12,23 +12,24 @@ The `idf.saveScope` allows the user to specify where to save settings when using
 
 These are the configuration settings that ESP-IDF extension contributes to your Visual Studio Code editor settings.
 
-| Setting ID                      | Description                                                                              |
-| ------------------------------- | ---------------------------------------------------------------------------------------- |
-| `idf.buildDirectoryName`        | Custom build directory name for extension commands. (Default: \${workspaceFolder}/build) |
-| `idf.cmakeCompilerArgs`         | Arguments for CMake compilation task                                                     |
-| `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                           |
-| `idf.customExtraVars`           | Variables to be added to system environment variables                                    |
-| `idf.gitPath`                   | Path to git executable                                                                   |
-| `idf.gitPathWin`                | Path to git executable in Windows                                                        |
-| `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                                |
-| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                            |
-| `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                              |
-| `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                                   |
-| `idf.ninjaArgs`                 | Arguments for Ninja build task                                                           |
-| `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts                       |
-| `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows            |
-| `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                            |
-| `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                                 |
+| Setting ID                      | Description                                                                               |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `idf.buildPath`                 | Custom build directory name for extension commands. (Default: \${workspaceFolder}/build)  |
+| `idf.buildPathWin`              | Custom build directory name for extension commands. (Default: \${workspaceFolder}\\build) |
+| `idf.cmakeCompilerArgs`         | Arguments for CMake compilation task                                                      |
+| `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                            |
+| `idf.customExtraVars`           | Variables to be added to system environment variables                                     |
+| `idf.gitPath`                   | Path to git executable                                                                    |
+| `idf.gitPathWin`                | Path to git executable in Windows                                                         |
+| `idf.enableCCache`              | Enable CCache on build task (make sure CCache is in PATH)                                 |
+| `idf.enableIdfComponentManager` | Enable IDF Component manager in build command                                             |
+| `idf.espIdfPath`                | Path to locate ESP-IDF framework (IDF_PATH)                                               |
+| `idf.espIdfPathWin`             | Path to locate ESP-IDF framework in Windows (IDF_PATH)                                    |
+| `idf.ninjaArgs`                 | Arguments for Ninja build task                                                            |
+| `idf.pythonBinPath`             | Python absolute binary path used to execute ESP-IDF Python Scripts                        |
+| `idf.pythonBinPathWin`          | Python absolute binary path used to execute ESP-IDF Python Scripts in Windows             |
+| `idf.toolsPath`                 | Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)                                             |
+| `idf.toolsPathWin`              | Path to locate ESP-IDF Tools in Windows (IDF_TOOLS_PATH)                                  |
 
 This is how the extension uses them:
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -91,7 +91,7 @@
   "param.preFlashTask": "Pre flash custom task",
   "param.postFlashTask": "Post flash custom task",
   "param.customTask": "Custom task",
-  "param.buildDirectoryName": "Name of CMake build directory",
+  "param.buildPath": "Name of CMake build directory",
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "view.components.name": "Project Components",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -94,7 +94,7 @@
   "param.preFlashTask": "Pre build tarea personalizada",
   "param.postFlashTask": "Post build tarea personalizada",
   "param.customTask": "Tarea personalizada",
-  "param.buildDirectoryName": "Nombre del directorio de construcción de CMake",
+  "param.buildPath": "Nombre del directorio de construcción de CMake",
   "param.svdFile": "Archivo SVD para la vista de perifericos en ventana de depuracion",
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "view.components.name": "Componentes de proyecto",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -94,7 +94,7 @@
   "param.preFlashTask": "Специальная задача предварительной прошивки",
   "param.postFlashTask": "Опубликовать настраиваемую задачу Flash",
   "param.customTask": "Специальная задача",
-  "param.buildDirectoryName": "Имя каталога сборки CMake",
+  "param.buildPath": "Имя каталога сборки CMake",
   "param.svdFile": "Файл SVD для разрешения периферийного представления ESP-IDF в представлении отладки",
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "view.components.name": "Компоненты проекта",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -94,7 +94,7 @@
   "param.preFlashTask": "闪存前自定义任务",
   "param.postFlashTask": "flash后自定义任务",
   "param.customTask": "自定义任务",
-  "param.buildDirectoryName": "CMake生成目录的名称",
+  "param.buildPath": "CMake生成目录的名称",
   "param.svdFile": "用于在调试视图中解析ESP-IDF外围视图的奇异值分解文件",
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "view.components.name": "项目组件",

--- a/package.json
+++ b/package.json
@@ -485,7 +485,13 @@
           },
           "idf.buildDirectoryName": {
             "type": "string",
-            "default": "build",
+            "default": "${workspaceFolder}/build",
+            "description": "%param.buildDirectoryName%",
+            "scope": "resource"
+          },
+          "idf.buildDirectoryNameWin": {
+            "type": "string",
+            "default": "${workspaceFolder}\\build",
             "description": "%param.buildDirectoryName%",
             "scope": "resource"
           },

--- a/package.json
+++ b/package.json
@@ -501,8 +501,7 @@
               "-G",
               "Ninja",
               "-DPYTHON_DEPS_CHECKED=1",
-              "-DESP_PLATFORM=1",
-              ".."
+              "-DESP_PLATFORM=1"
             ],
             "description": "%param.cmakeCompilerArgs%",
             "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -483,16 +483,16 @@
             "description": "%param.adapterTargetName%",
             "scope": "resource"
           },
-          "idf.buildDirectoryName": {
+          "idf.buildPath": {
             "type": "string",
             "default": "${workspaceFolder}/build",
-            "description": "%param.buildDirectoryName%",
+            "description": "%param.buildPath%",
             "scope": "resource"
           },
-          "idf.buildDirectoryNameWin": {
+          "idf.buildPathWin": {
             "type": "string",
             "default": "${workspaceFolder}\\build",
-            "description": "%param.buildDirectoryName%",
+            "description": "%param.buildPath%",
             "scope": "resource"
           },
           "idf.cmakeCompilerArgs": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -93,7 +93,7 @@
   "param.postFlashTask": "Post flash custom task",
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
-  "param.buildDirectoryName": "Name of CMake build directory",
+  "param.buildPath": "Name of CMake build directory",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -206,7 +206,7 @@
     "param.qemuTcpPort",
     "param.openOcdDebugLevel",
     "param.customTask",
-    "param.buildDirectoryName",
+    "param.buildPath",
     "param.preBuildTask",
     "param.postBuildTask",
     "param.preFlashTask",

--- a/src/build/buildCmd.ts
+++ b/src/build/buildCmd.ts
@@ -65,11 +65,10 @@ export async function buildCommand(
     customTask.addCustomTask(CustomTaskType.PostBuild);
     await TaskManager.runTasks();
     if (flashType === ESP.FlashType.DFU) {
-      const buildDirName = readParameter(
+      const buildPath = readParameter(
         "idf.buildDirectoryName",
         workspace
       ) as string;
-      const buildPath = join(workspace.fsPath, buildDirName);
       if (!(await pathExists(join(buildPath, "flasher_args.json")))) {
         return Logger.warnNotify(
           "flasher_args.json file is missing from the build directory, can't proceed, please build properly!!"

--- a/src/build/buildCmd.ts
+++ b/src/build/buildCmd.ts
@@ -66,7 +66,7 @@ export async function buildCommand(
     await TaskManager.runTasks();
     if (flashType === ESP.FlashType.DFU) {
       const buildPath = readParameter(
-        "idf.buildDirectoryName",
+        "idf.buildPath",
         workspace
       ) as string;
       if (!(await pathExists(join(buildPath, "flasher_args.json")))) {

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -27,7 +27,7 @@ import { selectedDFUAdapterId } from "../flash/dfu";
 
 export class BuildTask {
   public static isBuilding: boolean;
-  private buildDirName: string;
+  private buildDirPath: string;
   private curWorkspace: vscode.Uri;
   private idfPathDir: string;
   private adapterTargetName: string;
@@ -42,7 +42,7 @@ export class BuildTask {
       "idf.adapterTargetName",
       workspace
     ) as string;
-    this.buildDirName = idfConf.readParameter(
+    this.buildDirPath = idfConf.readParameter(
       "idf.buildDirectoryName",
       workspace
     ) as string;
@@ -87,10 +87,10 @@ export class BuildTask {
         "tools",
         "mkdfu.py"
       )} write -o ${join(
-        join(this.curWorkspace.fsPath, this.buildDirName),
+        this.buildDirPath,
         "dfu.bin"
       )} --json ${join(
-        join(this.curWorkspace.fsPath, this.buildDirName),
+        this.buildDirPath,
         "flasher_args.json"
       )} --pid ${selectedDFUAdapterId(this.adapterTargetName)}`,
       options
@@ -111,7 +111,7 @@ export class BuildTask {
     }
     this.building(true);
     const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
-    await ensureDir(join(this.curWorkspace.fsPath, this.buildDirName));
+    await ensureDir(this.buildDirPath);
     const canAccessCMake = await isBinInPath(
       "cmake",
       this.curWorkspace.fsPath,
@@ -124,8 +124,7 @@ export class BuildTask {
     );
 
     const cmakeCachePath = join(
-      this.curWorkspace.fsPath,
-      this.buildDirName,
+      this.buildDirPath,
       "CMakeCache.txt"
     );
     const cmakeCacheExists = await pathExists(cmakeCachePath);
@@ -135,7 +134,7 @@ export class BuildTask {
     }
 
     const options: vscode.ShellExecutionOptions = {
-      cwd: join(this.curWorkspace.fsPath, this.buildDirName),
+      cwd: this.buildDirPath,
       env: modifiedEnv,
     };
     const isSilentMode = idfConf.readParameter(
@@ -212,7 +211,7 @@ export class BuildTask {
   public async buildDfu() {
     this.building(true);
     const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
-    await ensureDir(join(this.curWorkspace.fsPath, this.buildDirName));
+    await ensureDir(this.buildDirPath);
 
     const options: vscode.ShellExecutionOptions = {
       cwd: this.curWorkspace.fsPath,

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -86,10 +86,7 @@ export class BuildTask {
         this.idfPathDir,
         "tools",
         "mkdfu.py"
-      )} write -o ${join(
-        this.buildDirPath,
-        "dfu.bin"
-      )} --json ${join(
+      )} write -o ${join(this.buildDirPath, "dfu.bin")} --json ${join(
         this.buildDirPath,
         "flasher_args.json"
       )} --pid ${selectedDFUAdapterId(this.adapterTargetName)}`,
@@ -123,10 +120,7 @@ export class BuildTask {
       modifiedEnv
     );
 
-    const cmakeCachePath = join(
-      this.buildDirPath,
-      "CMakeCache.txt"
-    );
+    const cmakeCachePath = join(this.buildDirPath, "CMakeCache.txt");
     const cmakeCacheExists = await pathExists(cmakeCachePath);
 
     if (canAccessCMake === "" || canAccessNinja === "") {
@@ -154,8 +148,13 @@ export class BuildTask {
         "Ninja",
         "-DPYTHON_DEPS_CHECKED=1",
         "-DESP_PLATFORM=1",
-        "..",
       ];
+      compilerArgs.push(
+        "-B",
+        this.buildDirPath,
+        "-S",
+        this.curWorkspace.fsPath
+      );
       const enableCCache = idfConf.readParameter(
         "idf.enableCCache",
         this.curWorkspace

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -43,7 +43,7 @@ export class BuildTask {
       workspace
     ) as string;
     this.buildDirPath = idfConf.readParameter(
-      "idf.buildDirectoryName",
+      "idf.buildPath",
       workspace
     ) as string;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,7 @@ export namespace ESP {
   }
 
   export const platformDepConfigurations: string[] = [
+    "idf.buildDirectoryName",
     "idf.espIdfPath",
     "idf.espAdfPath",
     "idf.espMatterPath",

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export namespace ESP {
   }
 
   export const platformDepConfigurations: string[] = [
-    "idf.buildDirectoryName",
+    "idf.buildPath",
     "idf.espIdfPath",
     "idf.espAdfPath",
     "idf.espMatterPath",

--- a/src/coverage/coverageService.ts
+++ b/src/coverage/coverageService.ts
@@ -158,7 +158,6 @@ export async function generateCoverageForEditors(
             dirPath
           ) as string;
           gcovObjFilePath = join(
-            dirPath.fsPath,
             buildDirName,
             "esp-idf",
             fileParts[fileParts.length - 1],

--- a/src/coverage/coverageService.ts
+++ b/src/coverage/coverageService.ts
@@ -153,12 +153,12 @@ export async function generateCoverageForEditors(
           .split(sep);
         if (fileParts && fileParts.length > 1) {
           const fileName = fileParts.pop();
-          const buildDirName = idfConf.readParameter(
-            "idf.buildDirectoryName",
+          const buildDirPath = idfConf.readParameter(
+            "idf.buildPath",
             dirPath
           ) as string;
           gcovObjFilePath = join(
-            buildDirName,
+            buildDirPath,
             "esp-idf",
             fileParts[fileParts.length - 1],
             "CMakeFiles",

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -126,7 +126,6 @@ export class DebugAdapterManager extends EventEmitter {
           this.currentWorkspace
         ) as string;
         const flasherArgsJsonPath = path.join(
-          this.currentWorkspace.fsPath,
           buildDirName,
           "flasher_args.json"
         );
@@ -315,11 +314,7 @@ export class DebugAdapterManager extends EventEmitter {
         "idf.buildDirectoryName",
         this.currentWorkspace
       ) as string;
-      this.elfFile = `${path.join(
-        this.currentWorkspace.fsPath,
-        buildDirName,
-        "project-name"
-      )}.elf`;
+      this.elfFile = `${path.join(buildDirName, "project-name")}.elf`;
     }
   }
 

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -121,12 +121,12 @@ export class DebugAdapterManager extends EventEmitter {
           "idf.flashBaudRate",
           this.currentWorkspace
         );
-        const buildDirName = idfConf.readParameter(
-          "idf.buildDirectoryName",
+        const buildDirPath = idfConf.readParameter(
+          "idf.buildPath",
           this.currentWorkspace
         ) as string;
         const flasherArgsJsonPath = path.join(
-          buildDirName,
+          buildDirPath,
           "flasher_args.json"
         );
         if (!canAccessFile(flasherArgsJsonPath, constants.R_OK)) {
@@ -310,11 +310,11 @@ export class DebugAdapterManager extends EventEmitter {
     this.initGdbCommands = [];
     this.elfFile = "";
     if (this.currentWorkspace) {
-      const buildDirName = idfConf.readParameter(
-        "idf.buildDirectoryName",
+      const buildDirPath = idfConf.readParameter(
+        "idf.buildPath",
         this.currentWorkspace
       ) as string;
-      this.elfFile = `${path.join(buildDirName, "project-name")}.elf`;
+      this.elfFile = `${path.join(buildDirPath, "project-name")}.elf`;
     }
   }
 

--- a/src/espIdf/debugAdapter/verifyApp.ts
+++ b/src/espIdf/debugAdapter/verifyApp.ts
@@ -43,11 +43,7 @@ export async function verifyAppBinary(workspaceFolder: Uri) {
     "idf.buildDirectoryName",
     workspaceFolder
   ) as string;
-  const flasherArgsJsonPath = join(
-    workspaceFolder.fsPath,
-    buildDirName,
-    "flasher_args.json"
-  );
+  const flasherArgsJsonPath = join(buildDirName, "flasher_args.json");
   const model = await createFlashModel(
     flasherArgsJsonPath,
     serialPort,

--- a/src/espIdf/debugAdapter/verifyApp.ts
+++ b/src/espIdf/debugAdapter/verifyApp.ts
@@ -39,11 +39,11 @@ export async function verifyAppBinary(workspaceFolder: Uri) {
     "esptool",
     "esptool.py"
   );
-  const buildDirName = readParameter(
-    "idf.buildDirectoryName",
+  const buildDirPath = readParameter(
+    "idf.buildPath",
     workspaceFolder
   ) as string;
-  const flasherArgsJsonPath = join(buildDirName, "flasher_args.json");
+  const flasherArgsJsonPath = join(buildDirPath, "flasher_args.json");
   const model = await createFlashModel(
     flasherArgsJsonPath,
     serialPort,

--- a/src/espIdf/menuconfig/kconfigMenuLoader.ts
+++ b/src/espIdf/menuconfig/kconfigMenuLoader.ts
@@ -70,7 +70,6 @@ export class KconfigMenuLoader {
       this.workspaceFolder
     ) as string;
     const kconfigMenusPath = path.join(
-      this.workspaceFolder.fsPath,
       buildDirName,
       "config",
       "kconfig_menus.json"

--- a/src/espIdf/menuconfig/kconfigMenuLoader.ts
+++ b/src/espIdf/menuconfig/kconfigMenuLoader.ts
@@ -65,12 +65,12 @@ export class KconfigMenuLoader {
   }
 
   public initMenuconfigServer(): Menu[] {
-    const buildDirName = readParameter(
-      "idf.buildDirectoryName",
+    const buildDirPath = readParameter(
+      "idf.buildPath",
       this.workspaceFolder
     ) as string;
     const kconfigMenusPath = path.join(
-      buildDirName,
+      buildDirPath,
       "config",
       "kconfig_menus.json"
     );

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -16,19 +16,21 @@
  * limitations under the License.
  */
 import { join } from "path";
-import { commands, env, Uri, Terminal, window } from "vscode";
+import { commands, Uri } from "vscode";
 import { FlashTask } from "../../flash/flashTask";
 import { readParameter } from "../../idfConfiguration";
 import * as utils from "../../utils";
 import { BuildTask } from "../../build/buildTask";
 import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
+import { R_OK } from "constants";
+import { getProjectName } from "../../workspaceConfig";
+import { IDFMonitor } from ".";
 
 const locDic = new LocDictionary(__filename);
 
-export async function createMonitorTerminal(
-  monitorTerminal: Terminal,
-  workspace: Uri,
+export async function createNewIdfMonitor(
+  workspaceFolder: Uri,
   serialPort?: string
 ) {
   if (BuildTask.isBuilding || FlashTask.isFlashing) {
@@ -42,27 +44,9 @@ export async function createMonitorTerminal(
     );
     return;
   }
-
-  const idfPathDir =
-    readParameter("idf.espIdfPath", workspace) || process.env.IDF_PATH;
-  const pythonBinPath = readParameter("idf.pythonBinPath", workspace) as string;
-  const port = serialPort ? serialPort : readParameter("idf.port", workspace);
-  const idfPath = join(idfPathDir, "tools", "idf.py");
-  const modifiedEnv = utils.appendIdfAndToolsToPath(workspace);
-  if (!utils.isBinInPath(pythonBinPath, workspace.fsPath, modifiedEnv)) {
-    Logger.errorNotify(
-      "Python binary path is not defined",
-      new Error("idf.pythonBinPath is not defined")
-    );
-    return;
-  }
-  if (!idfPathDir) {
-    Logger.errorNotify(
-      "ESP-IDF Path is not defined",
-      new Error("idf.espIdfPath is not defined")
-    );
-    return;
-  }
+  const port = serialPort
+    ? serialPort
+    : (readParameter("idf.port", workspaceFolder) as string);
   if (!port) {
     try {
       await commands.executeCommand("espIdf.selectPort");
@@ -73,19 +57,50 @@ export async function createMonitorTerminal(
       "Select a serial port before flashing",
       new Error("NOT_SELECTED_PORT")
     );
-    return;
   }
-  if (typeof monitorTerminal === "undefined") {
-    monitorTerminal = window.createTerminal({
-      name: "ESP-IDF Monitor",
-      env: modifiedEnv,
-      cwd: workspace.fsPath || modifiedEnv.IDF_PATH || process.cwd(),
-      shellArgs: [],
-      shellPath: env.shell,
-      strictEnv: true,
-    });
+  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
+    workspaceFolder.fsPath
+  );
+  const pythonBinPath = readParameter(
+    "idf.pythonBinPath",
+    workspaceFolder
+  ) as string;
+  if (!utils.canAccessFile(pythonBinPath, R_OK)) {
+    Logger.errorNotify(
+      "Python binary path is not defined",
+      new Error("idf.pythonBinPath is not defined")
+    );
   }
-  monitorTerminal.show();
-  monitorTerminal.sendText(`${pythonBinPath} ${idfPath} -p ${port} monitor`);
-  return monitorTerminal;
+  const idfPath = readParameter("idf.espIdfPath", workspaceFolder) as string;
+  const idfVersion = await utils.getEspIdfFromCMake(idfPath);
+  const idfMonitorToolPath = join(idfPath, "tools", "idf_monitor.py");
+  if (!utils.canAccessFile(idfMonitorToolPath, R_OK)) {
+    Logger.errorNotify(
+      idfMonitorToolPath + " is not defined",
+      new Error(idfMonitorToolPath + " is not defined")
+    );
+  }
+  const buildDirPath = readParameter(
+    "idf.buildPath",
+    workspaceFolder
+  ) as string;
+  let idfTarget = readParameter("idf.adapterTargetName", workspaceFolder);
+  if (idfTarget === "custom") {
+    idfTarget = readParameter("idf.customAdapterTargetName", workspaceFolder);
+  }
+  const projectName = await getProjectName(buildDirPath);
+  const elfFilePath = join(buildDirPath, `${projectName}.elf`);
+  const toolchainPrefix = utils.getToolchainToolName(idfTarget, "");
+  const monitor = new IDFMonitor({
+    port,
+    baudRate: sdkMonitorBaudRate,
+    pythonBinPath,
+    idfTarget,
+    idfMonitorToolPath,
+    idfVersion,
+    elfFilePath,
+    workspaceFolder,
+    toolchainPrefix,
+  });
+  return monitor;
 }

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -104,8 +104,8 @@ export class IDFSize {
       "idf.buildDirectoryName",
       this.workspaceRoot
     ) as string;
-    const projectName = await getProjectName(this.workspaceRoot.fsPath, buildDirName);
-    return path.join(this.workspaceRoot.fsPath, buildDirName, `${projectName}.map`);
+    const projectName = await getProjectName(buildDirName);
+    return path.join(buildDirName, `${projectName}.map`);
   }
 
   private idfPath(): string {

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -100,12 +100,12 @@ export class IDFSize {
   }
 
   private async mapFilePath() {
-    const buildDirName = idfConf.readParameter(
-      "idf.buildDirectoryName",
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
       this.workspaceRoot
     ) as string;
-    const projectName = await getProjectName(buildDirName);
-    return path.join(buildDirName, `${projectName}.map`);
+    const projectName = await getProjectName(buildDirPath);
+    return path.join(buildDirPath, `${projectName}.map`);
   }
 
   private idfPath(): string {

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -61,20 +61,13 @@ export class IdfSizeTask {
   }
 
   private async mapFilePath() {
-    const projectName = await getProjectName(
-      this.curWorkspace.fsPath,
-      this.buildDirName
-    );
-    return join(
-      this.curWorkspace.fsPath,
-      this.buildDirName,
-      `${projectName}.map`
-    );
+    const projectName = await getProjectName(this.buildDirName);
+    return join(this.buildDirName, `${projectName}.map`);
   }
 
   public async getSizeInfo() {
     const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
-    await ensureDir(join(this.curWorkspace.fsPath, this.buildDirName));
+    await ensureDir(this.buildDirName);
     const options: ShellExecutionOptions = {
       cwd: this.curWorkspace.fsPath,
       env: modifiedEnv,

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -36,7 +36,7 @@ export class IdfSizeTask {
   private curWorkspace: Uri;
   private pythonBinPath: string;
   private idfSizePath: string;
-  private buildDirName: string;
+  private buildDirPath: string;
 
   constructor(workspacePath: Uri) {
     this.curWorkspace = workspacePath;
@@ -46,8 +46,8 @@ export class IdfSizeTask {
     ) as string;
     const idfPathDir = readParameter("idf.espIdfPath", workspacePath) as string;
     this.idfSizePath = join(idfPathDir, "tools", "idf_size.py");
-    this.buildDirName = readParameter(
-      "idf.buildDirectoryName",
+    this.buildDirPath = readParameter(
+      "idf.buildPath",
       workspacePath
     ) as string;
   }
@@ -61,13 +61,13 @@ export class IdfSizeTask {
   }
 
   private async mapFilePath() {
-    const projectName = await getProjectName(this.buildDirName);
-    return join(this.buildDirName, `${projectName}.map`);
+    const projectName = await getProjectName(this.buildDirPath);
+    return join(this.buildDirPath, `${projectName}.map`);
   }
 
   public async getSizeInfo() {
     const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
-    await ensureDir(this.buildDirName);
+    await ensureDir(this.buildDirPath);
     const options: ShellExecutionOptions = {
       cwd: this.curWorkspace.fsPath,
       env: modifiedEnv,

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -22,7 +22,12 @@ import { env, Uri, window } from "vscode";
 import { readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
-import { appendIdfAndToolsToPath, getToolchainToolName, isBinInPath, PreCheck } from "../../utils";
+import {
+  appendIdfAndToolsToPath,
+  getToolchainToolName,
+  isBinInPath,
+  PreCheck,
+} from "../../utils";
 import { getProjectName } from "../../workspaceConfig";
 import { OpenOCDManager } from "../openOcd/openOcdManager";
 import { AppTraceArchiveTreeDataProvider } from "./tree/appTraceArchiveTreeDataProvider";
@@ -73,23 +78,12 @@ export class GdbHeapTraceManager {
           "idf.buildDirectoryName",
           workspace
         ) as string;
-        const buildExists = await pathExists(
-          join(workspace.fsPath, buildDirName)
-        );
+        const buildExists = await pathExists(buildDirName);
         if (!buildExists) {
-          throw new Error(
-            `${workspace.fsPath} build doesn't exist. Build first.`
-          );
+          throw new Error(`${buildDirName} doesn't exist. Build first.`);
         }
-        const projectName = await getProjectName(
-          workspace.fsPath,
-          buildDirName
-        );
-        const elfFilePath = join(
-          workspace.fsPath,
-          buildDirName,
-          `${projectName}.elf`
-        );
+        const projectName = await getProjectName(buildDirName);
+        const elfFilePath = join(buildDirName, `${projectName}.elf`);
         const elfFileExists = await pathExists(elfFilePath);
         if (!elfFileExists) {
           throw new Error(`${elfFilePath} doesn't exist.`);
@@ -98,7 +92,7 @@ export class GdbHeapTraceManager {
           `${gdbTool} -x ${this.gdbinitFileName} "${elfFilePath}"`,
           [],
           {
-            cwd: workspace.fsPath,
+            cwd: buildDirName,
             env: modifiedEnv,
             shell: env.shell,
           }
@@ -121,7 +115,7 @@ export class GdbHeapTraceManager {
 
         this.childProcess.on("exit", (code, signal) => {
           if (code && code !== 0) {
-            const errMsg = `Heap tracing process exited with code ${code} and signal ${signal}`
+            const errMsg = `Heap tracing process exited with code ${code} and signal ${signal}`;
             Logger.errorNotify(errMsg, new Error(errMsg));
           }
         });

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -74,16 +74,16 @@ export class GdbHeapTraceManager {
         if (!isGdbToolInPath) {
           throw new Error(`${gdbTool} is not available in PATH.`);
         }
-        const buildDirName = readParameter(
-          "idf.buildDirectoryName",
+        const buildDirPath = readParameter(
+          "idf.buildPath",
           workspace
         ) as string;
-        const buildExists = await pathExists(buildDirName);
+        const buildExists = await pathExists(buildDirPath);
         if (!buildExists) {
-          throw new Error(`${buildDirName} doesn't exist. Build first.`);
+          throw new Error(`${buildDirPath} doesn't exist. Build first.`);
         }
-        const projectName = await getProjectName(buildDirName);
-        const elfFilePath = join(buildDirName, `${projectName}.elf`);
+        const projectName = await getProjectName(buildDirPath);
+        const elfFilePath = join(buildDirPath, `${projectName}.elf`);
         const elfFileExists = await pathExists(elfFilePath);
         if (!elfFileExists) {
           throw new Error(`${elfFilePath} doesn't exist.`);
@@ -92,7 +92,7 @@ export class GdbHeapTraceManager {
           `${gdbTool} -x ${this.gdbinitFileName} "${elfFilePath}"`,
           [],
           {
-            cwd: buildDirName,
+            cwd: buildDirPath,
             env: modifiedEnv,
             shell: env.shell,
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -360,12 +360,12 @@ export async function activate(context: vscode.ExtensionContext) {
         const coverageOptions = getCoverageOptions(workspaceRoot);
         covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
       }
-      const buildDirName = idfConf.readParameter(
-        "idf.buildDirectoryName",
+      const buildDirPath = idfConf.readParameter(
+        "idf.buildPath",
         workspaceRoot
       ) as string;
-      const projectName = await getProjectName(buildDirName);
-      const projectElfFile = `${path.join(buildDirName, projectName)}.elf`;
+      const projectName = await getProjectName(buildDirPath);
+      const projectElfFile = `${path.join(buildDirPath, projectName)}.elf`;
       const debugAdapterConfig = {
         currentWorkspace: workspaceRoot,
         elfFile: projectElfFile,
@@ -531,7 +531,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerIDFCommand("espIdf.fullClean", () => {
     PreCheck.perform([openFolderCheck], async () => {
       const buildDir = idfConf.readParameter(
-        "idf.buildDirectoryName",
+        "idf.buildPath",
         workspaceRoot
       ) as string;
       const buildDirExists = await utils.dirExistPromise(buildDir);
@@ -1027,7 +1027,7 @@ export async function activate(context: vscode.ExtensionContext) {
         workspaceRoot
       ) as string;
       statusBarItems["flashType"].text = `$(star-empty) ${flashType}`;
-    } else if (e.affectsConfiguration("idf.buildDirectoryName")) {
+    } else if (e.affectsConfiguration("idf.buildPath")) {
       updateIdfComponentsTree(workspaceRoot);
     }
   });
@@ -1162,11 +1162,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.getProjectName", () => {
     return PreCheck.perform([openFolderCheck], async () => {
-      const buildDirName = idfConf.readParameter(
-        "idf.buildDirectoryName",
+      const buildDirPath = idfConf.readParameter(
+        "idf.buildPath",
         workspaceRoot
       ) as string;
-      return await getProjectName(buildDirName);
+      return await getProjectName(buildDirPath);
     });
   });
 
@@ -1889,7 +1889,7 @@ export async function activate(context: vscode.ExtensionContext) {
         ) => {
           try {
             const buildDir = idfConf.readParameter(
-              "idf.buildDirectoryName",
+              "idf.buildPath",
               workspaceRoot
             ) as string;
             const qemuBinExists = await pathExists(
@@ -1919,12 +1919,12 @@ export async function activate(context: vscode.ExtensionContext) {
       if (qemuManager.isRunning()) {
         qemuManager.stop();
       }
-      const buildDirName = idfConf.readParameter(
-        "idf.buildDirectoryName",
+      const buildDirPath = idfConf.readParameter(
+        "idf.buildPath",
         workspaceRoot
       ) as string;
       const qemuBinExists = await pathExists(
-        path.join(buildDirName, "merged_qemu.bin")
+        path.join(buildDirPath, "merged_qemu.bin")
       );
       if (!qemuBinExists) {
         await mergeFlashBinaries(workspaceRoot);
@@ -2375,12 +2375,12 @@ export async function activate(context: vscode.ExtensionContext) {
             new Error(idfMonitorToolPath + " is not defined")
           );
         }
-        const buildDirName = idfConf.readParameter(
-          "idf.buildDirectoryName",
+        const buildDirPath = idfConf.readParameter(
+          "idf.buildPath",
           workspaceRoot
         ) as string;
-        const projectName = await getProjectName(buildDirName);
-        const elfFilePath = path.join(buildDirName, `${projectName}.elf`);
+        const projectName = await getProjectName(buildDirPath);
+        const elfFilePath = path.join(buildDirPath, `${projectName}.elf`);
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const monitor = new IDFMonitor({
           port,
@@ -2410,13 +2410,13 @@ export async function activate(context: vscode.ExtensionContext) {
               },
               async (progress) => {
                 const espCoreDumpPyTool = new ESPCoreDumpPyTool(idfPath);
-                const buildDirName = idfConf.readParameter(
-                  "idf.buildDirectoryName",
+                const buildDirPath = idfConf.readParameter(
+                  "idf.buildPath",
                   workspaceRoot
                 ) as string;
-                const projectName = await getProjectName(buildDirName);
+                const projectName = await getProjectName(buildDirPath);
                 const coreElfFilePath = path.join(
-                  buildDirName,
+                  buildDirPath,
                   `${projectName}.coredump.elf`
                 );
                 if (
@@ -2610,7 +2610,7 @@ export async function activate(context: vscode.ExtensionContext) {
             "ninja-build-summary.py"
           );
           const buildDir = idfConf.readParameter(
-            "idf.buildDirectoryName",
+            "idf.buildPath",
             workspaceRoot
           ) as string;
           const summaryResult = await utils.execChildProcess(
@@ -3111,12 +3111,12 @@ class IdfDebugConfigurationProvider
     token?: vscode.CancellationToken
   ): Promise<vscode.DebugConfiguration> {
     try {
-      const buildDirName = idfConf.readParameter(
-        "idf.buildDirectoryName",
+      const buildDirPath = idfConf.readParameter(
+        "idf.buildPath",
         workspaceRoot
       ) as string;
-      const projectName = await getProjectName(buildDirName);
-      const elfFilePath = path.join(buildDirName, `${projectName}.elf`);
+      const projectName = await getProjectName(buildDirPath);
+      const elfFilePath = path.join(buildDirPath, `${projectName}.elf`);
       const elfFileExists = await pathExists(elfFilePath);
       if (!elfFileExists) {
         throw new Error(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -364,15 +364,8 @@ export async function activate(context: vscode.ExtensionContext) {
         "idf.buildDirectoryName",
         workspaceRoot
       ) as string;
-      const projectName = await getProjectName(
-        workspaceRoot.fsPath,
-        buildDirName
-      );
-      const projectElfFile = `${path.join(
-        workspaceRoot.fsPath,
-        buildDirName,
-        projectName
-      )}.elf`;
+      const projectName = await getProjectName(buildDirName);
+      const projectElfFile = `${path.join(buildDirName, projectName)}.elf`;
       const debugAdapterConfig = {
         currentWorkspace: workspaceRoot,
         elfFile: projectElfFile,
@@ -537,11 +530,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.fullClean", () => {
     PreCheck.perform([openFolderCheck], async () => {
-      const buildDirName = idfConf.readParameter(
+      const buildDir = idfConf.readParameter(
         "idf.buildDirectoryName",
         workspaceRoot
       ) as string;
-      const buildDir = path.join(workspaceRoot.fsPath, buildDirName);
       const buildDirExists = await utils.dirExistPromise(buildDir);
       if (!buildDirExists) {
         return Logger.warnNotify(
@@ -1174,7 +1166,7 @@ export async function activate(context: vscode.ExtensionContext) {
         "idf.buildDirectoryName",
         workspaceRoot
       ) as string;
-      return await getProjectName(workspaceRoot.fsPath, buildDirName);
+      return await getProjectName(buildDirName);
     });
   });
 
@@ -1896,12 +1888,12 @@ export async function activate(context: vscode.ExtensionContext) {
           cancelToken: vscode.CancellationToken
         ) => {
           try {
-            const buildDirName = idfConf.readParameter(
+            const buildDir = idfConf.readParameter(
               "idf.buildDirectoryName",
               workspaceRoot
             ) as string;
             const qemuBinExists = await pathExists(
-              path.join(workspaceRoot.fsPath, buildDirName, "merged_qemu.bin")
+              path.join(buildDir, "merged_qemu.bin")
             );
             if (!qemuBinExists) {
               progress.report({
@@ -1932,7 +1924,7 @@ export async function activate(context: vscode.ExtensionContext) {
         workspaceRoot
       ) as string;
       const qemuBinExists = await pathExists(
-        path.join(workspaceRoot.fsPath, buildDirName, "merged_qemu.bin")
+        path.join(buildDirName, "merged_qemu.bin")
       );
       if (!qemuBinExists) {
         await mergeFlashBinaries(workspaceRoot);
@@ -2387,15 +2379,8 @@ export async function activate(context: vscode.ExtensionContext) {
           "idf.buildDirectoryName",
           workspaceRoot
         ) as string;
-        const projectName = await getProjectName(
-          workspaceRoot.fsPath.toString(),
-          buildDirName
-        );
-        const elfFilePath = path.join(
-          workspaceRoot.fsPath,
-          buildDirName,
-          `${projectName}.elf`
-        );
+        const projectName = await getProjectName(buildDirName);
+        const elfFilePath = path.join(buildDirName, `${projectName}.elf`);
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const monitor = new IDFMonitor({
           port,
@@ -2429,12 +2414,8 @@ export async function activate(context: vscode.ExtensionContext) {
                   "idf.buildDirectoryName",
                   workspaceRoot
                 ) as string;
-                const projectName = await getProjectName(
-                  workspaceRoot.fsPath,
-                  buildDirName
-                );
+                const projectName = await getProjectName(buildDirName);
                 const coreElfFilePath = path.join(
-                  workspaceRoot.fsPath,
                   buildDirName,
                   `${projectName}.coredump.elf`
                 );
@@ -2628,11 +2609,10 @@ export async function activate(context: vscode.ExtensionContext) {
             "chromium",
             "ninja-build-summary.py"
           );
-          const buildDirName = idfConf.readParameter(
+          const buildDir = idfConf.readParameter(
             "idf.buildDirectoryName",
             workspaceRoot
           ) as string;
-          const buildDir = path.join(workspaceRoot.fsPath, buildDirName);
           const summaryResult = await utils.execChildProcess(
             `${pythonBinPath} ${ninjaSummaryScript} -C ${buildDir}`,
             workspaceRoot.fsPath,
@@ -3135,15 +3115,8 @@ class IdfDebugConfigurationProvider
         "idf.buildDirectoryName",
         workspaceRoot
       ) as string;
-      const projectName = await getProjectName(
-        workspaceRoot.fsPath,
-        buildDirName
-      );
-      const elfFilePath = path.join(
-        workspaceRoot.fsPath,
-        buildDirName,
-        `${projectName}.elf`
-      );
+      const projectName = await getProjectName(buildDirName);
+      const elfFilePath = path.join(buildDirName, `${projectName}.elf`);
       const elfFileExists = await pathExists(elfFilePath);
       if (!elfFileExists) {
         throw new Error(

--- a/src/flash/flashCmd.ts
+++ b/src/flash/flashCmd.ts
@@ -47,12 +47,10 @@ export async function verifyCanFlash(
     );
   }
 
-  const buildDirName = idfConf.readParameter(
+  const buildPath = idfConf.readParameter(
     "idf.buildDirectoryName",
     workspace
   ) as string;
-
-  const buildPath = join(workspace.fsPath, buildDirName);
   if (!(await pathExists(buildPath))) {
     return Logger.errorNotify(
       `Build is required before Flashing, ${buildPath} can't be accessed`,
@@ -64,7 +62,7 @@ export async function verifyCanFlash(
       "flasher_args.json file is missing from the build directory, can't proceed, please build properly!!"
     );
   }
-  const projectName = await getProjectName(workspace.fsPath, buildDirName);
+  const projectName = await getProjectName(buildPath);
   if (!(await pathExists(join(buildPath, `${projectName}.elf`)))) {
     return Logger.warnNotify(
       `Can't proceed with flashing, since project elf file (${projectName}.elf) is missing from the build dir. (${buildPath})`

--- a/src/flash/flashCmd.ts
+++ b/src/flash/flashCmd.ts
@@ -48,7 +48,7 @@ export async function verifyCanFlash(
   }
 
   const buildPath = idfConf.readParameter(
-    "idf.buildDirectoryName",
+    "idf.buildPath",
     workspace
   ) as string;
   if (!(await pathExists(buildPath))) {

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -67,11 +67,7 @@ export class FlashTask {
     for (const flashFile of this.model.flashSections) {
       if (
         !canAccessFile(
-          join(
-            this.workspaceUri.fsPath,
-            this.buildDirName,
-            flashFile.binFilePath
-          ),
+          join(this.buildDirName, flashFile.binFilePath),
           constants.R_OK
         )
       ) {
@@ -124,7 +120,7 @@ export class FlashTask {
     const modifiedEnv = appendIdfAndToolsToPath(this.workspaceUri);
     const flasherArgs = this.getFlasherArgs(this.flashScriptPath);
     const options: vscode.ShellExecutionOptions = {
-      cwd: join(this.workspaceUri.fsPath, this.buildDirName),
+      cwd: this.buildDirName,
       env: modifiedEnv,
     };
     const pythonBinPath = idfConf.readParameter(
@@ -160,7 +156,6 @@ export class FlashTask {
     }
     return new vscode.ShellExecution(
       `dfu-util -d 303a:${selectedDFUAdapterId(this.model.chip)} -D ${join(
-        this.workspaceUri.fsPath,
         this.buildDirName,
         "dfu.bin"
       )}`

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -31,7 +31,7 @@ export class FlashTask {
   private workspaceUri: vscode.Uri;
   private flashScriptPath: string;
   private model: FlashModel;
-  private buildDirName: string;
+  private buildDirPath: string;
   private encryptPartitions: boolean;
 
   constructor(
@@ -49,8 +49,8 @@ export class FlashTask {
       "esptool.py"
     );
     this.model = model;
-    this.buildDirName = idfConf.readParameter(
-      "idf.buildDirectoryName",
+    this.buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
       workspace
     ) as string;
     this.encryptPartitions = encryptPartitions;
@@ -67,7 +67,7 @@ export class FlashTask {
     for (const flashFile of this.model.flashSections) {
       if (
         !canAccessFile(
-          join(this.buildDirName, flashFile.binFilePath),
+          join(this.buildDirPath, flashFile.binFilePath),
           constants.R_OK
         )
       ) {
@@ -120,7 +120,7 @@ export class FlashTask {
     const modifiedEnv = appendIdfAndToolsToPath(this.workspaceUri);
     const flasherArgs = this.getFlasherArgs(this.flashScriptPath);
     const options: vscode.ShellExecutionOptions = {
-      cwd: this.buildDirName,
+      cwd: this.buildDirPath,
       env: modifiedEnv,
     };
     const pythonBinPath = idfConf.readParameter(
@@ -156,7 +156,7 @@ export class FlashTask {
     }
     return new vscode.ShellExecution(
       `dfu-util -d 303a:${selectedDFUAdapterId(this.model.chip)} -D ${join(
-        this.buildDirName,
+        this.buildDirPath,
         "dfu.bin"
       )}`
     );

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -44,11 +44,10 @@ export async function jtagFlashCommand(workspace: Uri) {
     "openocd.jtag.command.force_unix_path_separator",
     workspace
   );
-  const buildDirName = readParameter(
+  let buildPath = readParameter(
     "idf.buildDirectoryName",
     workspace
   ) as string;
-  let buildPath = join(workspace.fsPath, buildDirName);
   const customTask = new CustomTask(Uri.file(buildPath));
   if (forceUNIXPathSeparator === true) {
     buildPath = buildPath.replace(/\\/g, "/");

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -45,7 +45,7 @@ export async function jtagFlashCommand(workspace: Uri) {
     workspace
   );
   let buildPath = readParameter(
-    "idf.buildDirectoryName",
+    "idf.buildPath",
     workspace
   ) as string;
   const customTask = new CustomTask(Uri.file(buildPath));

--- a/src/flash/uartFlash.ts
+++ b/src/flash/uartFlash.ts
@@ -36,11 +36,10 @@ export async function flashCommand(
   encryptPartitions: boolean
 ) {
   let continueFlag = true;
-  const buildDirName = readParameter(
+  const buildPath = readParameter(
     "idf.buildDirectoryName",
     workspace
   ) as string;
-  const buildPath = join(workspace.fsPath, buildDirName);
   const buildFiles = await readdir(buildPath);
   const binFiles = buildFiles.filter(
     (fileName) => fileName.endsWith(".bin") === true

--- a/src/flash/uartFlash.ts
+++ b/src/flash/uartFlash.ts
@@ -37,7 +37,7 @@ export async function flashCommand(
 ) {
   let continueFlag = true;
   const buildPath = readParameter(
-    "idf.buildDirectoryName",
+    "idf.buildPath",
     workspace
   ) as string;
   const buildFiles = await readdir(buildPath);

--- a/src/idfComponentsDataProvider.ts
+++ b/src/idfComponentsDataProvider.ts
@@ -41,7 +41,6 @@ export class IdfTreeDataProvider implements TreeDataProvider<IdfComponent> {
       workspaceFolder
     ) as string;
     this.projectDescriptionJsonPath = join(
-      workspaceFolder.fsPath,
       buildDirName,
       "project_description.json"
     );
@@ -54,7 +53,6 @@ export class IdfTreeDataProvider implements TreeDataProvider<IdfComponent> {
       workspaceFolder
     ) as string;
     this.projectDescriptionJsonPath = join(
-      workspaceFolder.fsPath,
       buildDirName,
       "project_description.json"
     );

--- a/src/idfComponentsDataProvider.ts
+++ b/src/idfComponentsDataProvider.ts
@@ -36,24 +36,24 @@ export class IdfTreeDataProvider implements TreeDataProvider<IdfComponent> {
 
   constructor(workspaceFolder: vscode.Uri) {
     this.workspaceFolder = workspaceFolder;
-    const buildDirName = idfConf.readParameter(
-      "idf.buildDirectoryName",
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
       workspaceFolder
     ) as string;
     this.projectDescriptionJsonPath = join(
-      buildDirName,
+      buildDirPath,
       "project_description.json"
     );
   }
 
   public refresh(workspaceFolder: vscode.Uri): void {
     this.workspaceFolder = workspaceFolder;
-    const buildDirName = idfConf.readParameter(
-      "idf.buildDirectoryName",
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
       workspaceFolder
     ) as string;
     this.projectDescriptionJsonPath = join(
-      buildDirName,
+      buildDirPath,
       "project_description.json"
     );
     this.OnDidChangeTreeData.fire(null);

--- a/src/qemu/mergeFlashBin.ts
+++ b/src/qemu/mergeFlashBin.ts
@@ -77,11 +77,10 @@ export async function mergeFlashBinaries(
   const idfPath = readParameter("idf.espIdfPath", wsFolder);
   const port = readParameter("idf.port", wsFolder);
   const flashBaudRate = readParameter("idf.flashBaudRate", wsFolder);
-  const buildDirName = readParameter(
+  const buildDirPath = readParameter(
     "idf.buildDirectoryName",
     wsFolder
   ) as string;
-  const buildDirPath = join(wsFolder.fsPath, buildDirName);
   const flasherArgsJsonPath = join(buildDirPath, "flasher_args.json");
   const esptoolPath = join(
     idfPath,

--- a/src/qemu/mergeFlashBin.ts
+++ b/src/qemu/mergeFlashBin.ts
@@ -78,7 +78,7 @@ export async function mergeFlashBinaries(
   const port = readParameter("idf.port", wsFolder);
   const flashBaudRate = readParameter("idf.flashBaudRate", wsFolder);
   const buildDirPath = readParameter(
-    "idf.buildDirectoryName",
+    "idf.buildPath",
     wsFolder
   ) as string;
   const flasherArgsJsonPath = join(buildDirPath, "flasher_args.json");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -553,11 +553,19 @@ export async function getElfFilePath(
   }
 
   try {
-    const buildDirName = idfConf.readParameter(
+    const buildDir = idfConf.readParameter(
       "idf.buildDirectoryName",
       workspaceURI
     ) as string;
-    projectName = await getProjectName(workspaceURI.fsPath, buildDirName);
+    if (!canAccessFile(buildDir, fs.constants.R_OK)) {
+      throw new Error("Build is required once to generate the ELF File");
+    }
+
+    const elfFilePath = path.join(buildDir, `${projectName}.elf`);
+    if (!canAccessFile(elfFilePath, fs.constants.R_OK)) {
+      throw new Error(`Failed to access .elf file at ${elfFilePath}`);
+    }
+    return elfFilePath;
   } catch (error) {
     Logger.errorNotify(
       "Failed to read project name while fetching elf file",
@@ -565,21 +573,6 @@ export async function getElfFilePath(
     );
     return;
   }
-
-  const buildDirName = idfConf.readParameter(
-    "idf.buildDirectoryName",
-    workspaceURI
-  ) as string;
-  const buildDir = path.join(workspaceURI.fsPath, buildDirName);
-  if (!canAccessFile(buildDir, fs.constants.R_OK)) {
-    throw new Error("Build is required once to generate the ELF File");
-  }
-
-  const elfFilePath = path.join(buildDir, `${projectName}.elf`);
-  if (!canAccessFile(elfFilePath, fs.constants.R_OK)) {
-    throw new Error(`Failed to access .elf file at ${elfFilePath}`);
-  }
-  return elfFilePath;
 }
 
 export function checkIsProjectCmakeLists(dir: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -554,7 +554,7 @@ export async function getElfFilePath(
 
   try {
     const buildDir = idfConf.readParameter(
-      "idf.buildDirectoryName",
+      "idf.buildPath",
       workspaceURI
     ) as string;
     if (!canAccessFile(buildDir, fs.constants.R_OK)) {

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -43,15 +43,8 @@ export function updateIdfComponentsTree(workspaceFolder: vscode.Uri) {
   idfDataProvider.refresh(workspaceFolder);
 }
 
-export function getProjectName(
-  workspacePath: string,
-  buildDir: string
-): Promise<string> {
-  const projDescJsonPath = path.join(
-    workspacePath,
-    buildDir,
-    "project_description.json"
-  );
+export function getProjectName(buildDir: string): Promise<string> {
+  const projDescJsonPath = path.join(buildDir, "project_description.json");
   return new Promise((resolve, reject) => {
     try {
       if (!utils.fileExists(projDescJsonPath)) {


### PR DESCRIPTION
## Description

Use `idf.buildPath` as absolute build path instead of relative path.

Fixes #786 

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Run existing extension commands and test the behavior has not changed.

- Manual Test

**Test Configuration**:
* ESP-IDF Version: v4.4.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
