### PR TITLE
Updated esp-matter checkout submodules arguments

### DIFF
--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -38,6 +38,7 @@ import { TaskManager } from "../taskManager";
 import { OutputChannel } from "../logger/outputChannel";
 import { PackageProgress } from "../PackageProgress";
 import { installEspMatterPyReqs } from "../pythonManager";
+import { platform } from "os";
 
 export class EspMatterCloning extends AbstractCloning {
   public static isBuildingGn: boolean;
@@ -144,20 +145,25 @@ export class EspMatterCloning extends AbstractCloning {
     progress?: Progress<{ message?: string; increment?: number }>,
   ) {
      return new Promise<void>((resolve, reject) => {
+      const matterDir = join(
+        espMatterDir,
+        "connectedhomeip",
+        "connectedhomeip"
+      )
+
       const checkoutProcess = spawn(
         join(
-          espMatterDir,
-          "connectedhomeip",
-          "connectedhomeip",
+          matterDir,
           "scripts",
           "checkout_submodules.py"
         ),
         [
           "--platform",
           "esp32",
+          platform(),
           "--shallow"
         ],
-        { cwd: espMatterDir }
+        { cwd: matterDir}
       );
 
       checkoutProcess.stderr.on("data", (data) => {


### PR DESCRIPTION
## Description

Since https://github.com/espressif/esp-matter/commit/7b2912a9e5be3cb7e69e80fed315aa017f75127e, platform is requested for checking out matter submodules in a lightweight way (So only esp32 submodules).

This change was also applied to ESP-Matter repo in this commit: https://github.com/espressif/esp-matter/commit/ca1258fd51f9ee395cc3592af8240121365105b4

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Launch command "ESP-IDF: install ESP-Matter"
2. Request to download esp32 platform submodules only
3. Wait to install
4. Build an ESP-Matter example

- Expected behaviour:
All is run without any problem

## Checklist
- [ ] PR Self Reviewed
- [X] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- Verified on: 
  + [x] Linux
  + [ ] macOS
