### PR TITLE
fix args order build task

### DIFF
--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -149,12 +149,13 @@ export class BuildTask {
         "-DPYTHON_DEPS_CHECKED=1",
         "-DESP_PLATFORM=1",
       ];
-      compilerArgs.push(
-        "-B",
-        this.buildDirPath,
-        "-S",
-        this.curWorkspace.fsPath
-      );
+      if (compilerArgs.indexOf("-B") === -1) {
+        compilerArgs.push("-B", this.buildDirPath);
+      }
+
+      if (compilerArgs.indexOf("-S") === -1) {
+        compilerArgs.push("-S", this.curWorkspace.fsPath);
+      }
       const enableCCache = idfConf.readParameter(
         "idf.enableCCache",
         this.curWorkspace
@@ -162,7 +163,7 @@ export class BuildTask {
       if (enableCCache && compilerArgs && compilerArgs.length) {
         const indexOfCCache = compilerArgs.indexOf("-DCCACHE_ENABLE=1");
         if (indexOfCCache === -1) {
-          compilerArgs.splice(compilerArgs.length - 1, 0, "-DCCACHE_ENABLE=1");
+          compilerArgs.push("-DCCACHE_ENABLE=1");
         }
       }
       const compileExecution = this.getShellExecution(compilerArgs, options);


### PR DESCRIPTION
## Description

Check that build compiler arguments doesn't already exists before adding them to the list. Make sure to add the CCache argument at the end.

Fix #837 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual build test on Windows

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Windows 



## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
