### PR TITLE
:bug: Fix wrong binary with multiple options

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1048,9 +1048,11 @@ export async function isBinInPath(
       result.toString() === "" ||
       result.toString().indexOf("Could not find files") < 0
     ) {
-      return binaryName.localeCompare(result.toString().trim()) === 0
+      // Sometimes multiple paths can be returned. They are separated by new lines, get only the first one
+      const selectedResult = result.toString().split("\n")[0].trim();
+      return binaryName.localeCompare(selectedResult) === 0
         ? ""
-        : result.toString().trim();
+        : selectedResult;
     }
   } catch (error) {
     Logger.error(`Cannot access filePath: ${binaryName}`, error);


### PR DESCRIPTION
## Description

On windows the call to `where` can return multiple results separated by a newline. This takes the first found result.

## Type of change

Please delete options that are not relevant.
- Bug fix

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- On windows. 
    - Run the command `${command:espIdf.getXtensaGdb}`. 
    - The following string is returned: `C:\Users\<user>\.local\share\esp\espressif-tools\tools\xtensa-esp-elf-gdb\11.2_20220823\xtensa-esp-elf-gdb\bin\xtensa-esp32-elf-gdb.exe\r\nC:\<user>\jmarc\.local\share\esp\espressif-tools\tools\xtensa-esp32-elf\esp-2021r2-patch5-8.4.0\xtensa-esp32-elf\bin\xtensa-esp32-elf-gdb.exe`
    - Afterwards `selectedResult` has the value `C:\Users\<user>\.local\share\esp\espressif-tools\tools\xtensa-esp-elf-gdb\11.2_20220823\xtensa-esp-elf-gdb\bin\xtensa-esp32-elf-gdb.exe`


**Test Configuration**:
* ESP-IDF Version: 4.4.4
* OS (Windows,Linux and macOS): Windows

## Dependent components impacted by this PR:

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] ~Added Documentation~ (not needed)
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
