### PR TITLE
Support esp32c6

### DIFF
--- a/package.json
+++ b/package.json
@@ -473,6 +473,7 @@
               "esp32s2",
               "esp32s3",
               "esp32c3",
+              "esp32c6",
               "custom"
             ],
             "enumDescriptions": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "esp32",
     "esp32c2",
     "esp32c3",
+    "esp32c6",
     "esp32h2",
     "esp32s2",
     "esp32s3",

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -65,6 +65,18 @@ export const defaultBoards = [
     target: "esp32c3",
     configFiles: ["board/esp32c3-builtin.cfg"],
   } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via ESP-PROG)",
+    description: "ESP32-C6 used with ESP-PROG board",
+    target: "esp32c6",
+    configFiles: ["board/esp32c6-ftdi.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via builtin USB-JTAG)",
+    description: "ESP32-C6 debugging via builtin USB-JTAG",
+    target: "esp32c6",
+    configFiles: ["board/esp32c6-builtin.cfg"],
+  } as IdfBoard,
 ];
 
 export function getOpenOcdScripts(workspace: Uri): string {

--- a/src/test/suite/testCoverage.test.ts
+++ b/src/test/suite/testCoverage.test.ts
@@ -7,11 +7,13 @@ import { CoverageRenderer } from "../../coverage/renderer";
 suite("Test Coverage Unit Tests", () => {
   test("gcov executables based on idfTarget", () => {
     const esp32c3 = getGcovExecutable("esp32c3")
+    const esp32c6 = getGcovExecutable("esp32c6")
     const esp32s2 = getGcovExecutable("esp32s2")
     const esp32s3 = getGcovExecutable("esp32s3")
     const esp32 = getGcovExecutable("esp32")
 
     assert.equal(esp32c3, "riscv32-esp-elf-gcov");
+    assert.equal(esp32c6, "riscv32-esp-elf-gcov");
     assert.equal(esp32s2, "xtensa-esp32s2-elf-gcov");
     assert.equal(esp32s3, "xtensa-esp32s3-elf-gcov");
     assert.equal(esp32, "xtensa-esp32-elf-gcov");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,6 +252,7 @@ export function getToolchainToolName(idfTarget: string, tool: string = "gcc") {
   switch (idfTarget) {
     case "esp32c2":
     case "esp32c3":
+    case "esp32c6":
     case "esp32h2":
       return `riscv32-esp-elf-${tool}`;
     case "esp32":

--- a/testFiles/esp-config.json
+++ b/testFiles/esp-config.json
@@ -4,7 +4,8 @@
       { "id": "esp32", "name": "ESP32" },
       { "id": "esp32s2", "name": "ESP32-S2" },
       { "id": "esp32s3", "name": "ESP32-S3" },
-      { "id": "esp32c3", "name": "ESP32-C3" }
+      { "id": "esp32c3", "name": "ESP32-C3" },
+      { "id": "esp32c6", "name": "ESP32-C6" }
   ],
   "boards" : [
       {

--- a/testFiles/esp-config.json
+++ b/testFiles/esp-config.json
@@ -82,6 +82,22 @@
           "config_files": [
               "board/esp32c3-builtin.cfg"
           ]
+      },
+      {
+        "name": "ESP32-C6 chip (via ESP-PROG)",
+        "description": "ESP32-C6 used with ESP-PROG board",
+        "target": "esp32c6",
+        "config_files": [
+            "board/esp32c6-ftdi.cfg"
+        ]
+      },
+      {
+        "name": "ESP32-C6 chip (via builtin USB-JTAG)",
+        "description": "ESP32-C6 debugging via builtin USB-JTAG",
+        "target": "esp32c6",
+        "config_files": [
+            "board/esp32c6-builtin.cfg"
+        ]
       }
   ],
   "options": [


### PR DESCRIPTION
Support esp32c6

works fine, but i have to use the latest OpenOCD v0.12 in order to have JTAG as v0.10 and v0.11 does not include the settings files for the esp32c6.

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
