### PR TITLE
Feature: install matter python requirements (VSC-1030)

### DIFF
--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -33,6 +33,7 @@
   "espIdf.getEspAdf.title": "ESP-IDF: Install ESP-ADF",
   "espIdf.getEspMdf.title": "ESP-IDF: Install ESP-MDF",
   "espIdf.getEspMatter.title": "ESP-IDF: Install ESP-Matter",
+  "espIdf.installEspMatterPyReqs.title": "ESP-IDF: Install ESP-Matter Python Packages",
   "espIdf.installPyReqs.title": "ESP-IDF: Install ESP-IDF extension Python Packages",
   "espIdf.openDocUrl.title": "ESP-IDF: Open ESP-IDF Documentation...",
   "espIdf.doctorCommand.title": "ESP-IDF: Doctor command",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -33,6 +33,7 @@
   "espIdf.getEspAdf.title": "ESP-IDF: Instalar ESP-ADF",
   "espIdf.getEspMdf.title": "ESP-IDF: Instalar ESP-MDF",
   "espIdf.getEspMatter.title": "ESP-IDF: Instalar ESP-Matter",
+  "espIdf.installEspMatterPyReqs.title": "ESP-IDF: Instalar paquetes Python para ESP-Matter",
   "espIdf.installPyReqs.title": "ESP-IDF: Instalar paquetes Python para extensión ESP-IDF",
   "espIdf.openDocUrl.title": "ESP-IDF: Abrir documentación ESP-IDF...",
   "espIdf.doctorCommand.title": "ESP-IDF: Comando Doctor",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -33,6 +33,7 @@
   "espIdf.getEspAdf.title": "ESP-IDF: Установить ESP-ADF",
   "espIdf.getEspMdf.title": "ESP-IDF: Установить ESP-MDF",
   "espIdf.getEspMatter.title": "ESP-IDF: Установить ESP-Matter",
+  "espIdf.installEspMatterPyReqs.title": "ESP-IDF: Установите пакеты Python ESP-Matter",
   "espIdf.installPyReqs.title": "ESP-IDF: Установите пакеты Python расширения ESP-IDF",
   "espIdf.openDocUrl.title": "ESP-IDF: Открыть документацию ...",
   "espIdf.doctorCommand.title": "ESP-IDF: Команда врача",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -33,6 +33,7 @@
   "espIdf.getEspAdf.title": "ESP-IDF: 安装 ESP-ADF",
   "espIdf.getEspMdf.title": "ESP-IDF: 安装 ESP-MDF",
   "espIdf.getEspMatter.title": "ESP-IDF: 安装 ESP-Matter",
+  "espIdf.installEspMatterPyReqs.title": "ESP-IDF: 安装 ESP-Matter Python 包",
   "espIdf.installPyReqs.title": "ESP-IDF: 安装 ESP-IDF 扩展 Python 包",
   "espIdf.openDocUrl.title": "ESP-IDF: 打开 ESP-IDF 文档...",
   "espIdf.doctorCommand.title": "ESP-IDF: 诊断命令",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "onCommand:espIdf.getEspAdf",
     "onCommand:espIdf.getEspMdf",
     "onCommand:espIdf.getEspMatter",
+    "onCommand:espIdf.installEspMatterPyReqs",
     "onCommand:espIdf.installPyReqs",
     "onCommand:esp.webview.open.partition-table",
     "onCommand:espIdf.webview.nvsPartitionEditor",
@@ -1031,6 +1032,10 @@
       {
         "command": "espIdf.getEspMatter",
         "title": "%espIdf.getEspMatter.title%"
+      },
+      {
+        "command": "espIdf.installEspMatterPyReqs",
+        "title": "%espIdf.installEspMatterPyReqs.title%"
       },
       {
         "command": "espIdf.installPyReqs",

--- a/package.nls.json
+++ b/package.nls.json
@@ -33,6 +33,7 @@
   "espIdf.getEspAdf.title": "ESP-IDF: Install ESP-ADF",
   "espIdf.getEspMdf.title": "ESP-IDF: Install ESP-MDF",
   "espIdf.getEspMatter.title": "ESP-IDF: Install ESP-Matter",
+  "espIdf.installEspMatterPyReqs.title": "ESP-IDF: Install ESP-Matter Python Packages",
   "espIdf.installPyReqs.title": "ESP-IDF: Install ESP-IDF extension Python Packages",
   "espIdf.openDocUrl.title": "ESP-IDF: Open ESP-IDF Documentation...",
   "espIdf.doctorCommand.title": "ESP-IDF: Doctor command",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -111,6 +111,7 @@
     "espIdf.getEspAdf.title",
     "espIdf.getEspMdf.title",
     "espIdf.getEspMatter.title",
+    "espIdf.installEspMatterPyReqs.title",
     "espIdf.installPyReqs.title",
     "espIdf.openDocUrl.title",
     "espIdf.clearDocsSearchResult.title",


### PR DESCRIPTION
## Description

Installs python requirements for ESP-Matter when it gets installed.
Also added a command to install this requirements in other python environments in case that is needed.

And fixed some notifications in ESP-Matter installation.

Fixes # ([VSC-1029](https://github.com/espressif/vscode-esp-idf-extension/issues/868))

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Build the extension and run the whole installation process. Also I tested the command in another python env.

**Test Configuration**:
* ESP-IDF Version: 4.4.3
* OS (Windows,Linux and macOS): Linux

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
