### PR TITLE
add any as valid platform

### DIFF
--- a/src/IPackage.ts
+++ b/src/IPackage.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as tmp from "tmp";
-
 export interface IFileInfo {
   sha256: string;
   size: number;
@@ -21,6 +19,7 @@ export interface IFileInfo {
 }
 
 export interface IVersion {
+  any: IFileInfo;
   name: string;
   status: string;
   win32: IFileInfo;

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -59,7 +59,7 @@ export class IdfToolsManager {
     private platformInfo: PlatformInformation,
     private toolsManagerChannel: vscode.OutputChannel,
     public espIdfPath: string
-  ) { }
+  ) {}
 
   public getPackageList(onReqPkgs?: string[]): Promise<IPackage[]> {
     return new Promise<IPackage[]>((resolve, reject) => {
@@ -154,9 +154,7 @@ export class IdfToolsManager {
       const platformType = Object.getOwnPropertyNames(value).indexOf(
         this.platformInfo.platformToUse
       );
-      const allPlatformType = Object.getOwnPropertyNames(value).indexOf(
-        "any"
-      );
+      const allPlatformType = Object.getOwnPropertyNames(value).indexOf("any");
       return (
         (value.status === "recommended" ||
           value.status === "supported" ||

--- a/src/installManager.ts
+++ b/src/installManager.ts
@@ -44,7 +44,7 @@ export class InstallManager {
     return idfToolsManager.getPackageList(onReqPkgs).then((packages) => {
       let count: number = 1;
       return utils.buildPromiseChain(packages, async (pkg) => {
-        const versionName = idfToolsManager.getVersionToUse(pkg);
+        const versionName = idfToolsManager.getVersionNameToUse(pkg);
         const absolutePath: string = this.getToolPackagesPath([
           "tools",
           pkg.name,
@@ -59,7 +59,7 @@ export class InstallManager {
             pkg,
             binDir
           );
-          const expectedVersion = idfToolsManager.getVersionToUse(pkg);
+          const expectedVersion = idfToolsManager.getVersionNameToUse(pkg);
           if (binVersion === expectedVersion) {
             this.appendChannel(
               `Using existing ${pkg.description} in ${absolutePath}`
@@ -437,7 +437,7 @@ export class InstallManager {
     pkg: IPackage,
     cancelToken?: vscode.CancellationToken
   ) {
-    const versionToUse = idfToolsManager.getVersionToUse(pkg);
+    const versionToUse = idfToolsManager.getVersionNameToUse(pkg);
     return installEspIdfToolFromIdf(
       idfToolsManager.espIdfPath,
       pythonBinPath,

--- a/src/test/suite/downloadManager.test.ts
+++ b/src/test/suite/downloadManager.test.ts
@@ -175,7 +175,7 @@ suite("Download Manager Tests", () => {
         },
       ],
     } as IPackage;
-    const versionName = idfToolsManager.getVersionToUse(pkg);
+    const versionName = idfToolsManager.getVersionNameToUse(pkg);
     const absolutePath: string = installManager.getToolPackagesPath([
       "tools",
       pkg.name,


### PR DESCRIPTION
## Description

Add the $IDF_PATH/tools/tools.json `any` as valid platform for all OS.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Tested by running the setup wizard on Windows for a fresh master branch install

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
