### PR TITLE
Log Doctor Command; Replace path with '<HOMEPATH>'

### DIFF
--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -164,7 +164,7 @@ export function replaceUserPath(report: reportObj): reportObj {
     const result = process.env.HOMEPATH.replace(reWin, '\\\\\\\\')
     re = new RegExp(result, 'g');
   }
-  const parsedReport = strReport.replace(re, '...');
+  const parsedReport = strReport.replace(re, '<HOMEPATH>');
   Logger.warnNotify(parsedReport, {tag: 'DOCTOR COMMAND'});
 
   return JSON.parse(parsedReport);

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -27,13 +27,18 @@ export async function writeTextReport(
   reportedResult: reportObj,
   context: vscode.ExtensionContext
 ) {
-  const strReportResults = await JSON.stringify(reportedResult);
+  const strReportResults = JSON.stringify(reportedResult);
 
-  // Replacing all process.env.HOME paths with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
-  const re = new RegExp(process.env.HOME, 'g');
+  // Replacing all home paths (based on OS) with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
+  let re = new RegExp(process.env.HOME, 'g');
+  if(process.env.windir) {
+    const reWin = new RegExp('\\\\', 'g');
+    const result = process.env.HOMEPATH.replace(reWin, '\\\\\\\\')
+    re = new RegExp(result, 'g');
+  }
   const prvPathsReport = strReportResults.replace(re, '...');
 
-  reportedResult = await JSON.parse(prvPathsReport);
+  reportedResult = JSON.parse(prvPathsReport);
   Logger.warnNotify(prvPathsReport, {tag: 'DOCTOR COMMAND'});
   
   let output = `---------------------------------------------- ESP-IDF Extension for Visual Studio Code report ---------------------------------------------${EOL}`;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -27,19 +27,7 @@ export async function writeTextReport(
   reportedResult: reportObj,
   context: vscode.ExtensionContext
 ) {
-  const strReportResults = JSON.stringify(reportedResult);
-
-  // Replacing all home paths (based on OS) with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
-  let re = new RegExp(process.env.HOME, 'g');
-  if(process.env.windir) {
-    const reWin = new RegExp('\\\\', 'g');
-    const result = process.env.HOMEPATH.replace(reWin, '\\\\\\\\')
-    re = new RegExp(result, 'g');
-  }
-  const prvPathsReport = strReportResults.replace(re, '...');
-
-  reportedResult = JSON.parse(prvPathsReport);
-  Logger.warnNotify(prvPathsReport, {tag: 'DOCTOR COMMAND'});
+  reportedResult = replaceUserPath(reportedResult);
   
   let output = `---------------------------------------------- ESP-IDF Extension for Visual Studio Code report ---------------------------------------------${EOL}`;
   const lineBreak = `--------------------------------------------------------------------------------------------------------------------------------------------${EOL}`;
@@ -164,4 +152,20 @@ export async function writeTextReport(
     spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
   });
   return output;
+}
+
+export function replaceUserPath(report: reportObj): reportObj {
+  const strReport = JSON.stringify(report);
+
+  // Replacing all home paths (based on OS) with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
+  let re = new RegExp(process.env.HOME, 'g');
+  if(process.env.windir) {
+    const reWin = new RegExp('\\\\', 'g');
+    const result = process.env.HOMEPATH.replace(reWin, '\\\\\\\\')
+    re = new RegExp(result, 'g');
+  }
+  const parsedReport = strReport.replace(re, '...');
+  Logger.warnNotify(parsedReport, {tag: 'DOCTOR COMMAND'});
+
+  return JSON.parse(parsedReport);
 }

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -19,12 +19,23 @@ import { writeFile, writeJson } from "fs-extra";
 import { EOL } from "os";
 import { join } from "path";
 import * as vscode from "vscode";
+import { Logger } from "../logger/logger";
+import { readParameter } from "../idfConfiguration";
 import { reportObj } from "./types";
 
 export async function writeTextReport(
   reportedResult: reportObj,
   context: vscode.ExtensionContext
 ) {
+  const strReportResults = await JSON.stringify(reportedResult);
+
+  // Replacing all process.env.HOME paths with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
+  const re = new RegExp(process.env.HOME, 'g');
+  const prvPathsReport = strReportResults.replace(re, '...');
+
+  reportedResult = await JSON.parse(prvPathsReport);
+  Logger.warnNotify(prvPathsReport, {tag: 'DOCTOR COMMAND'});
+  
   let output = `---------------------------------------------- ESP-IDF Extension for Visual Studio Code report ---------------------------------------------${EOL}`;
   const lineBreak = `--------------------------------------------------------------------------------------------------------------------------------------------${EOL}`;
   output += `OS ${reportedResult.systemInfo.platform} ${reportedResult.systemInfo.architecture} ${reportedResult.systemInfo.systemName} ${EOL}`;

--- a/src/test/suite/writeReport.test.ts
+++ b/src/test/suite/writeReport.test.ts
@@ -11,7 +11,7 @@ suite("Write Report Suite", () => {
     }
     let result = replaceUserPath(mockData);
     let mockResult = new reportObj();
-    mockResult.workspaceFolder = '/Users/.../esp/blink';
+    mockResult.workspaceFolder = '/Users/<HOMEPATH>/esp/blink';
     assert.equal(JSON.stringify(result), JSON.stringify(mockResult));
   });
 });

--- a/src/test/suite/writeReport.test.ts
+++ b/src/test/suite/writeReport.test.ts
@@ -1,0 +1,17 @@
+import * as assert from "assert";
+import { replaceUserPath } from "../../support/writeReport";
+import { reportObj } from "../../support/types";
+
+suite("Write Report Suite", () => {
+  test("replaceUserPath", () => {
+    const mockData = new reportObj();
+    mockData.workspaceFolder = `/Users/${process.env.HOME}/esp/blink`;
+    if(process.env.windir) {
+        mockData.workspaceFolder =`C:\\\\${process.env.HOMEPATH}\\esp\\blink`;
+    }
+    let result = replaceUserPath(mockData);
+    let mockResult = new reportObj();
+    mockResult.workspaceFolder = '/Users/.../esp/blink';
+    assert.equal(JSON.stringify(result), JSON.stringify(mockResult));
+  });
+});


### PR DESCRIPTION
## Description
* Add Doctor Command's output to Log file
* Replace user's home path with '<HOMEPATH>'
Part of task # ([VSC-881](https://jira.espressif.com:8443/browse/VSC-881))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run any IDF example project in VSCode(ex: blink)
- Run "Doctor Command" in the Command Palette (CTRL + SHIFT + P) / (Command + Shift + P)
- Check the **esp_idf_vsc_ext.log** 
  - **Windows**: %USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log
  - **Linux & MacOSX**: $HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/esp_idf_vsc_ext.log
- Last log should contain the Doctor Command Output where all the user's path should be replaced with "..."
      Example: `'/Users/<name of the user>/esp/blink'`  should be replaced with `'/Users/<HOMEPATH>/esp/blink'`

**Test Configuration**:
* ESP-IDF Version: 4.4
* OS (Windows,Linux and macOS): macOs and Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
