### PR TITLE
add container user to dialout group

### DIFF
--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -35,7 +35,8 @@ RUN wget --no-verbose ${QEMU_URL} \
 ENV PATH=/opt/qemu/bin:${PATH}
 
 RUN groupadd --gid $USER_GID $CONTAINER_USER \
-    && adduser --uid $USER_UID --gid $USER_GID --disabled-password --gecos "" ${CONTAINER_USER}
+    && adduser --uid $USER_UID --gid $USER_GID --disabled-password --gecos "" ${CONTAINER_USER} \
+    && usermod -a -G dialout $CONTAINER_USER
 USER ${CONTAINER_USER}
 ENV USER=${CONTAINER_USER}
 WORKDIR /home/${CONTAINER_USER}


### PR DESCRIPTION
## Description

Add container user to dialout to allow serial port access.

Fix #942 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Start VS Code, run the Dev Containers: Open Folder in Container... command from the Command Palette (F1) or quick actions Status bar item, and select the project folder you would like to set up the container for.
2. Run `ESP-IDF Monitor` and see if it works.

- Expected behaviour: Monitor starts working correctly. No `Permission denied: '/dev/ttyUSB0'` errors

- Expected output: Normal IDF Monitor output

## How has this been tested?

Tested by manual run of container blink ESP-IDF example.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
