### PR TITLE
fix empty workspace folder issues

### DIFF
--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -56,7 +56,7 @@
   "espIdf.welcome.title": "Welcome",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
-  "debug.initConfig.name": "ESP-IDF: Launch",
+  "debug.initConfig.name": "ESP-IDF Debug: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",
   "param.customAdapterTargetName": "Custom target name for ESP-IDF Debug Adapter",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -56,7 +56,7 @@
   "espIdf.flashBinaryToPartition.title": "Programar binarios a la partición...",
   "espIdf.customTask.title": "Ejecutar tarea personalizada",
   "espIdf.welcome.title": "Bienvenido/a",
-  "debug.initConfig.name": "Lanzar ESP-IDF:",
+  "debug.initConfig.name": "Lanzar Depuracion ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",
   "param.customAdapterTargetName": "Custom target para el ESP-IDF Debug Adapter",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -56,7 +56,7 @@
   "espIdf.welcome.title": "Добро пожаловать",
   "esp.component-manager.ui.show.title": "Показать реестр компонентов",
   "esp.component-manager.cli.addDependencyError": "Ошибка при добавлении зависимости к компоненту",
-  "debug.initConfig.name": "ESP-IDF: Запустить",
+  "debug.initConfig.name": "Отладка ESP-IDF: запуск",
   "debug.initConfig.description": "Новая конфигурация для запуска проектов ESP-IDF",
   "param.adapterTargetName": "Целевое устройство для адаптера отладки ESP-IDF",
   "param.customAdapterTargetName": "Настраиваемое целевое имя для адаптера отладки ESP-IDF",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -56,7 +56,7 @@
   "espIdf.welcome.title": "欢迎",
   "esp.component-manager.ui.show.title": "显示组件注册表",
   "esp.component-manager.cli.addDependencyError": "向组件添加依赖项时遇到错误",
-  "debug.initConfig.name": "ESP-IDF：启动",
+  "debug.initConfig.name": "ESP-IDF调试 启动",
   "debug.initConfig.description": "启用 ESP-IDF 项目的新配置",
   "param.adapterTargetName": "ESP-IDF 调试适配器的目标名称",
   "param.customAdapterTargetName": "ESP-IDF 调试适配器的自定义目标名称",

--- a/package.json
+++ b/package.json
@@ -1215,16 +1215,18 @@
           {
             "name": "%debug.initConfig.name%",
             "type": "espidf",
-            "request": "launch",
-            "preLaunchTask": "adapter"
+            "request": "launch"
           }
         ],
         "configurationSnippets": [
           {
-            "name": "%debug.initConfig.name%",
-            "type": "espidf",
-            "request": "launch",
-            "preLaunchTask": "adapter"
+            "label": "%debug.initConfig.name%",
+            "body": {
+              "name": "%debug.initConfig.name%",
+              "type": "espidf",
+              "request": "launch"
+            },
+            "description": "%debug.initConfig.description%"
           }
         ]
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -56,7 +56,7 @@
   "espIdf.welcome.title": "Welcome",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
-  "debug.initConfig.name": "ESP-IDF: Launch",
+  "debug.initConfig.name": "ESP-IDF Debug: Launch",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "param.adapterTargetName": "Target name for ESP-IDF Debug Adapter",
   "param.customAdapterTargetName": "Custom target name for ESP-IDF Debug Adapter",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2073,6 +2073,9 @@ export async function activate(context: vscode.ExtensionContext) {
             workspaceRoot,
             reportedResult
           );
+          await vscode.window.showTextDocument(
+            vscode.Uri.file(path.join(context.extensionPath, "report.txt"))
+          );
         } catch (error) {
           reportedResult.latestError = error;
           const errMsg = error.message

--- a/src/support/checkVscodeFiles.ts
+++ b/src/support/checkVscodeFiles.ts
@@ -26,6 +26,7 @@ export async function checkLaunchJson(
   currentWorkspace: Uri
 ) {
   if (!currentWorkspace) {
+    reportedResult.launchJson = "No workspace folder is opened";
     return;
   }
   const launchJsonPath = join(
@@ -42,6 +43,7 @@ export async function checkCCppPropertiesJson(
   currentWorkspace: Uri
 ) {
   if (!currentWorkspace) {
+    reportedResult.cCppPropertiesJson = "No workspace folder is opened";
     return;
   }
   const cCppPropertiesJsonPath = join(

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -24,7 +24,7 @@ export function getConfigurationSettings(
 ) {
   const winFlag = process.platform === "win32" ? "Win" : "";
   const conf = workspace.getConfiguration("", scope);
-  reportedResult.workspaceFolder = scope.fsPath;
+  reportedResult.workspaceFolder = scope ? scope.fsPath: "No workspace folder is open";
   reportedResult.configurationSettings = {
     espAdfPath: conf.get("idf.espAdfPath" + winFlag),
     espIdfPath: conf.get("idf.espIdfPath" + winFlag),

--- a/src/support/pythonPackages.ts
+++ b/src/support/pythonPackages.ts
@@ -32,7 +32,7 @@ export async function getPythonPackages(
   const parsedPkgsListMatches = rawPythonPackagesList.match(/\[.*\]/g);
   if (parsedPkgsListMatches && parsedPkgsListMatches.length) {
     reportedResult.configurationSettings.pythonPackages = JSON.parse(
-      parsedPkgsListMatches[0]
+      parsedPkgsListMatches[parsedPkgsListMatches.length - 1]
     );
   }
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes using the doctor command when no workspace folder is opened. 
Fix Python packages json match in doctor command
Open the doctor command result text file after finished.

Fix #827

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual testing running the `ESP-IDF Doctor Command`. Delete `launch.json` and create from debug activity bar. Also tested VSCode autocomplete.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): MacOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
