### PR TITLE
chore(templates): change to linux-tools-virtual package

### DIFF
--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update \
   libglib2.0-0 \
   libnuma1 \
   libpixman-1-0 \
-  linux-tools-5.4.0-77-generic \
+  linux-tools-virtual \
   && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
+RUN update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
 
 # QEMU
 ENV QEMU_REL=esp-develop-20220203


### PR DESCRIPTION
This PR will change the package `linux-tools-5.4.0.77-generic` to `linux-tools-virtual` in the template Dockerfile.

## Description

According to [dorssel/usbipd-win](https://github.com/dorssel/usbipd-win/wiki/WSL-support#usbip-client-tools), the instructions have changed in `usbipd-win` version 2.0.0 (released in Januaray 2022) or higher. 

## Type of change

Please delete options that are not relevant.

## How has this been tested?

- update generated `.devcontainer/Dockerfile` in an idf project
- rebuild container in vs code
- (in 3.3.6) `make clean`, `make build`, `make flash`, `make monitor`
- (in 4.4.2) use `Build, flash and Monitor` provided by idf extension

**Test Configuration**:
* ESP-IDF Version: `v3.3.6` and `v4.4.2`
* OS (Windows,Linux and macOS): Windows 11 22H2 / WSL2 with Ubuntu 20.04.5 LTS
* Docker Desktop `4.12.0 (85629)`
* usbipd `2.3.0+42.Branch.master.Sha.3d9f5c5acc4e133ab8147684ad1463cbaec43240`

## Dependent components impacted by this PR:

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
