### PR TITLE
use idf showOnboardingOnInit on extension activate

### DIFF
--- a/src/checkExtensionSettings.ts
+++ b/src/checkExtensionSettings.ts
@@ -29,6 +29,9 @@ export async function checkExtensionSettings(
   workspace: vscode.Uri
 ) {
   const showSetupWindow = readParameter("idf.showOnboardingOnInit") as boolean;
+  if (!showSetupWindow) {
+    return;
+  }
   const isExtensionConfigured = await isCurrentInstallValid(workspace);
   if (isExtensionConfigured) {
     return;
@@ -49,10 +52,6 @@ export async function checkExtensionSettings(
           progress,
           workspace
         );
-        if (showSetupWindow && !setupArgs.hasPrerequisites) {
-          vscode.commands.executeCommand("espIdf.setup.start", setupArgs);
-          return;
-        }
         if (
           setupArgs.espIdfPath &&
           setupArgs.espToolsPath &&


### PR DESCRIPTION
## Description

Use `idf.showOnboardingOnInit` to show extension setup on activation.

Fixes #928

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

If `idf.showOnboardingOnInit` is set to true and the extension is not configured. It will try to self configure (if existing settings are correct) else it will not.

- Expected behaviour:

- Expected output:

## How has this been tested?

Tested manually by setting `idf.showOnboardingOnInit` and re-open the visual studio code and the extension.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
