### PR TITLE
Added option for lighter Matter repo download (VSC-996)

### DIFF
--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -17,7 +17,11 @@
  */
 import { pathExists } from "fs-extra";
 import { join } from "path";
+import { spawn } from "child_process";
 import {
+  CancellationToken,
+  Progress,
+  ProgressLocation,
   ShellExecution,
   ShellExecutionOptions,
   TaskPanelKind,
@@ -25,11 +29,14 @@ import {
   TaskRevealKind,
   TaskScope,
   Uri,
+  window,
 } from "vscode";
 import { AbstractCloning } from "../common/abstractCloning";
 import { readParameter } from "../idfConfiguration";
 import { Logger } from "../logger/logger";
 import { TaskManager } from "../taskManager";
+import { OutputChannel } from "../logger/outputChannel";
+import { PackageProgress } from "../PackageProgress";
 
 export class EspMatterCloning extends AbstractCloning {
   public static isBuildingGn: boolean;
@@ -49,7 +56,7 @@ export class EspMatterCloning extends AbstractCloning {
     return new ShellExecution(`source ${bootstrapFilePath}`, shellOptions);
   }
 
-  public async startBootstrap() {
+  public async startBootstrap(onlyActivate: boolean = false) {
     if (EspMatterCloning.isBuildingGn) {
       throw new Error("ALREADY_BUILDING");
     }
@@ -63,7 +70,7 @@ export class EspMatterCloning extends AbstractCloning {
       "connectedhomeip",
       "connectedhomeip"
     );
-    const bootstrapFilePath = join(workingDir, "scripts", "bootstrap.sh");
+    const bootstrapFilePath = join(workingDir, "scripts", onlyActivate ? "activate.sh" : "bootstrap.sh");
     const bootstrapFilePathExists = await pathExists(bootstrapFilePath);
     if (!bootstrapFilePathExists) {
       return;
@@ -98,14 +105,129 @@ export class EspMatterCloning extends AbstractCloning {
       matterBootstrapPresentationOptions
     );
   }
+
+  public async initEsp32PlatformSubmodules(
+    espMatterDir: string,
+  ) {
+    OutputChannel.appendLine('Downloading ESP-Matter ESP32 platform submodules');
+    await window.withProgress(
+      {
+        cancellable: true,
+        location: ProgressLocation.Notification,
+        title: 'Checking out ESP32 platform specific submodules',
+      },
+      async (
+        progress: Progress<{ message: string; increment: number }>,
+        cancelToken: CancellationToken
+      ) => {
+        try {
+          cancelToken.onCancellationRequested((e) => {
+            this.cancel();
+          });
+          await this.checkoutEsp32PlatformSubmodules(espMatterDir, undefined, progress);
+          Logger.infoNotify(`ESP32 platform specific submodules checked out successfully`);
+        } catch (error) {
+          OutputChannel.appendLine(error.message);
+          Logger.errorNotify(error.message, error);
+        }
+      }
+    );
+  }
+
+  public async checkoutEsp32PlatformSubmodules(
+    espMatterDir: string,
+    pkgProgress?: PackageProgress,
+    progress?: Progress<{ message?: string; increment?: number }>,
+  ) {
+     return new Promise<void>((resolve, reject) => {
+      const checkoutProcess = spawn(
+        join(
+          espMatterDir,
+          "connectedhomeip",
+          "connectedhomeip",
+          "scripts",
+          "checkout_submodules.py"
+        ),
+        [
+          "--platform",
+          "esp32",
+          "--shallow"
+        ],
+        { cwd: espMatterDir }
+      );
+
+      checkoutProcess.stderr.on("data", (data) => {
+        OutputChannel.appendLine(data.toString());
+        Logger.info(data.toString());
+        const errRegex = /\b(Error)\b/g;
+        if (errRegex.test(data.toString())) {
+          reject(data.toString());
+        }
+        const progressRegex = /(\d+)(\.\d+)?%/g;
+        const matches = data.toString().match(progressRegex);
+        if (matches) {
+          let progressMsg = `Downloading ${matches[matches.length - 1]}`;
+          if (progress) {
+            progress.report({
+              message: progressMsg,
+            });
+          }
+          if (pkgProgress) {
+            pkgProgress.Progress = matches[matches.length - 1];
+          }
+        } else if (data.toString().indexOf("Cloning into") !== -1) {
+          let detailMsg = " " + data.toString();
+          if (progress) {
+            progress.report({
+              message: `${data.toString()}`,
+            });
+          }
+          if (pkgProgress) {
+            pkgProgress.Progress = detailMsg;
+          }
+        }
+      });
+
+      checkoutProcess.on("exit", (code, signal) => {
+        if (!signal && code !== 0) {
+          const msg = `ESP32 platform submodules clone has exit with ${code}`;
+          OutputChannel.appendLine(msg);
+          Logger.errorNotify("ESP32 platform submodules cloning error", new Error(msg));
+          return reject(new Error(msg));
+        }
+        return resolve();
+      });
+    });
+  }
 }
 
 export async function getEspMatter(workspace?: Uri) {
   const gitPath = (await readParameter("idf.gitPath", workspace)) || "/usr/bin/git";
   const espMatterInstaller = new EspMatterCloning(gitPath, workspace);
+  const installAllSubmodules = await window.showQuickPick(
+      [
+        {
+          label: `No, download ESP32 platform specific submodules only`,
+          target: "false",
+        },
+        {
+          label: "Yes, download all Matter submodules",
+          target: "true",
+        },
+      ],
+      { placeHolder: `Download all Matter submodules?` }
+    );
+  
   try {
-    await espMatterInstaller.getRepository("idf.espMatterPath", workspace);
-    await espMatterInstaller.startBootstrap();
+    if (installAllSubmodules.target === "true") {
+      await espMatterInstaller.getRepository("idf.espMatterPath", workspace);
+      await espMatterInstaller.startBootstrap();
+    } else {
+      await espMatterInstaller.getRepository("idf.espMatterPath", workspace, false);
+      await espMatterInstaller.getSubmodules(readParameter("idf.espMatterPath", workspace));
+      await espMatterInstaller.initEsp32PlatformSubmodules(readParameter("idf.espMatterPath", workspace));
+      await espMatterInstaller.startBootstrap(true);
+    }
     await TaskManager.runTasks();
     EspMatterCloning.isBuildingGn = false;
   } catch (error) {


### PR DESCRIPTION
## Description
When "Install ESP-Matter" command is run, the extension will ask if it should download all the Matter submodules, or ESP32 platform specific only submodules.

For that, first it was necessary to avoid recursive download when cloning, so I added an argument to `downloadByCloning` (and also `getRepository`) from `AbstractCloning.ts` class that specifies if recursive download is required and changes the git clone arguments depending on that argument. By default, this argument is set to `true`, so that other calls to this function remain with the same functionality.

I also created a function at `AbstractCloning.ts` that download submodules of a git repository (but not recursively) and a function at `espMatterDownload.ts` that calls to `path/to/esp-matter/connectedhomeip/connectedhomeip/scripts/checkout_submodules.py --platform esp32 --shallow` that download required submodules in Matter for ESP32.

On the `startBootstrap` function at `espMatterDownload.ts` I added a parameter that selects between `activate.sh` or `bootstrap.sh`. `bootsrap.sh` will download all the submodules, while `activate.sh` will not and will perform the other actions that `bootstrap.sh` does too. So `activate.sh` will be used when performing the lighter download.

Fixes # ([VSC-983](https://github.com/espressif/vscode-esp-idf-extension/issues/819))

## Type of change
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Test for new feature
   1. Run "Install ESP-Matter".
   2. On prompt, select "No, download ESP32 platform specific submodules only".
   3. Open an ESP-Matter example and build. Build should be succesfull.
- Test for other features that calls to `downloadByCloning` or `getRepository` which its functionality should remain unmodified.
   - Run "Install ESP-Matter" and select "Yes, download all Matter submodules"
   - Run "Install ESP-ADF"
   - Run "Install ESP-MDF"

**Test Configuration**:
* ESP-IDF Version: 4.4.2
* OS (Windows,Linux and macOS): Linux (Ubuntu)

## Dependent components impacted by this PR:

- ESP-Matter

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
 Verified on platforms:
    - [ ] Windows
    - [x]  Linux 
    - [ ] macOS
