### PR TITLE
Fixed default branch from esp-matter repository (VSC-971)

### DIFF
--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -37,7 +37,7 @@ export class EspMatterCloning extends AbstractCloning {
     super(
       "https://github.com/espressif/esp-matter.git",
       "ESP-MATTER",
-      "master",
+      "main",
       gitBinPath
     );
   }


### PR DESCRIPTION
## Description

This fixes esp-matter download through this extension. (https://github.com/espressif/vscode-esp-idf-extension/issues/808) 

Fix #808

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I didn't test as is not a braking change, but I test that main branch its able to clone the repo.

**Test Configuration**:
* ESP-IDF Version: 4.4.2
* OS (Windows,Linux and macOS): Linux

## Dependent components impacted by this PR:

- esp-matter

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
