### PR TITLE
trim nvs csv columns

### DIFF
--- a/src/test/suite/nvsPartitionTable.test.ts
+++ b/src/test/suite/nvsPartitionTable.test.ts
@@ -8,11 +8,6 @@ import {
   minValues,
   maxValues
 } from "../../views/nvs-partition-table/util";
-// You can import and use all API from the "vscode" module
-// as well as import your extension to test it
-import * as vscode from "vscode";
-import { stringify } from "querystring";
-import { NvsPartitionTable } from "../../views/nvs-partition-table/store/index";
 import * as fse from "fs-extra";
 import { resolve } from "path";
 

--- a/src/views/nvs-partition-table/util.ts
+++ b/src/views/nvs-partition-table/util.ts
@@ -129,10 +129,8 @@ export function isInValidRow(row: NvsPartitionTable.IRow): string {
   return;
 }
 
-export const expectedHeader = "key,type,encoding,value";
-
 export function JSON2CSV(rows: NvsPartitionTable.IRow[]) {
-  let csv = expectedHeader + EOL;
+  let csv = `key, type, encoding, value ${EOL}`;
   for (const row of rows) {
     if (
       row.key === "" &&
@@ -150,13 +148,17 @@ export function JSON2CSV(rows: NvsPartitionTable.IRow[]) {
 export function csv2Json(csv: string) {
   const rows = new Array<NvsPartitionTable.IRow>();
   const lines = csv.split(EOL);
-  const header = lines.shift();
-  if (header !== expectedHeader) {
+  const header = lines.shift().trim();
+  // key, type, encoding, value
+  const matches = csv.match(
+    /\s*key,\s*type,\s*encoding,\s*value/g
+  );
+  if (!matches || !matches.length) {
     console.log("Not a NVS partition table csv, skipping...");
     return rows;
   }
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i] === "") {
+    if (lines[i] === "" || lines[i].startsWith("#")) {
       continue;
     }
     let cols = lines[i].split(",");

--- a/src/views/nvs-partition-table/util.ts
+++ b/src/views/nvs-partition-table/util.ts
@@ -161,10 +161,10 @@ export function csv2Json(csv: string) {
     }
     let cols = lines[i].split(",");
     rows.push({
-      key: cols.shift(),
-      type: cols.shift(),
-      encoding: cols.shift(),
-      value: cols.shift(),
+      key: cols.shift().trim(),
+      type: cols.shift().trim(),
+      encoding: cols.shift().trim(),
+      value: cols.shift().trim(),
       error: undefined,
     });
   }

--- a/testFiles/nvs-test.csv
+++ b/testFiles/nvs-test.csv
@@ -1,4 +1,4 @@
-key,type,encoding,value
+key, type, encoding, value 
 namespace_name,namespace,,
 key1,data,u8,1
 key2,file,string,/path/to/file


### PR DESCRIPTION
## Description

Trim columns in NVS partition table editor

Fixes #937

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Right click on a NVS partition table csv with CRLF line ending
2. click `ESP-IDF: Open NVS Partition Editor` command
4. Observe results. The table values should shown in the editor.

- Expected behaviour: The table values should shown in the editor.

- Expected output: The table values should shown in the editor.

## How has this been tested?

Manual test using csv with CRLF end of lines characters.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
