### PR TITLE
chore(templates): update qemu to 20220919

### DIFF
--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update \
 RUN update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
 
 # QEMU
-ENV QEMU_REL=esp-develop-20220203
-ENV QEMU_SHA256=c83e483e3290f48a563c2a376b7413cd94a8692d8c7308b119f4268ca6d164b6
+ENV QEMU_REL=esp-develop-20220919
+ENV QEMU_SHA256=f6565d3f0d1e463a63a7f81aec94cce62df662bd42fc7606de4b4418ed55f870
 ENV QEMU_DIST=qemu-${QEMU_REL}.tar.bz2
 ENV QEMU_URL=https://github.com/espressif/qemu/releases/download/${QEMU_REL}/${QEMU_DIST}
 


### PR DESCRIPTION
## Description

This PR will update espressif/qemu from `20220203` to `20220919`

## Type of change

Please delete options that are not relevant.

## How has this been tested?

- `add docker container configuration` by idf extension
- modify generated `.devcontainer/Dockerfile` in an idf project
- rebuild container in vs code
- (in 3.3.6) `make clean`, `make build`, `make flash`, `make monitor`
- (in 4.4.2) use `Build, flash and Monitor` provided by idf extension

**Test Configuration**:
* ESP-IDF Version: `v3.3.6` and `v4.4.2`
* OS (Windows,Linux and macOS): Windows 11 22H2 / WSL2 with Ubuntu 20.04.5 LTS
* Docker Desktop `4.12.0 (85629)`
* usbipd `2.3.0+42.Branch.master.Sha.3d9f5c5acc4e133ab8147684ad1463cbaec43240`

## Dependent components impacted by this PR:

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
