### PR TITLE
fix linux-tools package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Make sure to review our [documentation](./docs/ONBOARDING.md) first to properly 
 # Tutorials
 
 1. [Install and setup the extension](./docs/tutorial/install.md).
-2. [Create a project from example, Build, flash and monitor](./docs/tutorial/new_project_wizard.md).
+2. [Create a project from ESP-IDF examples, Build, flash and monitor](./docs/tutorial/basic_use.md).
 3. [Debugging](./docs/tutorial/debugging.md) with steps to configure OpenOCD and debug adapter.
 4. [Heap tracing](./docs/tutorial/heap_tracing.md)
 5. [Code coverage](./docs/tutorial/code_coverage.md)

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -19,8 +19,8 @@ sudo apt-get install git wget flex bison gperf python3-pip python3-venv python3-
 To complete the `usbipd` installation, the user needs to run the following commands on WSL with sudo privileges:
 
 ```c
-apt install linux-tools-5.4.0-77-generic hwdata
-update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
+sudo apt install linux-tools-virtual hwdata
+sudo update-alternatives --install /usr/local/bin/usbip usbip 'ls /usr/lib/linux-tools/*/usbip | tail -n1' 20
 ```
 
 if errors occurred during the installation, run the following command as below:

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -20,7 +20,7 @@ To complete the `usbipd` installation, the user needs to run the following comma
 
 ```c
 sudo apt install linux-tools-virtual hwdata
-sudo update-alternatives --install /usr/local/bin/usbip usbip 'ls /usr/lib/linux-tools/*/usbip | tail -n1' 20
+sudo update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
 ```
 
 if errors occurred during the installation, run the following command as below:

--- a/docs/tutorial/wsl.md
+++ b/docs/tutorial/wsl.md
@@ -77,7 +77,7 @@ From windows side this tool should be already configured. However `usbipd` still
 
 ```c
 sudo apt install linux-tools-virtual hwdata
-sudo update-alternatives --install /usr/local/bin/usbip usbip 'ls /usr/lib/linux-tools/*/usbip | tail -n1' 20
+sudo update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
 ```
 
 If any errors are found, try updating apt-get packages first.

--- a/docs/tutorial/wsl.md
+++ b/docs/tutorial/wsl.md
@@ -76,8 +76,8 @@ sudo apt-get install git wget flex bison gperf python3-pip python3-venv python3-
 From windows side this tool should be already configured. However `usbipd` still need to be installed on the WSL, that is, open the WSL from Windows menu and then type in the following the commands separately:
 
 ```c
-apt install linux-tools-5.4.0-77-generic hwdata
-update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
+sudo apt install linux-tools-virtual hwdata
+sudo update-alternatives --install /usr/local/bin/usbip usbip 'ls /usr/lib/linux-tools/*/usbip | tail -n1' 20
 ```
 
 If any errors are found, try updating apt-get packages first.


### PR DESCRIPTION
## Description

Update the WSL docs to use `linux-tools-virtual` instead of `linux-tools-5.4.0-77-generic` according to `usbipd` documentation.

Fix #893 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Documentation update.

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
