### PR TITLE
fix kconfig server directory

### DIFF
--- a/src/kconfig/index.ts
+++ b/src/kconfig/index.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Friday, 7th May 2021 4:48:58 pm
  * Copyright 2021 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,10 +29,9 @@ export class KconfigLangClient {
   public static kconfigLangClient: LanguageClient;
 
   public static startKconfigLangServer(context: ExtensionContext) {
-    const serverModule =
-      __dirname.indexOf("out") > -1
-        ? context.asAbsolutePath(join("out", "kconfig", "server.js"))
-        : context.asAbsolutePath(join("dist", "kconfigServer.js"));
+    const serverModule = context.asAbsolutePath(
+      join("dist", "kconfigServer.js")
+    );
 
     const debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "outDir": "out",
+    "outDir": "dist",
     "lib": ["dom", "es6"],
     "sourceMap": true,
     "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "outDir": "dist",
+    "outDir": "out",
     "lib": ["dom", "es6"],
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
## Description

Fix reference to out directory in kconfig server which is not used anymore.

Fixes #885

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Test Config server works in directory containing `out` string.

**Test Configuration**:
* ESP-IDF Version: 4.4.3
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
