### PR TITLE
fix WSL installation command for usbipd

### DIFF
--- a/docs/tutorial/using-docker-container.md
+++ b/docs/tutorial/using-docker-container.md
@@ -85,8 +85,8 @@ As the distribution Ubuntu 20.04 has been updated to version 2, so it needs to m
 From windows side this tool should be already configured. However `usbipd` still need to be installed on the WSL, that is, open the WSL from Windows menu and then type in the following the commands separately:
 
 ```c
-apt install linux-tools-5.4.0-77-generic hwdata
-update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
+sudo apt install linux-tools-virtual hwdata
+sudo update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
 ```
 
 If any errors are found, try updating apt-get packages first.


### PR DESCRIPTION
## Description

The previous command for installing usbipd on WSL had issues, as discussed in [Unable to locate package linux-tools-5.4.0-77-generic](https://github.com/microsoft/WSL/issues/7652). This commit updates the command to the latest one provided in the [official documentation](https://github.com/dorssel/usbipd-win/wiki/WSL-support#usbip-client-tools).

## Type of change
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-  Test per documentation steps 

**Test Configuration**:
* ESP-IDF Version: x
* OS (Windows,Linux and macOS): Windows 10

## Dependent components impacted by this PR:

- none

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
