### PR TITLE
Added installation of zap-cli for esp-matter (VSC-1078)

### DIFF
--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { pathExists } from "fs-extra";
+import { move, pathExists, chmod, remove } from "fs-extra";
 import { join } from "path";
 import { spawn } from "child_process";
 import {
@@ -37,7 +37,7 @@ import { Logger } from "../logger/logger";
 import { TaskManager } from "../taskManager";
 import { OutputChannel } from "../logger/outputChannel";
 import { PackageProgress } from "../PackageProgress";
-import { installEspMatterPyReqs } from "../pythonManager";
+import { installEspMatterPyReqs, installMatterZapCli } from "../pythonManager";
 import { platform } from "os";
 
 export class EspMatterCloning extends AbstractCloning {
@@ -252,6 +252,64 @@ export async function installPythonReqs(
   );
 }
 
+export async function installZapCli(
+  espMatterPath: string,
+  workspace?: Uri
+) {
+  const espIdfPath = readParameter("idf.espIdfPath", workspace)
+  const pyPath = readParameter( "idf.pythonBinPath", workspace);
+  const containerPath =
+    process.platform === "win32"
+      ? process.env.USERPROFILE
+      : process.env.HOME;
+  const confToolsPath = readParameter("idf.toolsPath", workspace);
+  const toolsPath =
+    confToolsPath ||
+    process.env.IDF_TOOLS_PATH ||
+    join(containerPath, ".espressif");
+  await window.withProgress(
+    {
+      cancellable: true,
+      location: ProgressLocation.Notification,
+      title: 'Installing ESP-Matter',
+    },
+    async (
+      progress: Progress<{ message: string; increment?: number }>,
+      cancelToken: CancellationToken
+    ) => {
+      progress.report({
+        message: `Installing zap-cli...`,
+      });
+      const zapCliPath = await installMatterZapCli(
+        espIdfPath,
+        toolsPath,
+        espMatterPath,
+        pyPath,
+        undefined,
+        OutputChannel.init(),
+        cancelToken
+      );
+
+      const zapCliExists = await pathExists(zapCliPath);
+      if (zapCliExists) {
+        const espMatterZapCliPath = join(espMatterPath, ".zap");
+        const espMatterZapCliExists = await pathExists(espMatterZapCliPath);
+        if (espMatterZapCliExists) {
+          await remove(espMatterZapCliPath);
+        }
+        await move(zapCliPath, espMatterZapCliPath);
+        await chmod(join(espMatterZapCliPath, "zap-cli"), 0o755);
+      }
+      else
+      {
+        const msg = `zap-cli installation failed\n`;
+        OutputChannel.appendLine(msg);
+        Logger.errorNotify("zap-cli installation error", new Error(msg));
+      }
+    }
+  );
+}
+
 export async function getEspMatter(workspace?: Uri) {
   const gitPath = (await readParameter("idf.gitPath", workspace)) || "/usr/bin/git";
   let espMatterPath;
@@ -294,6 +352,17 @@ export async function getEspMatter(workspace?: Uri) {
       );
     }
     EspMatterCloning.isBuildingGn = false;
+    return Logger.errorNotify(msg, error);
+  }
+
+  try {
+    await installZapCli(espMatterPath, workspace);
+  } catch (error) {
+    const msg = error.message
+      ? error.message
+      : typeof error === "string"
+      ? error
+      : "Error installing zap-cli";
     return Logger.errorNotify(msg, error);
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -943,13 +943,6 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   modifiedEnv.IDF_TOOLS_PATH = toolsPath || defaultToolsPath;
   const matterPathDir = idfConf.readParameter("idf.espMatterPath") as string;
   modifiedEnv.ESP_MATTER_PATH = matterPathDir || modifiedEnv.ESP_MATTER_PATH;
-  
-  if (modifiedEnv.ESP_MATTER_PATH) {
-   modifiedEnv.ZAP_INSTALL_PATH = path.join(
-      modifiedEnv.ESP_MATTER_PATH,
-      ".zap"
-    );
-  }
 
   let pathToPigweed: string;
 
@@ -962,6 +955,10 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
       "cipd",
       "packages",
       "pigweed"
+    );
+    modifiedEnv.ZAP_INSTALL_PATH = path.join(
+      modifiedEnv.ESP_MATTER_PATH,
+      ".zap"
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -945,7 +945,10 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   modifiedEnv.ESP_MATTER_PATH = matterPathDir || modifiedEnv.ESP_MATTER_PATH;
   
   if (modifiedEnv.ESP_MATTER_PATH) {
-   modifiedEnv.ZAP_INSTALL_PATH = path.join(modifiedEnv.ESP_MATTER_PATH, ".zap");
+   modifiedEnv.ZAP_INSTALL_PATH = path.join(
+      modifiedEnv.ESP_MATTER_PATH,
+      ".zap"
+    );
   }
 
   let pathToPigweed: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -943,7 +943,10 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   modifiedEnv.IDF_TOOLS_PATH = toolsPath || defaultToolsPath;
   const matterPathDir = idfConf.readParameter("idf.espMatterPath") as string;
   modifiedEnv.ESP_MATTER_PATH = matterPathDir || modifiedEnv.ESP_MATTER_PATH;
-  modifiedEnv.ZAP_INSTALL_PATH = path.join(modifiedEnv.ESP_MATTER_PATH, ".zap");
+  
+  if (modifiedEnv.ESP_MATTER_PATH) {
+   modifiedEnv.ZAP_INSTALL_PATH = path.join(modifiedEnv.ESP_MATTER_PATH, ".zap");
+  }
 
   let pathToPigweed: string;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -943,6 +943,7 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   modifiedEnv.IDF_TOOLS_PATH = toolsPath || defaultToolsPath;
   const matterPathDir = idfConf.readParameter("idf.espMatterPath") as string;
   modifiedEnv.ESP_MATTER_PATH = matterPathDir || modifiedEnv.ESP_MATTER_PATH;
+  modifiedEnv.ZAP_INSTALL_PATH = path.join(modifiedEnv.ESP_MATTER_PATH, ".zap");
 
   let pathToPigweed: string;
 


### PR DESCRIPTION
## Description

In ESP-Matter repo, zap-cli is installed and the installation path is exported, this PR installs it in the specified path in install.sh from ESP-Matter repo and the install path is exported also.

I had to make also a modification in `execProcessWithLog` to return the output because the output of installing zap-cli returns the installation path. I could build that path manually, but as in `install.sh` obtained the installation path this way. I tried to find where is used also to check if it could break any functionality, but doesn't seem to.

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Steps to test this pull request

Delete old ESP-Matter installation, reinstall and then build an ESP-Matter code.

- Expected behaviour:
Everything should run fine.

## Checklist
- [ ] PR Self Reviewed
- [X] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on:
  - [X] Linux
  - [X] macOS
