### PR TITLE
Fixed pigweed path (VSC-982)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -913,6 +913,7 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
       "connectedhomeip",
       ".environment",
       "cipd",
+      "packages",
       "pigweed"
     );
     modifiedEnv.ESP_MATTER_DEVICE_PATH = path.join(


### PR DESCRIPTION
## Description
pigweed path is wrong because it points to `path/to/esp-matter/connectedhomeip/connectedhomeip/.environment/cipd/pigweed/` instead of pointing to `path/to/esp-matter/connectedhomeip/connectedhomeip/.environment/cipd/packages/pigweed/` (packages was missing).

Fixes # ([VSC-981](https://github.com/espressif/vscode-esp-idf-extension/issues/815))
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Run "Install ESP-Matter".
2. On prompt, select "No, download ESP32 platform specific submodules only".
3. Open an ESP-Matter example and build. Build should be succesfull.

**Test Configuration**:
* ESP-IDF Version: 4.4.2
* OS (Windows,Linux and macOS): Linux

## Dependent components impacted by this PR:

- ESP-Matter

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
 Verified on platforms:
    - [ ] Windows
    - [x]  Linux 
    - [ ] macOS
