### PR TITLE
catch cmakelists txt error sdkconfig file access

### DIFF
--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -64,6 +64,17 @@ export class PlatformInformation {
     }
   }
 
+  public get fallbackPlatform(): string {
+    switch (this.platform) {
+      case "darwin":
+        return "macos";
+      case "win32":
+        return this.architecture === "x86" ? "win32" : "win64";
+      default:
+        return "linux-amd64";
+    }
+  }
+
   public static GetUnknownArchitecture(): string {
     return "Unknown";
   }

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -81,6 +81,9 @@ export class IdfToolsManager {
                   return (
                     platOverride.platforms.indexOf(
                       this.platformInfo.platformToUse
+                    ) !== -1 ||
+                    platOverride.platforms.indexOf(
+                      this.platformInfo.fallbackPlatform
                     ) !== -1
                   );
                 }
@@ -140,6 +143,9 @@ export class IdfToolsManager {
         (Object.getOwnPropertyNames(value).indexOf(
           this.platformInfo.platformToUse
         ) > -1 ||
+          Object.getOwnPropertyNames(value).indexOf(
+            this.platformInfo.fallbackPlatform
+          ) > -1 ||
           Object.getOwnPropertyNames(value).indexOf("any") > -1)
       );
     });
@@ -151,7 +157,11 @@ export class IdfToolsManager {
     const linkInfo =
       Object.getOwnPropertyNames(versions[0]).indexOf("any") > -1
         ? (versions[0]["any"] as IFileInfo)
-        : (versions[0][this.platformInfo.platformToUse] as IFileInfo);
+        : Object.getOwnPropertyNames(versions[0]).indexOf(
+            this.platformInfo.platformToUse
+          ) > -1
+        ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
+        : (versions[0][this.platformInfo.fallbackPlatform] as IFileInfo);
     return linkInfo;
   }
 
@@ -171,6 +181,9 @@ export class IdfToolsManager {
         (Object.getOwnPropertyNames(value).indexOf(
           this.platformInfo.platformToUse
         ) > -1 ||
+          Object.getOwnPropertyNames(value).indexOf(
+            this.platformInfo.fallbackPlatform
+          ) > -1 ||
           Object.getOwnPropertyNames(value).indexOf("any") > -1)
       );
     });
@@ -314,6 +327,9 @@ export class IdfToolsManager {
         return (
           Object.getOwnPropertyNames(version).indexOf(
             this.platformInfo.platformToUse
+          ) > -1 ||
+          Object.getOwnPropertyNames(version).indexOf(
+            this.platformInfo.fallbackPlatform
           ) > -1
         );
       });

--- a/src/test/suite/idfToolsManager.test.ts
+++ b/src/test/suite/idfToolsManager.test.ts
@@ -81,6 +81,7 @@ suite("IDF Tools Manager Tests", async () => {
     architecture: "x86_64",
     platform: "darwin",
     platformToUse: "macos",
+    fallbackPlatform: "macos",
   };
   const output = OutputChannel.init();
   const idfToolsManager = new IdfToolsManager(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,17 +250,16 @@ export async function setCCppPropertiesJsonCompilerPath(
 
 export function getToolchainToolName(idfTarget: string, tool: string = "gcc") {
   switch (idfTarget) {
-    case "esp32c2":
-    case "esp32c3":
-    case "esp32c6":
-    case "esp32h2":
-      return `riscv32-esp-elf-${tool}`;
     case "esp32":
     case "esp32s2":
     case "esp32s3":
       return `xtensa-${idfTarget}-elf-${tool}`;
+    case "esp32c2":
+    case "esp32c3":
+    case "esp32c6":
+    case "esp32h2":
     default:
-      return undefined;
+      return `riscv32-esp-elf-${tool}`;
   }
 }
 
@@ -321,10 +320,18 @@ export function getVariableFromCMakeLists(workspacePath: string, key: string) {
 }
 
 export function getSDKConfigFilePath(workspacePath: vscode.Uri) {
-  let sdkconfigFilePath = getVariableFromCMakeLists(
-    workspacePath.fsPath,
-    "SDKCONFIG"
-  );
+  let sdkconfigFilePath = "";
+  try {
+    sdkconfigFilePath = getVariableFromCMakeLists(
+      workspacePath.fsPath,
+      "SDKCONFIG"
+    );
+  } catch (error) {
+    const errMsg = error.message
+      ? error.message
+      : `CMakeLists.txt file doesn't exists or can't be read`;
+    Logger.info(errMsg, error);
+  }
   if (
     sdkconfigFilePath &&
     sdkconfigFilePath.indexOf("${CMAKE_BINARY_DIR}") !== -1

--- a/templates/.vscode/c_cpp_properties.json
+++ b/templates/.vscode/c_cpp_properties.json
@@ -3,8 +3,6 @@
     {
       "name": "ESP-IDF",
       "compilerPath": "${default}",
-      "cStandard": "c11",
-      "cppStandard": "c++17",
       "includePath": [
         "${config:idf.espIdfPath}/components/**",
         "${config:idf.espIdfPathWin}/components/**",

--- a/testFiles/testWorkspace/.vscode/c_cpp_properties.json
+++ b/testFiles/testWorkspace/.vscode/c_cpp_properties.json
@@ -3,8 +3,6 @@
     {
       "name": "ESP-IDF",
       "compilerPath": "${default}",
-      "cStandard": "c11",
-      "cppStandard": "c++17",
       "includePath": [
         "${config:idf.espIdfPath}/components/**",
         "${config:idf.espIdfPathWin}/components/**",


### PR DESCRIPTION
## Description

Catch CMakeLists.txt file access error reading IDF Target on extension activation.

Fixes #897 
Fix #905 
Fix #907
Fix #911 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS Ventura

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
