### PR TITLE
fix openOcd version validator

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,10 +93,20 @@ export class PreCheck {
   ) {
     return (): boolean => {
       try {
-        return (
-          parseInt(currentVersion.split("-").pop()) >=
-          parseInt(minVersion.split("-").pop())
+        const minVersionParsed = minVersion.match(
+          /v(\d+.?\d+.?\d)-esp32-(\d+)/
         );
+        const currentVersionParsed = currentVersion.match(
+          /v(\d+.?\d+.?\d)-esp32-(\d+)/
+        );
+        if (!minVersionParsed || !currentVersionParsed) {
+          throw new Error("Error parsing versions");
+        }
+        return currentVersionParsed[1] >= minVersionParsed[1]
+          ? currentVersionParsed[2] >= minVersionParsed[2]
+            ? true
+            : false
+          : false;
       } catch (error) {
         Logger.error(
           `openOCDVersionValidator failed unexpectedly - min:${minVersion}, curr:${currentVersion}`,


### PR DESCRIPTION
## Description

Fix the openOCD version validator pre check and use regex parsing instead of last piece of string.

Fixes #804

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: 4.4
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
