### PR TITLE
add linux archs to platform info

### DIFF
--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -40,7 +40,7 @@ export class PlatformInformation {
   public get platformToUse(): string {
     switch (this.platform) {
       case "darwin":
-        return this.architecture === "arm64" ? "macos-arm64": "macos";
+        return this.architecture === "arm64" ? "macos-arm64" : "macos";
       case "win32":
         return this.architecture === "x86" ? "win32" : "win64";
       case "linux":

--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -40,14 +40,17 @@ export class PlatformInformation {
   public get platformToUse(): string {
     switch (this.platform) {
       case "darwin":
-        return "macos";
+        return this.architecture === "arm64" ? "macos-arm64": "macos";
       case "win32":
         return this.architecture === "x86" ? "win32" : "win64";
       case "linux":
         switch (this.architecture) {
           case "arm64":
+          case "armv8l":
+          case "aarch64":
             return "linux-arm64";
           case "armel":
+          case "armv7l":
             return "linux-armel";
           case "armhf":
             return "linux-armhf";

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -318,7 +318,13 @@ export async function getSetupInitialValues(
         prevInstall.toolsResults
       );
 
-      if (cmakeFromToolsIndex !== -1) {
+      const canAccessCMake = await utils.isBinInPath(
+        "cmake",
+        extensionPath,
+        process.env
+      );
+
+      if (cmakeFromToolsIndex !== -1 || canAccessCMake) {
         prevInstall.toolsResults.splice(cmakeFromToolsIndex, 1);
       } else {
         setupInitArgs.onReqPkgs = setupInitArgs.onReqPkgs
@@ -331,7 +337,13 @@ export async function getSetupInitialValues(
         prevInstall.toolsResults
       );
 
-      if (ninjaFromToolsIndex !== -1) {
+      const canAccessNinja = await utils.isBinInPath(
+        "ninja",
+        extensionPath,
+        process.env
+      );
+
+      if (ninjaFromToolsIndex !== -1 || canAccessNinja) {
         prevInstall.toolsResults.splice(ninjaFromToolsIndex, 1);
       } else {
         setupInitArgs.onReqPkgs = setupInitArgs.onReqPkgs

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -324,9 +324,9 @@ export async function getSetupInitialValues(
         process.env
       );
 
-      if (cmakeFromToolsIndex !== -1 || canAccessCMake) {
+      if (cmakeFromToolsIndex !== -1) {
         prevInstall.toolsResults.splice(cmakeFromToolsIndex, 1);
-      } else {
+      } else if (canAccessCMake === "") {
         setupInitArgs.onReqPkgs = setupInitArgs.onReqPkgs
           ? [...setupInitArgs.onReqPkgs, "cmake"]
           : ["cmake"];
@@ -343,9 +343,9 @@ export async function getSetupInitialValues(
         process.env
       );
 
-      if (ninjaFromToolsIndex !== -1 || canAccessNinja) {
+      if (ninjaFromToolsIndex !== -1) {
         prevInstall.toolsResults.splice(ninjaFromToolsIndex, 1);
-      } else {
+      } else if (canAccessNinja === "") {
         setupInitArgs.onReqPkgs = setupInitArgs.onReqPkgs
           ? [...setupInitArgs.onReqPkgs, "ninja"]
           : ["ninja"];


### PR DESCRIPTION
## Description

Add platform in idfToolsManager.ts to manage Linux arm packages.

Fix #840

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual testing of the setup wizard in Linux.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Linux

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
