### PR TITLE
Select multiple IDF versions in setup wizard

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -35,7 +35,7 @@ Setup wizard provides 3 choices:
 
 - **Express install**: Fastest option.
   1.  Choose to either download selected ESP-IDF version or find ESP-IDF in your system.
-  2.  Download and install ESP-IDF Tools. This step will use the existing value in `idf.toolsPath` or `idf.toolsPathWin` as ESP-IDF Tools directory.
+  2.  Choose directory, Download and install ESP-IDF Tools. This step will use the existing value in `idf.toolsPath` or `idf.toolsPathWin` as ESP-IDF Tools directory.
   3.  Create python virtual environment with required packages on existing ESP-IDF Tools directory.
 - **Advanced install**: Configurable option.
   1.  Choose to either download selected ESP-IDF version or find ESP-IDF in your system.
@@ -43,12 +43,10 @@ Setup wizard provides 3 choices:
       - Choose directory for ESP-IDF Tools and install ESP-IDF Tools. This step will update the existing value in `idf.toolsPath` or `idf.toolsPathWin`.
       - Specify directory than contains executable for each required ESP-IDF tool with matching version.
   3.  Create python virtual environment with required packages in chosen ESP-IDF Tools directory.
-- **Use existing setup**: This option will use an existing setup if:
-  1. `esp-idf.json` is found in the current `idf.toolsPath` (MacOS/Linux users) or `idf.toolsPathWin` (Windows users). This file is generated when you install ESP-IDF with the [IDF Windows installer](https://github.com/espressif/idf-installer) or using [IDF-ENV](https://github.com/espressif/idf-env).
-  2. ESP-IDF is found in `idf.espIdfPath` or `idf.espIdfPathWin`, `IDF_PATH` environment variable, `$HOME/esp/esp-idf` on MacOS/Linux and `%USERPROFILE%\esp\esp-idf` or `%USERPROFILE%\Desktop\esp-idf` in Windows.
-  3. ESP-IDF Tools and ESP-IDF Python virtual environment for the previous ESP-IDF are found in `idf.toolsPath` or `idf.toolsPathWin`, `IDF_TOOLS_PATH` environment variable, `$HOME\.espressif` on MacOS/Linux and `%USERPROFILE%\.espressif` on Windows.
+- **Use existing setup**: This option will show previous setup used in the extension and existing setup if:
+  1. `esp-idf.json` is found in the current `idf.toolsPath` (MacOS/Linux users) or `idf.toolsPathWin` (Windows users). This file is generated when you install ESP-IDF with the [IDF Windows installer](https://github.com/espressif/idf-installer) or using [IDF-ENV](https://github.com/espressif/idf-env) or this extension.
 
-> **NOTE:** When running any of these choices, the setup wizard will install ESP-IDF Python packages, this extension (`EXTENSION_PATH`/requirements.txt and ESP-IDF debug adapter (`EXTENSION_PATH`/esp_debug_adapter/requirements.txt) python packages where `EXTENSION_PATH` is:
+> **NOTE:** When running any of these choices, the setup wizard will install ESP-IDF Python packages, this extension (`EXTENSION_PATH`/requirements.txt and ESP-IDF debug adapter (`EXTENSION_PATH`/esp_debug_adapter/requirements.txt) python packages where `EXTENSION_PATH` is located in:
 
 - Windows: `%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION`
 - Linux & MacOSX: `$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION`

--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -1,0 +1,55 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Friday, 24th February 2023 9:22:15 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExtensionContext } from "vscode";
+import { ESP } from "../config";
+
+export class ExtensionConfigStore {
+  private static self: ExtensionConfigStore;
+  private ctx: ExtensionContext;
+
+  public static init(context: ExtensionContext): ExtensionConfigStore {
+    if (!this.self) {
+      return new ExtensionConfigStore(context);
+    }
+    return this.self;
+  }
+  private constructor(context: ExtensionContext) {
+    this.ctx = context;
+  }
+  public get<T>(key: string, defaultValue?: T): T {
+    return this.ctx.globalState.get<T>(key, defaultValue);
+  }
+  public set(key: string, value: any) {
+    this.ctx.globalState.update(key, value);
+  }
+  public clear(key: string) {
+    return this.set(key, undefined);
+  }
+
+  public getIdfSetupKeys() {
+    return this.ctx.globalState.get<string[]>(
+      ESP.GlobalConfiguration.IDF_SETUPS,
+      []
+    );
+  }
+
+  public updateIdfSetupKeys(setupKeys: string[]) {
+    this.ctx.globalState.update(ESP.GlobalConfiguration.IDF_SETUPS, setupKeys);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { ExtensionConfigStore } from "./common/store";
 import { IEspIdfDocVersion } from "./espIdf/documentation/getDocsVersion";
 import { RainmakerStore } from "./rainmaker/store";
 
@@ -29,6 +30,11 @@ export namespace ESP {
     JTAG = "JTAG",
     UART = "UART",
     DFU = "DFU",
+  }
+
+  export namespace GlobalConfiguration {
+    export let store: ExtensionConfigStore;
+    export const IDF_SETUPS = "IDF_SETUPS";
   }
 
   export const platformDepConfigurations: string[] = [

--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -207,7 +207,6 @@ export class EspMatterCloning extends AbstractCloning {
 
 export async function installPythonReqs(
   espMatterPath: string,
-  gitPath: string,
   workspace?: Uri
 ) {
   const espIdfPath = readParameter("idf.espIdfPath", workspace)
@@ -239,7 +238,6 @@ export async function installPythonReqs(
         toolsPath,
         espMatterPath,
         pyPath,
-        gitPath,
         undefined,
         OutputChannel.init(),
         cancelToken
@@ -250,7 +248,7 @@ export async function installPythonReqs(
 
 export async function getEspMatter(workspace?: Uri) {
   const gitPath = (await readParameter("idf.gitPath", workspace)) || "/usr/bin/git";
-  var espMatterPath;
+  let espMatterPath;
   const espMatterInstaller = new EspMatterCloning(gitPath, workspace);
   const installAllSubmodules = await window.showQuickPick(
       [
@@ -294,7 +292,7 @@ export async function getEspMatter(workspace?: Uri) {
   }
 
   try {
-    await installPythonReqs(espMatterPath, gitPath, workspace);
+    await installPythonReqs(espMatterPath, workspace);
   } catch (error) {
     const msg = error.message
       ? error.message

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,7 @@ import { ChangelogViewer } from "./changelog-viewer";
 import { getSetupInitialValues, ISetupInitArgs } from "./setup/setupInit";
 import {
   installEspMatterPyReqs,
-  installPythonEnvFromIdfTools,
+  installExtensionPyReqs,
 } from "./pythonManager";
 import { checkExtensionSettings } from "./checkExtensionSettings";
 import { CmakeListsEditorPanel } from "./cmake/cmakeEditorPanel";
@@ -125,6 +125,7 @@ import { getEspMatter } from "./espMatter/espMatterDownload";
 import { setIdfTarget } from "./espIdf/setTarget";
 import { PeripheralTreeView } from "./espIdf/debugAdapter/peripheralTreeView";
 import { PeripheralBaseNode } from "./espIdf/debugAdapter/nodes/base";
+import { ExtensionConfigStore } from "./common/store";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -246,6 +247,8 @@ export async function activate(context: vscode.ExtensionContext) {
   };
   // init rainmaker cache store
   ESP.Rainmaker.store = RainmakerStore.init(context);
+
+  ESP.GlobalConfiguration.store = ExtensionConfigStore.init(context);
 
   // Create a status bar item with current workspace
 
@@ -1252,9 +1255,6 @@ export async function activate(context: vscode.ExtensionContext) {
               "idf.espIdfPath",
               workspaceRoot
             ) as string;
-            const gitPath =
-              (idfConf.readParameter("idf.gitPath", workspaceRoot) as string) ||
-              "git";
             const containerPath =
               process.platform === "win32"
                 ? process.env.USERPROFILE
@@ -1272,16 +1272,14 @@ export async function activate(context: vscode.ExtensionContext) {
               workspaceRoot
             ) as string;
             progress.report({
-              message: `Installing ESP-IDF Python Requirements...`,
+              message: `Installing ESP-IDF extension Python Requirements...`,
             });
-            await installPythonEnvFromIdfTools(
+            await installExtensionPyReqs(
+              pyPath,
               espIdfPath,
               toolsPath,
               undefined,
-              pyPath,
-              gitPath,
-              OutputChannel.init(),
-              cancelToken
+              OutputChannel.init()
             );
             vscode.window.showInformationMessage(
               "ESP-IDF Python Requirements has been installed"
@@ -1316,9 +1314,6 @@ export async function activate(context: vscode.ExtensionContext) {
               "idf.espIdfPath",
               workspaceRoot
             ) as string;
-            const gitPath =
-              (idfConf.readParameter("idf.gitPath", workspaceRoot) as string) ||
-              "git";
             const containerPath =
               process.platform === "win32"
                 ? process.env.USERPROFILE
@@ -1347,7 +1342,6 @@ export async function activate(context: vscode.ExtensionContext) {
               toolsPath,
               espMatterPath,
               pyPath,
-              gitPath,
               undefined,
               OutputChannel.init(),
               cancelToken

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -39,9 +39,9 @@ export interface IEspIdfTool {
 }
 
 export class IdfToolsManager {
-  public static async createIdfToolsManager(idfPath: string, gitPath: string) {
+  public static async createIdfToolsManager(idfPath: string) {
     const platformInfo = await PlatformInformation.GetPlatformInformation();
-    const toolsJsonPath = await utils.getToolsJsonPath(idfPath, gitPath);
+    const toolsJsonPath = await utils.getToolsJsonPath(idfPath);
     const toolsObj = await readJSON(toolsJsonPath);
     const idfToolsManager = new IdfToolsManager(
       toolsObj,
@@ -318,8 +318,9 @@ export class IdfToolsManager {
         );
       });
       const expectedVersions = pkgVersionsForPlatform.map((p) => p.name);
-      const isToolVersionCorrect =
-        expectedVersions.indexOf(versions[pkg.name]) > -1;
+      let isToolVersionCorrect =
+        expectedVersions.indexOf(versions[pkg.name]) > -1 ||
+        versions[pkg.name] === "No command version";
       const versionToUse = this.getVersionToUse(pkg);
       let pkgExportedPath: string = "";
       let pkgVars = pkg.export_vars;

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -82,12 +82,7 @@ export async function installPythonEnvFromIdfTools(
     modifiedEnv.PYTHONNOUSERSITE = "1";
   }
 
-  const pyEnvPath = await getPythonEnvPath(
-    espDir,
-    idfToolsDir,
-    pythonBinPath,
-    gitPath
-  );
+  const pyEnvPath = await getPythonEnvPath(espDir, idfToolsDir, pythonBinPath);
 
   await execProcessWithLog(
     `"${pythonBinPath}" -m pip install --user virtualenv`,
@@ -125,7 +120,6 @@ export async function installPythonEnvFromIdfTools(
     virtualEnvPython,
     espDir,
     idfToolsDir,
-    gitPath,
     pyTracker,
     channel,
     { env: modifiedEnv },
@@ -138,7 +132,6 @@ export async function installExtensionPyReqs(
   virtualEnvPython: string,
   espDir: string,
   idfToolsDir: string,
-  gitPath: string,
   pyTracker?: PyReqLog,
   channel?: OutputChannel,
   opts?: { env: NodeJS.ProcessEnv; cwd?: string },
@@ -176,7 +169,7 @@ export async function installExtensionPyReqs(
   if (channel) {
     channel.appendLine(installExtensionPyPkgsMsg + "\n");
   }
-  const espIdfVersion = await utils.getEspIdfVersion(espDir, gitPath);
+  const espIdfVersion = await utils.getEspIdfFromCMake(espDir);
   const constrainsFile = path.join(
     idfToolsDir,
     `espidf.constraints.v${espIdfVersion}.txt`
@@ -228,7 +221,6 @@ export async function installEspMatterPyReqs(
   idfToolsDir: string,
   espMatterDir: string,
   pythonBinPath: string,
-  gitPath: string,
   pyTracker?: PyReqLog,
   channel?: OutputChannel,
   cancelToken?: CancellationToken
@@ -237,12 +229,7 @@ export async function installEspMatterPyReqs(
     Object.assign({}, process.env)
   );
   const opts = { env: modifiedEnv };
-  const pyEnvPath = await getPythonEnvPath(
-    espDir,
-    idfToolsDir,
-    pythonBinPath,
-    gitPath
-  );
+  const pyEnvPath = await getPythonEnvPath(espDir, idfToolsDir, pythonBinPath);
   const pyDir =
     process.platform === "win32"
       ? ["Scripts", "python.exe"]
@@ -303,8 +290,7 @@ export async function execProcessWithLog(
 export async function getPythonEnvPath(
   espIdfDir: string,
   idfToolsDir: string,
-  pythonBin: string,
-  gitPath: string
+  pythonBin: string
 ) {
   const pythonVersion = (
     await utils.execChildProcess(
@@ -312,7 +298,7 @@ export async function getPythonEnvPath(
       espIdfDir
     )
   ).replace(/(\n|\r|\r\n)/gm, "");
-  const fullEspIdfVersion = await utils.getEspIdfVersion(espIdfDir, gitPath);
+  const fullEspIdfVersion = await utils.getEspIdfFromCMake(espIdfDir);
   const majorMinorMatches = fullEspIdfVersion.match(/([0-9]+\.[0-9]+).*/);
   const espIdfVersion =
     majorMinorMatches && majorMinorMatches.length > 0

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -241,6 +241,46 @@ export class SetupPanel {
             );
           }
           break;
+        case "useIdfSetup":
+          if (message.selectedIdfSetup) {
+            this.panel.webview.postMessage({
+              command: "updateIdfGitStatus",
+              status: StatusType.installed,
+            });
+            this.panel.webview.postMessage({
+              command: "updateIdfPythonStatus",
+              status: StatusType.installed,
+            });
+            this.panel.webview.postMessage({
+              command: "updateEspIdfStatus",
+              status: StatusType.installed,
+            });
+            this.panel.webview.postMessage({
+              command: "updateEspIdfToolsStatus",
+              status: StatusType.installed,
+            });
+            this.panel.webview.postMessage({
+              command: "updatePyVEnvStatus",
+              status: StatusType.started,
+            });
+            this.panel.webview.postMessage({
+              command: "goToCustomPage",
+              installing: true,
+              page: "/status",
+            });
+            await installExtensionPyReqs(
+             
+            );
+            await saveSettings(
+              
+            );
+            this.panel.webview.postMessage({
+              command: "setIsInstalled",
+              isInstalled: true,
+            });
+            await this.getOpenOcdRulesPath();
+          }
+          break;
         case "usePreviousSettings":
           if (
             setupArgs.espIdfPath &&

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -245,7 +245,10 @@ export class SetupPanel {
           }
           break;
         case "useIdfSetup":
-          if (message.selectedIdfSetup && message.saveScope) {
+          if (
+            typeof message.selectedIdfSetup !== undefined &&
+            message.saveScope
+          ) {
             this.panel.webview.postMessage({
               command: "updateIdfGitStatus",
               status: StatusType.installed,

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { LocDictionary } from "../localizationDictionary";
-import { ISetupInitArgs, saveSettings } from "./setupInit";
+import { ISetupInitArgs } from "./setupInit";
 import {
   IdfMirror,
   IEspIdfLink,
@@ -24,10 +24,9 @@ import {
 import * as idfConf from "../idfConfiguration";
 import { ensureDir } from "fs-extra";
 import path from "path";
-import vscode, { Uri } from "vscode";
+import vscode, { ConfigurationTarget, Uri } from "vscode";
 import { expressInstall } from "./espIdfDownloadStep";
 import { IdfToolsManager } from "../idfToolsManager";
-import { installExtensionPyReqs } from "./installPyReqs";
 import { OutputChannel } from "../logger/outputChannel";
 import { Logger } from "../logger/logger";
 import { createPyReqs } from "./pyReqsInstallStep";
@@ -35,6 +34,7 @@ import { downloadIdfTools } from "./toolsDownloadStep";
 import { installIdfGit, installIdfPython } from "./embedGitPy";
 import { getOpenOcdRules } from "./addOpenOcdRules";
 import { checkSpacesInPath } from "../utils";
+import { useIdfSetupSettings } from "./setupValidation/espIdfSetup";
 
 const locDic = new LocDictionary("SetupPanel");
 
@@ -119,7 +119,6 @@ export class SetupPanel {
             await this.checkRequiredTools(
               message.espIdf,
               message.toolsPath,
-              setupArgs.gitPath,
               setupArgs.onReqPkgs
             );
           }
@@ -129,6 +128,7 @@ export class SetupPanel {
             message.espIdfContainer &&
             message.selectedEspIdfVersion &&
             message.toolsPath &&
+            message.saveScope &&
             typeof message.selectedPyPath !== undefined &&
             typeof message.manualEspIdfPath !== undefined &&
             typeof message.mirror !== undefined &&
@@ -148,6 +148,7 @@ export class SetupPanel {
               message.manualEspIdfPath,
               message.espIdfContainer,
               message.mirror,
+              message.saveScope,
               message.setupMode,
               setupArgs.onReqPkgs
             );
@@ -158,6 +159,7 @@ export class SetupPanel {
             message.espIdf &&
             message.pyPath &&
             message.toolsPath &&
+            message.saveScope &&
             typeof message.mirror !== undefined
           ) {
             await this.installEspIdfTools(
@@ -166,6 +168,7 @@ export class SetupPanel {
               message.toolsPath,
               setupArgs.gitPath,
               message.mirror,
+              message.saveScope,
               setupArgs.onReqPkgs
             );
           }
@@ -207,14 +210,12 @@ export class SetupPanel {
             espToolsPath: setupArgs.espToolsPath,
             gitVersion: setupArgs.gitVersion,
             hasPrerequisites: setupArgs.hasPrerequisites,
-            idfVersion: setupArgs.espIdfVersion,
             idfVersions: setupArgs.espIdfVersionsList,
             idfTags: setupArgs.espIdfTagsList,
+            idfSetups: setupArgs.existingIdfSetups,
             pathSep,
             platform: process.platform,
-            pyBinPath: setupArgs.pyBinPath,
             pyVersionList: setupArgs.pythonVersions,
-            toolsResults: setupArgs.toolsResults,
           });
           break;
         case "saveCustomSettings":
@@ -222,7 +223,8 @@ export class SetupPanel {
             message.espIdfPath &&
             message.toolsPath &&
             message.pyBinPath &&
-            message.tools
+            message.tools &&
+            message.saveScope
           ) {
             const { exportedPaths, exportedVars } = this.getCustomSetupSettings(
               message.tools
@@ -237,12 +239,13 @@ export class SetupPanel {
               message.pyBinPath,
               exportedPaths,
               exportedVars,
-              setupArgs.gitPath
+              setupArgs.gitPath,
+              message.saveScope
             );
           }
           break;
         case "useIdfSetup":
-          if (message.selectedIdfSetup) {
+          if (message.selectedIdfSetup && message.saveScope) {
             this.panel.webview.postMessage({
               command: "updateIdfGitStatus",
               status: StatusType.installed,
@@ -254,6 +257,12 @@ export class SetupPanel {
             this.panel.webview.postMessage({
               command: "updateEspIdfStatus",
               status: StatusType.installed,
+            });
+            SetupPanel.postMessage({
+              command: "setEspIdfErrorStatus",
+              errorMsg: `ESP-IDF is installed in ${
+                setupArgs.existingIdfSetups[message.selectedIdfSetup].idfPath
+              }`,
             });
             this.panel.webview.postMessage({
               command: "updateEspIdfToolsStatus",
@@ -268,65 +277,9 @@ export class SetupPanel {
               installing: true,
               page: "/status",
             });
-            await installExtensionPyReqs(
-             
-            );
-            await saveSettings(
-              
-            );
-            this.panel.webview.postMessage({
-              command: "setIsInstalled",
-              isInstalled: true,
-            });
-            await this.getOpenOcdRulesPath();
-          }
-          break;
-        case "usePreviousSettings":
-          if (
-            setupArgs.espIdfPath &&
-            setupArgs.pyBinPath &&
-            setupArgs.exportedPaths &&
-            setupArgs.exportedVars &&
-            setupArgs.espToolsPath
-          ) {
-            this.panel.webview.postMessage({
-              command: "updateIdfGitStatus",
-              status: StatusType.installed,
-            });
-            this.panel.webview.postMessage({
-              command: "updateIdfPythonStatus",
-              status: StatusType.installed,
-            });
-            this.panel.webview.postMessage({
-              command: "updateEspIdfStatus",
-              status: StatusType.installed,
-            });
-            this.panel.webview.postMessage({
-              command: "updateEspIdfToolsStatus",
-              status: StatusType.installed,
-            });
-            this.panel.webview.postMessage({
-              command: "updatePyVEnvStatus",
-              status: StatusType.started,
-            });
-            this.panel.webview.postMessage({
-              command: "goToCustomPage",
-              installing: true,
-              page: "/status",
-            });
-            await installExtensionPyReqs(
-              setupArgs.espToolsPath,
-              setupArgs.pyBinPath,
-              setupArgs.espIdfPath,
-              setupArgs.gitPath
-            );
-            await saveSettings(
-              setupArgs.espIdfPath,
-              setupArgs.pyBinPath,
-              setupArgs.exportedPaths,
-              setupArgs.exportedVars,
-              setupArgs.espToolsPath,
-              setupArgs.gitPath
+            await useIdfSetupSettings(
+              setupArgs.existingIdfSetups[message.selectedIdfSetup],
+              message.saveScope
             );
             this.panel.webview.postMessage({
               command: "setIsInstalled",
@@ -386,6 +339,7 @@ export class SetupPanel {
     espIdfPath: string,
     idfContainerPath: string,
     mirror: IdfMirror,
+    saveScope: vscode.ConfigurationTarget,
     setupMode: SetupMode,
     onReqPkgs?: string[]
   ) {
@@ -429,6 +383,7 @@ export class SetupPanel {
             idfContainerPath,
             toolsPath,
             mirror,
+            saveScope,
             setupMode,
             idfGitPath,
             progress,
@@ -445,13 +400,9 @@ export class SetupPanel {
   private async checkRequiredTools(
     idfPath: string,
     toolsInfo: IEspIdfTool[],
-    gitPath: string,
     onReqPkgs?: string[]
   ) {
-    const toolsManager = await IdfToolsManager.createIdfToolsManager(
-      idfPath,
-      gitPath
-    );
+    const toolsManager = await IdfToolsManager.createIdfToolsManager(idfPath);
     const pathToVerify = toolsInfo
       .reduce((prev, curr, i) => {
         return prev + path.delimiter + curr.path;
@@ -504,6 +455,7 @@ export class SetupPanel {
     toolsPath: string,
     gitPath: string,
     mirror: IdfMirror,
+    saveScope: vscode.ConfigurationTarget,
     onReqPkgs?: string[]
   ) {
     return await vscode.window.withProgress(
@@ -545,6 +497,7 @@ export class SetupPanel {
             pyPath,
             gitPath,
             mirror,
+            saveScope,
             progress,
             cancelToken,
             onReqPkgs
@@ -562,7 +515,8 @@ export class SetupPanel {
     pyPath: string,
     exportPaths: string,
     exportVars: { [key: string]: string },
-    gitPath: string
+    gitPath: string,
+    saveScope: ConfigurationTarget
   ) {
     return await vscode.window.withProgress(
       {
@@ -587,6 +541,7 @@ export class SetupPanel {
             exportPaths,
             exportVars,
             gitPath,
+            saveScope,
             progress,
             cancelToken
           );

--- a/src/setup/existingIdfSetups.ts
+++ b/src/setup/existingIdfSetups.ts
@@ -39,16 +39,18 @@ export function getPreviousIdfSetups() {
 export async function createIdfSetup(
   idfPath: string,
   toolsPath: string,
-  pythonPath: string
+  pythonPath: string,
+  gitPath: string
 ) {
   const idfSetupId = getIdfMd5sum(idfPath);
   const idfVersion = await getEspIdfFromCMake(idfPath);
   const newIdfSetup: IdfSetup = {
     id: idfSetupId,
-    version: idfVersion,
-    path: idfPath,
+    idfPath,
+    gitPath,
     toolsPath,
     python: pythonPath,
+    version: idfVersion,
   };
   addIdfSetup(newIdfSetup);
 }
@@ -73,7 +75,8 @@ export async function loadIdfSetupsFromEspIdfJson(toolsPath: string) {
     for (let idfInstalledKey of Object.keys(espIdfJson.idfInstalled)) {
       idfSetups.push({
         id: idfInstalledKey,
-        path: espIdfJson.idfInstalled[idfInstalledKey].path,
+        idfPath: espIdfJson.idfInstalled[idfInstalledKey].path,
+        gitPath: espIdfJson.gitPath,
         python: espIdfJson.idfInstalled[idfInstalledKey].python,
         version: espIdfJson.idfInstalled[idfInstalledKey].version,
         toolsPath: toolsPath,

--- a/src/setup/existingIdfSetups.ts
+++ b/src/setup/existingIdfSetups.ts
@@ -1,0 +1,84 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Friday, 24th February 2023 10:30:49 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESP } from "../config";
+import { getEspIdfFromCMake } from "../utils";
+import { IdfSetup } from "../views/setup/types";
+import { getIdfMd5sum, loadEspIdfJson } from "./espIdfJson";
+
+export function getPreviousIdfSetups() {
+  const setupKeys = ESP.GlobalConfiguration.store.getIdfSetupKeys();
+  const idfSetups: IdfSetup[] = [];
+  for (let idfSetupKey of setupKeys) {
+    let idfSetup = ESP.GlobalConfiguration.store.get<IdfSetup>(
+      idfSetupKey,
+      undefined
+    );
+    if (idfSetup) {
+      idfSetups.push(idfSetup);
+    }
+  }
+  return idfSetups;
+}
+
+export async function createIdfSetup(
+  idfPath: string,
+  toolsPath: string,
+  pythonPath: string
+) {
+  const idfSetupId = getIdfMd5sum(idfPath);
+  const idfVersion = await getEspIdfFromCMake(idfPath);
+  const newIdfSetup: IdfSetup = {
+    id: idfSetupId,
+    version: idfVersion,
+    path: idfPath,
+    toolsPath,
+    python: pythonPath,
+  };
+  addIdfSetup(newIdfSetup);
+}
+
+export function addIdfSetup(newIdfSetup: IdfSetup) {
+  const setupKeys = ESP.GlobalConfiguration.store.getIdfSetupKeys();
+  if (setupKeys.indexOf(newIdfSetup.id) === -1) {
+    setupKeys.push(newIdfSetup.id);
+    ESP.GlobalConfiguration.store.updateIdfSetupKeys(setupKeys);
+  }
+  ESP.GlobalConfiguration.store.set(newIdfSetup.id, newIdfSetup);
+}
+
+export async function loadIdfSetupsFromEspIdfJson(toolsPath: string) {
+  const espIdfJson = await loadEspIdfJson(toolsPath);
+  if (
+    espIdfJson &&
+    espIdfJson.idfInstalled &&
+    Object.keys(espIdfJson.idfInstalled).length
+  ) {
+    let idfSetups: IdfSetup[] = [];
+    for (let idfInstalledKey of Object.keys(espIdfJson.idfInstalled)) {
+      idfSetups.push({
+        id: idfInstalledKey,
+        path: espIdfJson.idfInstalled[idfInstalledKey].path,
+        python: espIdfJson.idfInstalled[idfInstalledKey].python,
+        version: espIdfJson.idfInstalled[idfInstalledKey].version,
+        toolsPath: toolsPath,
+      });
+    }
+    return idfSetups;
+  }
+}

--- a/src/setup/installPyReqs.ts
+++ b/src/setup/installPyReqs.ts
@@ -55,9 +55,13 @@ export async function installPyReqs(
     Logger.info(msg);
     return;
   }
-  const isNotVirtualEnv = await pythonManager.checkIfNotVirtualEnv(sysPyBinPath, workingDir);
+  const isNotVirtualEnv = await pythonManager.checkIfNotVirtualEnv(
+    sysPyBinPath,
+    workingDir
+  );
   if (!isNotVirtualEnv) {
-    const msg = "Selected python is from a virtual environment. Choose system python";
+    const msg =
+      "Selected python is from a virtual environment. Choose system python";
     sendPyReqLog(msg);
     OutputChannel.appendLine(msg);
     Logger.info(msg);
@@ -97,15 +101,13 @@ export async function installPyReqs(
 export async function installExtensionPyReqs(
   idfToolsDir: string,
   pythonBinPath: string,
-  espIdfPath: string,
-  gitPath: string
+  espIdfPath: string
 ) {
   const logTracker = new PyReqLog(sendPyReqLog);
   await pythonManager.installExtensionPyReqs(
     pythonBinPath,
     espIdfPath,
     idfToolsDir,
-    gitPath,
     logTracker,
     OutputChannel.init()
   );

--- a/src/setup/pyReqsInstallStep.ts
+++ b/src/setup/pyReqsInstallStep.ts
@@ -28,6 +28,7 @@ export async function createPyReqs(
   exportPaths: string,
   exportVars: { [key: string]: string },
   gitPath: string,
+  saveScope: vscode.ConfigurationTarget,
   progress: vscode.Progress<{ message: string; increment?: number }>,
   cancelToken: vscode.CancellationToken
 ) {
@@ -49,7 +50,8 @@ export async function createPyReqs(
     exportPaths,
     exportVars,
     toolsPath,
-    gitPath
+    gitPath,
+    saveScope
   );
   let idfPathVersion = await getEspIdfVersion(idfPath, gitPath);
   await addIdfPath(idfPath, virtualEnvPath, idfPathVersion, toolsPath, gitPath);

--- a/src/setup/setupValidation/espIdfSetup.ts
+++ b/src/setup/setupValidation/espIdfSetup.ts
@@ -1,0 +1,98 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 27th February 2023 3:00:15 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path";
+import { IdfSetup } from "../../views/setup/types";
+import { IdfToolsManager } from "../../idfToolsManager";
+import { saveSettings } from "../setupInit";
+import { pathExists } from "fs-extra";
+import { Logger } from "../../logger/logger";
+import { installExtensionPyReqs } from "../installPyReqs";
+import { checkPyVenv } from "./pythonEnv";
+import { ConfigurationTarget } from "vscode";
+
+export async function useIdfSetupSettings(
+  setupConf: IdfSetup,
+  saveScope: ConfigurationTarget
+) {
+  const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
+    setupConf.idfPath
+  );
+
+  const exportedToolsPaths = await idfToolsManager.exportPathsInString(
+    join(setupConf.toolsPath, "tools"),
+    ["cmake", "ninja"]
+  );
+  const exportedVars = await idfToolsManager.exportVars(
+    join(setupConf.toolsPath, "tools")
+  );
+  await installExtensionPyReqs(
+    setupConf.toolsPath,
+    setupConf.python,
+    setupConf.idfPath
+  );
+  await saveSettings(
+    setupConf.idfPath,
+    setupConf.python,
+    exportedToolsPaths,
+    exportedVars,
+    setupConf.toolsPath,
+    setupConf.gitPath,
+    saveScope
+  );
+}
+
+export async function checkIdfSetup(setupConf: IdfSetup) {
+  try {
+    const doesIdfPathExists = await pathExists(setupConf.idfPath);
+    if (!doesIdfPathExists) {
+      return false;
+    }
+    const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
+      setupConf.idfPath
+    );
+    const exportedToolsPaths = await idfToolsManager.exportPathsInString(
+      join(setupConf.toolsPath, "tools"),
+      ["cmake", "ninja"]
+    );
+    const toolsInfo = await idfToolsManager.getRequiredToolsInfo(
+      join(setupConf.toolsPath, "tools"),
+      exportedToolsPaths,
+      ["cmake", "ninja"]
+    );
+
+    const failedToolsResult = toolsInfo.filter(
+      (tInfo) =>
+        !tInfo.doesToolExist && ["cmake", "ninja"].indexOf(tInfo.name) === -1
+    );
+
+    if (failedToolsResult.length) {
+      return false;
+    }
+
+    const pyEnvReqs = checkPyVenv(setupConf.python, setupConf.idfPath);
+    return pyEnvReqs;
+  } catch (error) {
+    const msg =
+      error && error.message
+        ? error.message
+        : `Error checking Idf Setup ${setupConf.idfPath}`;
+    Logger.error(msg, error);
+    return false;
+  }
+}

--- a/src/setup/setupValidation/pythonEnv.ts
+++ b/src/setup/setupValidation/pythonEnv.ts
@@ -1,0 +1,52 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 27th February 2023 7:13:29 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { pathExists } from "fs-extra";
+import { join } from "path";
+import { startPythonReqsProcess } from "../../utils";
+
+export async function checkPyVenv(pyVenvPath: string, espIdfPath: string) {
+  const pyExists = await pathExists(pyVenvPath);
+  if (!pyExists) {
+    return false;
+  }
+  let requirements: string;
+  requirements = join(
+    espIdfPath,
+    "tools",
+    "requirements",
+    "requirements.core.txt"
+  );
+  const coreRequirementsExists = await pathExists(requirements);
+  if (!coreRequirementsExists) {
+    requirements = join(espIdfPath, "requirements.txt");
+    const requirementsExists = await pathExists(requirements);
+    if (!requirementsExists) {
+      return false;
+    }
+  }
+  const reqsResults = await startPythonReqsProcess(
+    pyVenvPath,
+    espIdfPath,
+    requirements
+  );
+  if (reqsResults.indexOf("are not satisfied") > -1) {
+    return false;
+  }
+  return true;
+}

--- a/src/setup/toolsDownloadStep.ts
+++ b/src/setup/toolsDownloadStep.ts
@@ -26,14 +26,12 @@ export async function downloadIdfTools(
   pyPath: string,
   gitPath: string,
   mirror: IdfMirror,
+  saveScope: vscode.ConfigurationTarget,
   progress?: vscode.Progress<{ message: string; increment?: number }>,
   cancelToken?: vscode.CancellationToken,
   onReqPkgs?: string[]
 ) {
-  const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
-    idfPath,
-    gitPath
-  );
+  const idfToolsManager = await IdfToolsManager.createIdfToolsManager(idfPath);
   const exportPaths = await idfToolsManager.exportPathsInString(
     path.join(toolsPath, "tools"),
     onReqPkgs
@@ -51,7 +49,15 @@ export async function downloadIdfTools(
     command: "setRequiredToolsInfo",
     toolsInfo: requiredTools,
   });
-  await downloadEspIdfTools(toolsPath, idfToolsManager, mirror, progress, pyPath, cancelToken, onReqPkgs);
+  await downloadEspIdfTools(
+    toolsPath,
+    idfToolsManager,
+    mirror,
+    progress,
+    pyPath,
+    cancelToken,
+    onReqPkgs
+  );
   SetupPanel.postMessage({
     command: "updateEspIdfToolsStatus",
     status: StatusType.installed,
@@ -63,6 +69,7 @@ export async function downloadIdfTools(
     exportPaths,
     exportVars,
     gitPath,
+    saveScope,
     progress,
     cancelToken
   );

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -46,9 +46,9 @@ export async function writeTextReport(
   output += `ESP-Matter Path (idf.espMatterPath) ${reportedResult.configurationSettings.espMatterPath}${EOL}`;
   output += `Custom extra paths (idf.customExtraPaths) ${reportedResult.configurationSettings.customExtraPaths}${EOL}`;
   if (reportedResult.configurationSettings.customExtraVars && Object.keys(reportedResult.configurationSettings.customExtraVars)) {
-    output += `Custom extra vars (idf.customExtraVars) ${reportedResult.configurationSettings.customExtraVars}${EOL}`;
+    output += `Custom extra vars (idf.customExtraVars)${EOL}`;
     for (let key in reportedResult.configurationSettings.customExtraVars) {
-      output += `${key}: ${reportedResult.configurationSettings.customExtraVars[key]}${EOL}`;
+      output += `    ${key}: ${reportedResult.configurationSettings.customExtraVars[key]}${EOL}`;
     }
   }
   output += `Virtual env Python Path (idf.pythonBinPath) ${reportedResult.configurationSettings.pythonBinPath}${EOL}`;

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -308,9 +308,9 @@ suite("Doctor command tests", () => {
     expectedOutput += `ESP-Matter Path (idf.espMatterPath) ${reportObj.configurationSettings.espMatterPath}${os.EOL}`;
     expectedOutput += `Custom extra paths (idf.customExtraPaths) ${customExtraPaths}${os.EOL}`;
     if (reportObj.configurationSettings.customExtraVars && Object.keys(reportObj.configurationSettings.customExtraVars)) {
-      expectedOutput += `Custom extra vars (idf.customExtraVars) ${reportObj.configurationSettings.customExtraVars}${os.EOL}`;
+      expectedOutput += `Custom extra vars (idf.customExtraVars)${os.EOL}`;
       for (let key in reportObj.configurationSettings.customExtraVars) {
-        expectedOutput += `${key}: ${reportObj.configurationSettings.customExtraVars[key]}${os.EOL}`;
+        expectedOutput += `    ${key}: ${reportObj.configurationSettings.customExtraVars[key]}${os.EOL}`;
       }
     }
     expectedOutput += `Virtual env Python Path (idf.pythonBinPath) ${

--- a/src/ui-test/configure-test.ts
+++ b/src/ui-test/configure-test.ts
@@ -32,7 +32,7 @@ describe("Configure extension", () => {
   before(async function () {
     this.timeout(100000);
     await new Promise((res) => setTimeout(res, 2000));
-    const notifications  = await new Workbench().getNotifications();
+    const notifications = await new Workbench().getNotifications();
     for (let n of notifications) {
       await n.dismiss();
     }
@@ -270,15 +270,16 @@ describe("Configure extension", () => {
     await existingSetupElement.click();
     await new Promise((res) => setTimeout(res, 1000));
     // Status windows is loaded
-    const espIdfInstalledPath = await view.findWebElement(
-      By.xpath(`.//span[@data-config-id='download-status-installed']`)
-    );
-    const espIdfDestPathMsg = await espIdfInstalledPath.getText();
     const expectedDir = process.env.IDF_PATH
       ? process.env.IDF_PATH
       : join(process.env.HOME, "esp", "esp-idf");
-    const expectedEspIdfDestPath = `Installed in ${expectedDir}`;
-    expect(espIdfDestPathMsg).to.be.equal(expectedEspIdfDestPath);
+    const espIdfInstalledPath = await view.findWebElement(
+      By.xpath(`.//div[@data-config-id='${expectedDir}']`)
+    );
+    const espIdfDestPathMsg = await espIdfInstalledPath.getText();
+    expect(espIdfDestPathMsg).to.include(expectedDir);
+
+    await espIdfInstalledPath.click();
 
     await new Promise((res) => setTimeout(res, 60000));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -509,8 +509,8 @@ export function execChildProcess(
   });
 }
 
-export async function getToolsJsonPath(newIdfPath: string, gitPath: string) {
-  const espIdfVersion = await getEspIdfVersion(newIdfPath, gitPath);
+export async function getToolsJsonPath(newIdfPath: string) {
+  const espIdfVersion = await getEspIdfFromCMake(newIdfPath);
   let jsonToUse: string = path.join(newIdfPath, "tools", "tools.json");
   await pathExists(jsonToUse).then((exists) => {
     if (!exists) {

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="existing-setup">
+    <div
+      class="notification install-choice"
+      v-for="prevSetup in idfSetups"
+      :key="prevSetup.id"
+      @click.once="useIdfSetup(prevSetup.id)"
+    >
+      <label
+        :for="prevSetup.id"
+        class="subtitle"
+        :data-config-id="prevSetup.id"
+      >
+        {{ prevSetup.id }}</label
+      >
+      <p>IDF Version {{ prevSetup.version }}</p>
+      <p>Python: {{ prevSetup.python }}</p>
+      <p>IDF Tools Path: {{ prevSetup.toolsPath }}</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { Action, State } from "vuex-class";
+import { IdfSetup } from "./types";
+
+@Component
+export default class existingSetup extends Vue {
+  @State("existingIdfSetups") private storeIdfSetups: IdfSetup[];
+  @Action useIdfSetup: (id: number) => void;
+
+  get idfSetups() {
+    return this.storeIdfSetups;
+  }
+}
+</script>

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -1,21 +1,19 @@
 <template>
-  <div class="existing-setup">
+  <div class="centerize notification">
     <div
       class="notification install-choice"
-      v-for="prevSetup in idfSetups"
+      v-for="(prevSetup, i) in idfSetups"
       :key="prevSetup.id"
-      @click.once="useIdfSetup(prevSetup.id)"
+      :data-config-id="prevSetup.idfPath"
+      @click.once="useIdfSetup(i)"
     >
-      <label
-        :for="prevSetup.id"
-        class="subtitle"
-        :data-config-id="prevSetup.id"
-      >
-        {{ prevSetup.id }}</label
+      <label :for="prevSetup.id" class="subtitle">
+        {{ prevSetup.idfPath }}</label
       >
       <p>IDF Version {{ prevSetup.version }}</p>
       <p>Python: {{ prevSetup.python }}</p>
       <p>IDF Tools Path: {{ prevSetup.toolsPath }}</p>
+      <p>Git path: {{ prevSetup.gitPath }}</p>
     </div>
   </div>
 </template>
@@ -27,7 +25,7 @@ import { IdfSetup } from "./types";
 
 @Component
 export default class existingSetup extends Vue {
-  @State("existingIdfSetups") private storeIdfSetups: IdfSetup[];
+  @State("idfSetups") private storeIdfSetups: IdfSetup[];
   @Action useIdfSetup: (id: number) => void;
 
   get idfSetups() {

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -5,7 +5,7 @@
       v-for="(prevSetup, i) in idfSetups"
       :key="prevSetup.id"
       :data-config-id="prevSetup.idfPath"
-      @click.once="useIdfSetup(i)"
+      @click="useIdfSetup(i)"
     >
       <label :for="prevSetup.id" class="subtitle">
         {{ prevSetup.idfPath }}</label

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -35,6 +35,7 @@
         </p>
         <p>are installed before choosing the setup mode.</p>
         <h2 class="subtitle">Choose a setup mode.</h2>
+        <selectSaveScope />
       </div>
       <div
         class="notification install-choice"
@@ -45,10 +46,8 @@
           >EXPRESS</label
         >
         <p name="express">
-          Fastest option. Choose ESP-IDF version and python version to create
-          ESP-IDF python virtual environment. ESP-IDF Tools will be installed in
-          <span class="span-path">{{ toolsFolder }}</span
-          >.
+          Fastest option. Choose ESP-IDF, ESP-IDF Tools directory and python executable to create
+          ESP-IDF.
         </p>
       </div>
       <div
@@ -60,49 +59,43 @@
           >ADVANCED</label
         >
         <p name="advanced">
-          Configurable option. Choose ESP-IDF version and python version to
-          create ESP-IDF python virtual environment. Choose ESP-IDF Tools
-          install directory or manually input each existing ESP-IDF tool path.
+          Configurable option. Choose ESP-IDF, ESP-IDF Tools directory and python executable to
+          create ESP-IDF. <br>
+          Can choose ESP-IDF Tools download or manually input each existing ESP-IDF tool path.
         </p>
       </div>
       <div
         class="notification install-choice"
-        @click.once="useDefaultSettings"
-        v-if="isPreviousSetupValid"
+        @click="goTo('/existingsetup', setupMode.existing)"
         id="existing-install-btn"
       >
         <label for="existing" class="subtitle" data-config-id="existing-setup"
           >USE EXISTING SETUP</label
         >
-        <p>
-          We have found ESP-IDF version: {{ idfVersion }} @<span
-            class="span-path"
-            >{{ espIdf }}</span
-          >
-          and ESP-IDF tools in @<span class="span-path"> {{ toolsFolder }}</span
-          >. Click here to use them.
-        </p>
+        <p>Select existing ESP-IDF setup saved in the extension.</p>
       </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
+import { Component, Vue } from "vue-property-decorator";
 import { Action, Mutation, State } from "vuex-class";
-import { IEspIdfTool, SetupMode } from "./types";
+import { SetupMode } from "./types";
 import { router } from "./main";
+import selectSaveScope from "./components/selectSaveScope.vue";
 
-@Component
+@Component({
+  components: {
+    selectSaveScope
+  }
+})
 export default class Home extends Vue {
   @Action requestInitialValues;
   @Action useDefaultSettings;
   @Mutation setSetupMode;
   @State("hasPrerequisites") private storeHasPrerequisites: boolean;
-  @State("idfVersion") private storeIdfVersion: string;
   @State("manualPythonPath") storeManualSysPython: string;
-  @State("toolsResults") private storeToolsResults: IEspIdfTool[];
-  @State("toolsFolder") private storeToolsFolder: string;
   @State("espIdf") private storeEspIdf: string;
   @State("platform") private storePlatform: string;
 
@@ -114,37 +107,12 @@ export default class Home extends Vue {
     return this.storeHasPrerequisites;
   }
 
-  get idfVersion() {
-    return this.storeIdfVersion;
-  }
-
   get platform() {
     return this.storePlatform;
   }
 
-  get isPreviousSetupValid() {
-    if (this.storeToolsResults.length === 0) {
-      return false;
-    }
-    const failedToolsResult = this.storeToolsResults.filter(
-      (tInfo) => !tInfo.doesToolExist
-    );
-    if (
-      this.storeManualSysPython &&
-      this.storeToolsResults.length > 0 &&
-      failedToolsResult.length === 0
-    ) {
-      return true;
-    }
-    return false;
-  }
-
   get setupMode() {
     return SetupMode;
-  }
-
-  get toolsFolder() {
-    return this.storeToolsFolder;
   }
 
   mounted() {

--- a/src/views/setup/components/selectSaveScope.vue
+++ b/src/views/setup/components/selectSaveScope.vue
@@ -1,0 +1,36 @@
+<template>
+  <div id="select-py-version">
+    <div class="field">
+      <div class="control centerize">
+        <label for="python-version-select" class="label"
+          >Select where to save these settings:</label
+        >
+        <div class="select">
+          <select v-model="saveScope" id="settings-location-select">
+            <option value="1">Global</option>
+            <option value="2">Workspace</option>
+            <option value="3">Workspace Folder</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { Mutation, State } from "vuex-class";
+
+@Component
+export default class selectSaveScope extends Vue {
+  @State("saveScope") storeSaveScope: number;
+  @Mutation setSaveScope: (id: number) => void;
+
+  get saveScope() {
+    return this.storeSaveScope;
+  }
+  set saveScope(value: number) {
+    this.setSaveScope(value);
+  }
+}
+</script>

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -24,6 +24,8 @@ import Home from "./Home.vue";
 import Install from "./Install.vue";
 // @ts-ignore
 import Status from "./Status.vue";
+// @ts-ignore
+import ExistingSetup from "./ExistingSetup.vue";
 import IconifyIcon from "@iconify/vue";
 import check from "@iconify-icons/codicon/check";
 import close from "@iconify-icons/codicon/close";
@@ -41,6 +43,7 @@ Vue.component("iconify-icon", IconifyIcon);
 
 const routes = [
   { path: "/", component: Home },
+  { path: "/existingsetup", component: ExistingSetup },
   { path: "/autoinstall", component: Install },
   { path: "/custom", component: ToolsCustom },
   { path: "/status", component: Status },
@@ -86,8 +89,8 @@ window.addEventListener("message", (event) => {
       if (msg.idfTags) {
         store.commit("setEspIdfTagsList", msg.idfTags);
       }
-      if (msg.idfVersion) {
-        store.commit("setIdfVersion", msg.idfVersion);
+      if (msg.idfSetups) {
+        store.commit("setIdfSetups", msg.idfSetups);
       }
       if (msg.pyVersionList) {
         store.commit("setPyVersionsList", msg.pyVersionList);
@@ -100,12 +103,6 @@ window.addEventListener("message", (event) => {
       }
       if (msg.espIdfContainer) {
         store.commit("setEspIdfContainerPath", msg.espIdfContainer);
-      }
-      if (msg.pyBinPath) {
-        store.commit("setManualPyPath", msg.pyBinPath);
-      }
-      if (msg.toolsResults) {
-        store.commit("setToolsResult", msg.toolsResults);
       }
       if (msg.hasPrerequisites) {
         store.commit("setHasPrerequisites", msg.hasPrerequisites);
@@ -121,11 +118,6 @@ window.addEventListener("message", (event) => {
       if (typeof msg.errorMsg !== "undefined") {
         store.commit("setEspIdfErrorStatus", msg.errorMsg);
         store.commit("setIsIdfInstalling", false);
-      }
-      break;
-    case "setIdfVersion":
-      if (msg.idfVersion) {
-        store.commit("setIdfVersion", msg.idfVersion);
       }
       break;
     case "setIsIdfInstalling":

--- a/src/views/setup/store/index.ts
+++ b/src/views/setup/store/index.ts
@@ -19,6 +19,7 @@ import {
   IdfMirror,
   IEspIdfLink,
   IEspIdfTool,
+  IdfSetup,
   IDownload,
   SetupMode,
   StatusType,
@@ -38,7 +39,7 @@ export interface IState {
   idfDownloadStatus: IDownload;
   idfGitDownloadStatus: IDownload;
   idfPythonDownloadStatus: IDownload;
-  idfVersion: string;
+  idfSetups: IdfSetup[];
   isEspIdfValid: boolean;
   isIdfInstalling: boolean;
   isIdfInstalled: boolean;
@@ -49,6 +50,7 @@ export interface IState {
   pyExecErrorStatus: string;
   pyReqsLog: string;
   pyVersionsList: string[];
+  saveScope: number;
   selectedEspIdfVersion: IEspIdfLink;
   selectedIdfMirror: IdfMirror;
   selectedSysPython: string;
@@ -89,7 +91,7 @@ export const setupState: IState = {
     progress: "",
     progressDetail: "",
   },
-  idfVersion: "",
+  idfSetups: [],
   isEspIdfValid: false,
   isIdfInstalling: false,
   isIdfInstalled: false,
@@ -100,6 +102,7 @@ export const setupState: IState = {
   pyExecErrorStatus: "",
   pyReqsLog: "",
   pyVersionsList: [],
+  saveScope: 1,
   selectedEspIdfVersion: {
     filename: "",
     mirror: "",
@@ -157,6 +160,7 @@ export const actions: ActionTree<IState, any> = {
       selectedPyPath: pyPath,
       setupMode: context.state.setupMode,
       toolsPath: context.state.toolsFolder,
+      saveScope: context.state.saveScope
     });
   },
   installEspIdfTools(context) {
@@ -171,6 +175,7 @@ export const actions: ActionTree<IState, any> = {
       mirror: context.state.selectedIdfMirror,
       pyPath,
       toolsPath: context.state.toolsFolder,
+      saveScope: context.state.saveScope
     });
   },
   openEspIdfFolder() {
@@ -210,6 +215,7 @@ export const actions: ActionTree<IState, any> = {
       pyBinPath: pyPath,
       tools: context.state.toolsResults,
       toolsPath: context.state.toolsFolder,
+      saveScope: context.state.saveScope
     });
   },
   useDefaultSettings() {
@@ -217,12 +223,13 @@ export const actions: ActionTree<IState, any> = {
       command: "usePreviousSettings",
     });
   },
-  useIdfSetup(context, payload: string) {
+  useIdfSetup(context, payload: number) {
     vscode.postMessage({
       command: "useIdfSetup",
-      selectedIdfSetup: payload
-    })
-  }
+      selectedIdfSetup: payload,
+      saveScope: context.state.saveScope
+    });
+  },
 };
 
 export const mutations: MutationTree<IState> = {
@@ -284,9 +291,9 @@ export const mutations: MutationTree<IState> = {
     newState.idfDownloadStatus.progressDetail = progressDetail;
     Object.assign(state, newState);
   },
-  setIdfVersion(state, idfVersion) {
+  setIdfSetups(state, idfSetups: IdfSetup[]) {
     const newState = state;
-    newState.idfVersion = idfVersion;
+    newState.idfSetups = idfSetups;
     Object.assign(state, newState);
   },
   setIsIdfInstalled(state, isInstalled: boolean) {
@@ -335,6 +342,11 @@ export const mutations: MutationTree<IState> = {
     if (pyVersionsList && pyVersionsList.length > 0) {
       newState.selectedSysPython = pyVersionsList[0];
     }
+    Object.assign(state, newState);
+  },
+  setSaveScope(state, newSaveScope: number) {
+    const newState = state;
+    newState.saveScope = newSaveScope;
     Object.assign(state, newState);
   },
   setSelectedEspIdfVersion(state, selectedEspIdfVersion: IEspIdfLink) {

--- a/src/views/setup/store/index.ts
+++ b/src/views/setup/store/index.ts
@@ -217,6 +217,12 @@ export const actions: ActionTree<IState, any> = {
       command: "usePreviousSettings",
     });
   },
+  useIdfSetup(context, payload: string) {
+    vscode.postMessage({
+      command: "useIdfSetup",
+      selectedIdfSetup: payload
+    })
+  }
 };
 
 export const mutations: MutationTree<IState> = {

--- a/src/views/setup/types.ts
+++ b/src/views/setup/types.ts
@@ -19,6 +19,14 @@ export interface IEspIdfLink {
   url: string;
 }
 
+export interface IdfSetup {
+  id: string;
+  version: string;
+  python: string;
+  toolsPath: string;
+  path: string;
+}
+
 export enum IdfMirror {
   Espressif,
   Github,

--- a/src/views/setup/types.ts
+++ b/src/views/setup/types.ts
@@ -24,7 +24,8 @@ export interface IdfSetup {
   version: string;
   python: string;
   toolsPath: string;
-  path: string;
+  idfPath: string;
+  gitPath: string;
 }
 
 export enum IdfMirror {
@@ -60,4 +61,5 @@ export enum StatusType {
 export enum SetupMode {
   advanced,
   express,
+  existing
 }


### PR DESCRIPTION
## Description

Expand use existing setup to load existing ESP-IDF setups in the user systems.

Every time the user saves a new ESP-IDF path it will saved in the extension global state and appear later in the `Existing Setup` and also uses `IDF_TOOLS_PATH` to load `esp-idf.json` for existing ESP-IDF setups.

Fixes #832

## Type of change
- New feature (non-breaking change which adds functionality)

## How has this been tested?

Test changing multiple ESP-IDF versions using manual testing of wizard.

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS


## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
