### PR TITLE
add support for coredump data subtype (VSC-1065)

### DIFF
--- a/src/views/partition-table/components/Row.vue
+++ b/src/views/partition-table/components/Row.vue
@@ -98,7 +98,7 @@ export default class Row extends Vue {
         "test",
       ];
     } else if (this.sType === "data") {
-      return ["fat", "ota", "phy", "nvs", "nvs_keys", "spiffs"];
+      return ["fat", "ota", "phy", "nvs", "nvs_keys", "spiffs","coredump"];
     }
     return [];
   }


### PR DESCRIPTION
as per 
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/core_dump.html

## Description

Users should be allowed to select such subtype

Fixes #XXX

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS



## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
