### PR TITLE
add monitor no reset flag

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -103,6 +103,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                   |                           |
 | `idf.telemetry`                        | Enable Telemetry                                                            | User, Remote or Workspace |
 | `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`) | User, Remote or Workspace |
+| `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                    | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -103,6 +103,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                   |                           |
 | `idf.telemetry`                        | Enable Telemetry                                                            | User, Remote or Workspace |
 | `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`) | User, Remote or Workspace |
+| `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                       | User, Remote or Workspace |
 | `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                    | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -117,6 +117,7 @@
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
   "param.enableCCache.title": "Enable CCache in build task",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
+  "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -116,6 +116,7 @@
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
   "param.enableCCache.title": "Enable CCache in build task",
+  "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -103,6 +103,7 @@
   "param.svdFile": "Archivo SVD para la vista de perifericos en ventana de depuracion",
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración luego de IDF Monitor (ms)",
+  "param.monitorNoReset": "Habilitar no-reset en el IDF Monitor",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -102,6 +102,7 @@
   "param.sdkconfigDefaults": "Lista de valores por defecto para crear el archivo sdkconfig",
   "param.svdFile": "Archivo SVD para la vista de perifericos en ventana de depuracion",
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
+  "param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración luego de IDF Monitor (ms)",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -103,6 +103,7 @@
   "param.svdFile": "Файл SVD для разрешения периферийного представления ESP-IDF в представлении отладки",
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "param.monitorStartDelayBeforeDebug": "Задержка запуска сеанса отладки после выполнения монитора IDF (мс)",
+  "param.monitorNoReset": "Включить флаг отсутствия сброса для монитора IDF",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -102,6 +102,7 @@
   "param.sdkconfigDefaults": "Список значений по умолчанию sdkconfig для начальной конфигурации сборки",
   "param.svdFile": "Файл SVD для разрешения периферийного представления ESP-IDF в представлении отладки",
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
+  "param.monitorStartDelayBeforeDebug": "Задержка запуска сеанса отладки после выполнения монитора IDF (мс)",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -103,6 +103,7 @@
   "param.svdFile": "用于在调试视图中解析ESP-IDF外围视图的奇异值分解文件",
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "param.monitorStartDelayBeforeDebug": "IDF监视器执行后延迟启动调试会话 (ms)",
+  "param.monitorNoReset": "对IDF监视器启用无重置标志",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -102,6 +102,7 @@
   "param.sdkconfigDefaults": "初始生成配置的sdkconfig默认值列表",
   "param.svdFile": "用于在调试视图中解析ESP-IDF外围视图的奇异值分解文件",
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
+  "param.monitorStartDelayBeforeDebug": "IDF监视器执行后延迟启动调试会话 (ms)",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -820,6 +820,12 @@
             "default": false,
             "scope": "resource",
             "description": "%param.deleteComponentsOnFullClean%"
+          },
+          "idf.monitorStartDelayBeforeDebug": {
+            "type": "number",
+            "default": 5000,
+            "scope": "resource",
+            "description": "%param.monitorStartDelayBeforeDebug%"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -826,6 +826,12 @@
             "default": 5000,
             "scope": "resource",
             "description": "%param.monitorStartDelayBeforeDebug%"
+          },
+          "idf.monitorNoReset": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "description": "%param.monitorNoReset%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,6 +100,7 @@
   "param.buildPath": "Name of CMake build directory",
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
+  "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/package.nls.json
+++ b/package.nls.json
@@ -99,6 +99,7 @@
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "param.buildPath": "Name of CMake build directory",
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
+  "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -163,6 +163,7 @@
     "param.uncoveredLightTheme",
     "param.uncoveredDarkTheme",
     "param.sdkconfigDefaults",
+    "param.monitorStartDelayBeforeDebug",
     "view.components.name",
     "configuration.title",
     "espIdf.apptrace.archive.refresh.title",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -164,6 +164,7 @@
     "param.uncoveredDarkTheme",
     "param.sdkconfigDefaults",
     "param.monitorStartDelayBeforeDebug",
+    "param.monitorNoReset",
     "view.components.name",
     "configuration.title",
     "espIdf.apptrace.archive.refresh.title",

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -31,6 +31,7 @@ const locDic = new LocDictionary(__filename);
 
 export async function createNewIdfMonitor(
   workspaceFolder: Uri,
+  noReset: boolean = false,
   serialPort?: string
 ) {
   if (BuildTask.isBuilding || FlashTask.isFlashing) {
@@ -58,9 +59,7 @@ export async function createNewIdfMonitor(
       new Error("NOT_SELECTED_PORT")
     );
   }
-  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
-    workspaceFolder
-  );
+  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(workspaceFolder);
   const pythonBinPath = readParameter(
     "idf.pythonBinPath",
     workspaceFolder
@@ -98,6 +97,7 @@ export async function createNewIdfMonitor(
     idfTarget,
     idfMonitorToolPath,
     idfVersion,
+    noReset,
     elfFilePath,
     workspaceFolder,
     toolchainPrefix,

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -70,7 +70,7 @@ export class IDFMonitor {
       "--toolchain-prefix",
       this.config.toolchainPrefix,
     ];
-    if (this.config.noReset && this.config.idfVersion >= "4.3") {
+    if (this.config.noReset && this.config.idfVersion >= "5.0") {
       args.splice(2, 0, "--no-reset");
     }
     if (this.config.idfVersion >= "4.3") {

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -25,6 +25,7 @@ export interface MonitorConfig {
   idfMonitorToolPath: string;
   idfTarget: string;
   idfVersion: string;
+  noReset: boolean;
   port: string;
   pythonBinPath: string;
   toolchainPrefix: string;
@@ -69,6 +70,9 @@ export class IDFMonitor {
       "--toolchain-prefix",
       this.config.toolchainPrefix,
     ];
+    if (this.config.noReset && this.config.idfVersion >= "4.3") {
+      args.splice(2, 0, "--no-reset");
+    }
     if (this.config.idfVersion >= "4.3") {
       args.push("--target", this.config.idfTarget);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2576,6 +2576,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const elfFilePath = path.join(buildDirPath, `${projectName}.elf`);
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const idfVersion = await utils.getEspIdfFromCMake(idfPath);
+        const noReset = idfConf.readParameter(
+          "idf.monitorNoReset",
+          workspaceRoot
+        ) as boolean;
         const monitor = new IDFMonitor({
           port,
           baudRate: sdkMonitorBaudRate,
@@ -2584,7 +2588,7 @@ export async function activate(context: vscode.ExtensionContext) {
           toolchainPrefix,
           idfMonitorToolPath,
           idfVersion,
-          noReset: false,
+          noReset,
           elfFilePath,
           wsPort,
           workspaceFolder: workspaceRoot,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3293,8 +3293,12 @@ function createIdfTerminal() {
   });
 }
 
-function createMonitor(noReset: boolean = false) {
+function createMonitor() {
   PreCheck.perform([webIdeCheck, openFolderCheck], async () => {
+    const noReset = idfConf.readParameter(
+      "idf.monitorNoReset",
+      workspaceRoot
+    ) as boolean;
     await createIdfMonitor(noReset);
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3314,14 +3314,17 @@ function createMonitor(noReset: boolean = false) {
     const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset);
     monitorTerminal = idfMonitor.start();
     if (noReset) {
-      const idfPath = idfConf.readParameter("idf.espIdfPath", workspaceRoot) as string;
+      const idfPath = idfConf.readParameter(
+        "idf.espIdfPath",
+        workspaceRoot
+      ) as string;
       const idfVersion = await utils.getEspIdfFromCMake(idfPath);
       if (idfVersion <= "5.0") {
         const monitorDelay = idfConf.readParameter(
           "idf.monitorStartDelayBeforeDebug",
           workspaceRoot
         ) as number;
-        await utils.sleep(monitorDelay); 
+        await utils.sleep(monitorDelay);
       }
     }
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1216,7 +1216,7 @@ export async function activate(context: vscode.ExtensionContext) {
           useMonitorWithDebug
         ) {
           isMonitorLaunchedByDebug = true;
-          createMonitor();
+          createMonitor(true);
         }
         return new vscode.DebugAdapterServer(portToUse);
       } catch (error) {
@@ -2600,6 +2600,7 @@ export async function activate(context: vscode.ExtensionContext) {
           toolchainPrefix,
           idfMonitorToolPath,
           idfVersion,
+          noReset: false,
           elfFilePath,
           wsPort,
           workspaceFolder: workspaceRoot,
@@ -3155,7 +3156,7 @@ const flash = (
   });
 };
 
-function createQemuMonitor() {
+function createQemuMonitor(noReset: boolean = false) {
   PreCheck.perform([openFolderCheck], async () => {
     const isQemuLaunched = await qemuManager.isRunning();
     if (!isQemuLaunched) {
@@ -3167,7 +3168,7 @@ function createQemuMonitor() {
       workspaceRoot
     ) as number;
     const serialPort = `socket://localhost:${qemuTcpPort}`;
-    const idfMonitor = await createNewIdfMonitor(workspaceRoot, serialPort);
+    const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset, serialPort);
     monitorTerminal = idfMonitor.start();
   });
 }
@@ -3304,9 +3305,9 @@ function createIdfTerminal() {
   });
 }
 
-function createMonitor() {
+function createMonitor(noReset: boolean = false) {
   PreCheck.perform([webIdeCheck, openFolderCheck], async () => {
-    const idfMonitor = await createNewIdfMonitor(workspaceRoot);
+    const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset);
     monitorTerminal = idfMonitor.start();
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3168,7 +3168,11 @@ function createQemuMonitor(noReset: boolean = false) {
       workspaceRoot
     ) as number;
     const serialPort = `socket://localhost:${qemuTcpPort}`;
-    const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset, serialPort);
+    const idfMonitor = await createNewIdfMonitor(
+      workspaceRoot,
+      noReset,
+      serialPort
+    );
     monitorTerminal = idfMonitor.start();
   });
 }


### PR DESCRIPTION
## Description

Fix Monitor resetting the chip when debug session starts. This is done by adding `--no-reset` to IDF Monitor when debug session starts if `idf.launchMonitorOnDebugSession` is true (for IDF 5.0 or newer) and using a `idf.monitorStartDelayBeforeDebug` delay (in ms) to wait IDF Monitor is ready before debug session starts. (For IDf <5.0 need to modify this value)

add `idf.monitorNoReset` to enable or disable `--no-reset` flag for IDF Monitor and `idf.monitorStartDelayBeforeDebug` to set a delay to start debug session after IDF Monitor.

Fix #922

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature

## How has this been tested?

Tested using the debug session with IDF monitor with the `idf.monitorNoReset` set to true.

- Manual testing of debug blink example

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS


## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
