### PR TITLE
add build sdkconfig support

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -16,6 +16,7 @@ These are the configuration settings that ESP-IDF extension contributes to your 
 | ------------------------------- | ----------------------------------------------------------------------------------------- |
 | `idf.buildPath`                 | Custom build directory name for extension commands. (Default: \${workspaceFolder}/build)  |
 | `idf.buildPathWin`              | Custom build directory name for extension commands. (Default: \${workspaceFolder}\\build) |
+| `idf.sdkconfigDefaults`         | List of sdkconfig default values for initial build configuration                          |
 | `idf.cmakeCompilerArgs`         | Arguments for CMake compilation task                                                      |
 | `idf.customExtraPaths`          | Paths to be appended to \$PATH                                                            |
 | `idf.customExtraVars`           | Variables to be added to system environment variables                                     |

--- a/docs/tutorial/multiple_config.md
+++ b/docs/tutorial/multiple_config.md
@@ -1,0 +1,43 @@
+# Use multiple build configuration
+
+## Multiple ESP-IDF versions.
+
+You can use multiple ESP-IDF versions, one for each ESP-IDF project by explicitly defining your configuration settings in your current project directory `.vscode/settings.json`. 
+
+1. Set the `idf.saveScope` to WorkspaceFolder with the `ESP-IDF: Select where to save configuration settings` command or directly in the `.vscode/settings.json` of desired project opened in Visual Studio Code.
+
+2. Configure the extension as described in [here](./install.md) or use the [JSON manual configuration](../SETUP.md#json-manual-configuration) to set these values in your project's `.vscode/settings.json`.
+
+3. Make sure to delete any previous build directory since a different ESP-IDF version would not work if there is any cache of previous build.
+
+4. Repeat from 1) on any project you would like to use a different version from the global user settings.
+
+Look at the [Working with multiple projects](../MULTI_PROJECTS.md) documentation to understand where and how Visual Studio Code handle configuration settings and the scope of each location.
+
+## Using multiple build configuration.
+
+As shown in the [ESP-IDF CMake Multiple configuration example](https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config) you can use multiple build directories and multiple sdkconfig defaults files to produce different production output.
+
+In this extension you can define the build directory with the `idf.buildPath` (`idf.buildPathWin` fo Windows) configuration setting and the list of sdkconfig default files with `idf.sdkconfigDefaults` configuration. The value of these settings will be using by the extension build command.
+
+Say you want to make product 1:
+1) you have sdkconfig files `sdkconfig.prod_common` and `sdkconfig.prod1` and you want the resulting firmware to be generated in `<your-project>/build_prod1` where `build_prod1` is the name of the custom build folder.
+2) Add these settings in `<your-project>/.vscode/settings.json`:
+
+```json
+{
+  // ...
+  "idf.buildPath": "${workspaceFolder}/build_prod1",
+  "idf.sdkconfigDefaults": [
+    "sdkconfig.prod_common",
+    "sdkconfig.prod1"
+  ]
+  // ...
+}
+```
+
+3) Build your project using the `ESP-IDF: Build your project` command.
+
+4) Your resulting files will be generated in `<your-project>/build_prod1` and the sdkconfig being used by the SDK Configuration Editor will be `<your-project>/build_prod1/sdkconfig`.
+
+5) Change values in 2) for different products and configurations.

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -94,6 +94,7 @@
   "param.buildPath": "Name of CMake build directory",
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
+  "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -95,6 +95,7 @@
   "param.postFlashTask": "Post build tarea personalizada",
   "param.customTask": "Tarea personalizada",
   "param.buildPath": "Nombre del directorio de construcción de CMake",
+  "param.sdkconfigDefaults": "Lista de valores por defecto para crear el archivo sdkconfig",
   "param.svdFile": "Archivo SVD para la vista de perifericos en ventana de depuracion",
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "view.components.name": "Componentes de proyecto",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -95,6 +95,7 @@
   "param.postFlashTask": "Опубликовать настраиваемую задачу Flash",
   "param.customTask": "Специальная задача",
   "param.buildPath": "Имя каталога сборки CMake",
+  "param.sdkconfigDefaults": "Список значений по умолчанию sdkconfig для начальной конфигурации сборки",
   "param.svdFile": "Файл SVD для разрешения периферийного представления ESP-IDF в представлении отладки",
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "view.components.name": "Компоненты проекта",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -95,6 +95,7 @@
   "param.postFlashTask": "flash后自定义任务",
   "param.customTask": "自定义任务",
   "param.buildPath": "CMake生成目录的名称",
+  "param.sdkconfigDefaults": "初始生成配置的sdkconfig默认值列表",
   "param.svdFile": "用于在调试视图中解析ESP-IDF外围视图的奇异值分解文件",
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "view.components.name": "项目组件",

--- a/package.json
+++ b/package.json
@@ -506,6 +506,12 @@
             "description": "%param.cmakeCompilerArgs%",
             "scope": "resource"
           },
+          "idf.sdkconfigDefaults": {
+            "type":"array",
+            "default": [],
+            "description": "%param.sdkconfigDefaults%",
+            "scope": "resource"
+          },
           "idf.ninjaArgs": {
             "type": "array",
             "default": [],

--- a/package.nls.json
+++ b/package.nls.json
@@ -94,6 +94,7 @@
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "param.buildPath": "Name of CMake build directory",
+  "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -158,6 +158,7 @@
     "param.partialDarkTheme",
     "param.uncoveredLightTheme",
     "param.uncoveredDarkTheme",
+    "param.sdkconfigDefaults",
     "view.components.name",
     "configuration.title",
     "espIdf.apptrace.archive.refresh.title",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -156,6 +156,17 @@ export class BuildTask {
       if (compilerArgs.indexOf("-S") === -1) {
         compilerArgs.push("-S", this.curWorkspace.fsPath);
       }
+
+      const sdkconfigDefaults =
+        (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+
+      if (sdkconfigDefaults && sdkconfigDefaults.length) {
+        compilerArgs.push(
+          "-D",
+          `SDKCONFIG_DEFAULTS="${sdkconfigDefaults.join(";")}"`
+        );
+      }
+
       const enableCCache = idfConf.readParameter(
         "idf.enableCCache",
         this.curWorkspace

--- a/src/coverage/configureProject.ts
+++ b/src/coverage/configureProject.ts
@@ -32,31 +32,31 @@ import { getDocsLocaleLang, getDocsVersion } from "../espIdf/documentation/getDo
 export async function configureProjectWithGcov(workspacePath: Uri) {
   const appTraceDestTrax = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_DEST_TRAX",
-    workspacePath.fsPath
+    workspacePath
   );
   const appTraceEnable = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_ENABLE",
-    workspacePath.fsPath
+    workspacePath
   );
   const appTraceLockEnable = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_LOCK_ENABLE",
-    workspacePath.fsPath
+    workspacePath
   );
   const onPanicHostFlushTmo = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_ONPANIC_HOST_FLUSH_TMO",
-    workspacePath.fsPath
+    workspacePath
   );
   const postmortemFlushThresh = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_POSTMORTEM_FLUSH_THRESH",
-    workspacePath.fsPath
+    workspacePath
   );
   const appTracePendingDataSizeMax = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_PENDING_DATA_SIZE_MAX",
-    workspacePath.fsPath
+    workspacePath
   );
   const appTraceGcovEnable = getConfigValueFromSDKConfig(
     "CONFIG_APPTRACE_GCOV_ENABLE",
-    workspacePath.fsPath
+    workspacePath
   );
 
   const isGcovEnabled =

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -26,6 +26,7 @@ import { OutputChannel } from "../../logger/outputChannel";
 import {
   appendIdfAndToolsToPath,
   delConfigFile,
+  getSDKConfigFilePath,
   isStringNotEmpty,
 } from "../../utils";
 import { KconfigMenuLoader } from "./kconfigMenuLoader";
@@ -260,7 +261,7 @@ export class ConfserverProcess {
       idfConf.readParameter("idf.espIdfPath", workspaceFolder).toString() ||
       process.env.IDF_PATH;
     const pythonBinPath = idfConf.readParameter("idf.pythonBinPath", workspaceFolder) as string;
-    this.configFile = path.join(workspaceFolder.fsPath, "sdkconfig");
+    this.configFile = getSDKConfigFilePath(workspaceFolder);
 
     process.env.IDF_TARGET = "esp32";
     process.env.PYTHONUNBUFFERED = "0";

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -59,7 +59,7 @@ export async function createNewIdfMonitor(
     );
   }
   let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
-    workspaceFolder.fsPath
+    workspaceFolder
   );
   const pythonBinPath = readParameter(
     "idf.pythonBinPath",

--- a/src/espIdf/partition-table/tree.ts
+++ b/src/espIdf/partition-table/tree.ts
@@ -104,7 +104,7 @@ export class PartitionTreeDataProvider
       if (partitionTableOffsetOption.target.indexOf("sdkconfig") !== -1) {
         partitionTableOffset = getConfigValueFromSDKConfig(
           "CONFIG_PARTITION_TABLE_OFFSET",
-          workspace.fsPath
+          workspace
         );
       } else if (partitionTableOffsetOption.target.indexOf("custom") !== -1) {
         partitionTableOffset = await window.showInputBox({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2361,7 +2361,7 @@ export async function activate(context: vscode.ExtensionContext) {
           );
         }
         let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
-          workspaceRoot.fsPath
+          workspaceRoot
         );
         const pythonBinPath = idfConf.readParameter(
           "idf.pythonBinPath",
@@ -2552,7 +2552,7 @@ export async function activate(context: vscode.ExtensionContext) {
         try {
           const isCustomPartitionTableEnabled = utils.getConfigValueFromSDKConfig(
             "CONFIG_PARTITION_TABLE_CUSTOM",
-            workspaceRoot.fsPath
+            workspaceRoot
           );
           if (isCustomPartitionTableEnabled !== "y") {
             throw new Error(
@@ -2562,7 +2562,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
           let partitionTableFilePath = utils.getConfigValueFromSDKConfig(
             "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME",
-            workspaceRoot.fsPath
+            workspaceRoot
           );
           partitionTableFilePath = partitionTableFilePath.replace(/\"/g, "");
           if (!utils.isStringNotEmpty(partitionTableFilePath)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -324,12 +324,17 @@ export function getSDKConfigFilePath(workspacePath: vscode.Uri) {
     workspacePath.fsPath,
     "SDKCONFIG"
   );
-  if (sdkconfigFilePath && sdkconfigFilePath.indexOf("${CMAKE_BINARY_DIR}") !== -1) {
+  if (
+    sdkconfigFilePath &&
+    sdkconfigFilePath.indexOf("${CMAKE_BINARY_DIR}") !== -1
+  ) {
     const buildDirPath = idfConf.readParameter(
       "idf.buildPath",
       workspacePath
     ) as string;
-    sdkconfigFilePath = sdkconfigFilePath.replace("${CMAKE_BINARY_DIR}", buildDirPath).replace(/"/g, "");
+    sdkconfigFilePath = sdkconfigFilePath
+      .replace("${CMAKE_BINARY_DIR}", buildDirPath)
+      .replace(/"/g, "");
   }
   if (!sdkconfigFilePath) {
     const modifiedEnv = appendIdfAndToolsToPath(workspacePath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -308,12 +308,47 @@ export async function copyFromSrcProject(
   await copy(srcDirPath, destinationDir.fsPath);
 }
 
+export function getVariableFromCMakeLists(workspacePath: string, key: string) {
+  const cmakeListsFilePath = path.join(workspacePath, "CMakeLists.txt");
+  if (!canAccessFile(cmakeListsFilePath, fs.constants.R_OK)) {
+    throw new Error("CMakeLists.txt file doesn't exists or can't be read");
+  }
+  const cmakeListsContent = readFileSync(cmakeListsFilePath);
+  const regexExp = new RegExp(`(?:set|SET)\\(${key} (.*)\\)`);
+  const match = cmakeListsContent.match(regexExp);
+  return match ? match[1] : "";
+}
+
+export function getSDKConfigFilePath(workspacePath: vscode.Uri) {
+  let sdkconfigFilePath = getVariableFromCMakeLists(
+    workspacePath.fsPath,
+    "SDKCONFIG"
+  );
+  if (sdkconfigFilePath && sdkconfigFilePath.indexOf("${CMAKE_BINARY_DIR}") !== -1) {
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
+      workspacePath
+    ) as string;
+    sdkconfigFilePath = sdkconfigFilePath.replace("${CMAKE_BINARY_DIR}", buildDirPath).replace(/"/g, "");
+  }
+  if (!sdkconfigFilePath) {
+    const modifiedEnv = appendIdfAndToolsToPath(workspacePath);
+    sdkconfigFilePath = modifiedEnv.SDKCONFIG;
+  }
+  if (!sdkconfigFilePath) {
+    sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig");
+  }
+  if (!sdkconfigFilePath) {
+    sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig.defaults");
+  }
+  return sdkconfigFilePath;
+}
+
 export function getConfigValueFromSDKConfig(
   key: string,
-  workspacePath: string,
-  sdkconfigFileName: string = "sdkconfig"
+  workspacePath: vscode.Uri
 ): string {
-  const sdkconfigFilePath = path.join(workspacePath, sdkconfigFileName);
+  const sdkconfigFilePath = getSDKConfigFilePath(workspacePath);
   if (!canAccessFile(sdkconfigFilePath, fs.constants.R_OK)) {
     throw new Error("sdkconfig file doesn't exists or can't be read");
   }
@@ -323,7 +358,7 @@ export function getConfigValueFromSDKConfig(
   return match ? match[1] : "";
 }
 
-export function getMonitorBaudRate(workspacePath: string) {
+export function getMonitorBaudRate(workspacePath: vscode.Uri) {
   let sdkMonitorBaudRate: string = "";
   try {
     sdkMonitorBaudRate = getConfigValueFromSDKConfig(
@@ -340,7 +375,7 @@ export function getMonitorBaudRate(workspacePath: string) {
 }
 
 export function delConfigFile(workspaceRoot: vscode.Uri) {
-  const sdkconfigFile = path.join(workspaceRoot.fsPath, "sdkconfig");
+  const sdkconfigFile = getSDKConfigFilePath(workspaceRoot);
   fs.unlinkSync(sdkconfigFile);
 }
 


### PR DESCRIPTION
## Description

Add support for multiple build configuration as done in [esp-idf cmake multi_config example](https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config).

Load sdkconfig path as follows:
1) From current workspace folder root directory `CMakeLists.txt` SDKCONFIG variable else
2) From `SDKCONFIG` environment variable (either system or extension defined in `idf.customExtraVars` setting) else
3) From current workspace folder root directory `sdkconfig` file.

Also add `idf.sdkconfigDefaults` to define the set of SDKCONFIG_DEFAULTS to use to initially create the sdkconfig.

Fix #855 

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Manual testing building and running SDK Configuration editor.

**Test Configuration**:
* ESP-IDF Version: 4.4. 5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
