### PR TITLE
fix monitor use target arg idf version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Determine version
         id: version
-        run: "echo ::set-output name=version::${GITHUB_REF:11}"
+        run: echo "version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
 
       - name: Upload no dependencies release asset
         id: upload-open-release-asset

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -69,7 +69,7 @@ export class IDFMonitor {
       "--toolchain-prefix",
       this.config.toolchainPrefix,
     ];
-    if (this.config.idfVersion >= "4.2") {
+    if (this.config.idfVersion >= "4.3") {
       args.push("--target", this.config.idfTarget);
     }
     if (this.config.wsPort) {


### PR DESCRIPTION
## Description

ESP-IDF version needs to be `>=4.3` to use the `--target` argument in `idf_monitor.py`

Fix #838

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual testing running the extension Monitor command.

**Test Configuration**:
* ESP-IDF Version: 4.2 and 4.3
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
