### PR TITLE
add input for select custom openocd board

### DIFF
--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Friday, 8th January 2021 5:34:24 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ export const defaultBoards = [
   } as IdfBoard,
   {
     name: "ESP32-S3 chip (via builtin USB-JTAG)",
-    description: "ESP32-S3 used with ESP-PROG board",
+    description: "ESP32-S3 debugging via builtin USB-JTAG",
     target: "esp32s3",
     configFiles: ["board/esp32s3-builtin.cfg"],
   } as IdfBoard,
@@ -104,6 +104,15 @@ export async function getBoards(openOcdScriptsPath: string = "") {
         configFiles: b.config_files,
       } as IdfBoard;
     });
+    const tmpS3Board = {
+      name: "ESP32-S3 chip (via builtin USB-JTAG)",
+      description: "ESP32-S3 debugging via builtin USB-JTAG",
+      target: "esp32s3",
+      configFiles: ["board/esp32s3-builtin.cfg"],
+    } as IdfBoard;
+    if (espBoards.findIndex((b) => b.name === tmpS3Board.name) === -1) {
+      espBoards.push(tmpS3Board);
+    }
     const emptyBoard = {
       name: "Custom board",
       description: "No board selected",

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -106,6 +106,15 @@ export async function setIdfTarget(placeHolderMsg: string) {
             `ESP-IDF board not selected. Remember to set the configuration files for OpenOCD with idf.openOcdConfigs`
           );
         } else if (selectedBoard && selectedBoard.target) {
+          if (selectedBoard.label.indexOf("Custom board") !== -1) {
+            const inputBoard = await window.showInputBox({
+              placeHolder: "Enter comma separated configuration files",
+              value: selectedBoard.target.join(","),
+            });
+            if (inputBoard) {
+              selectedBoard.target = inputBoard.split(",");
+            }
+          }
           await writeParameter(
             "idf.openOcdConfigs",
             selectedBoard.target,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1683,6 +1683,17 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!selectedBoard) {
         return;
       }
+
+      if (selectedBoard.target.name.indexOf("Custom board") !== -1) {
+        const inputBoard = await vscode.window.showInputBox({
+          placeHolder: "Enter comma separated configuration files",
+          value: selectedBoard.target.configFiles.join(","),
+        });
+        if (inputBoard) {
+          selectedBoard.target.configFiles = inputBoard.split(",");
+        }
+      }
+
       const target = idfConf.readParameter("idf.saveScope");
       if (
         !PreCheck.isWorkspaceFolderOpen() &&


### PR DESCRIPTION
## Description

In the `ESP-IDF: Select OpenOCD Board Configuration` allow the user to manually input the configuration files for the `Custom Board` option. 

Also add the `ESP32-S3 debugging via builtin USB-JTAG` option if not available in `esp-config.json` temporary since it is only included in the latest OpenOCD release.

Fix #826

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Manual Testing using the UI command 

**Test Configuration**:
* ESP-IDF Version: 4.4.2
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- No Dependency affected

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
