### PR TITLE
add idf monitorBaudRate setting

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -52,6 +52,7 @@ These settings are specific to the ESP32 Chip/ Board
 | `idf.adapterTargetName`                          | ESP-IDF target Chip (Example: esp32)                                             |                           |
 | `idf.customAdapterTargetName`                    | Custom target name for ESP-IDF Debug Adapter                                     |                           |
 | `idf.flashBaudRate`                              | Flash Baud rate                                                                  |                           |
+| `idf.monitorBaudRate`                            | Monitor Baud rate                                                                |                           |
 | `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder              |                           |
 | `idf.openOcdLaunchArgs`                          | Launch arguments for OpenOCD before idf.openOcdDebugLevel and idf.openOcdConfigs |                           |
 | `idf.openOcdDebugLevel`                          | Set openOCD debug level (0-4) Default: 2                                         |                           |
@@ -70,11 +71,11 @@ This is how the extension uses them:
    > > If you want to customize the `idf.openOcdConfigs` alone, you can modify your user settings.json or use **ESP-IDF: Device configuration** and select `Enter OpenOCD Configuration File Paths list` by entering each file separated by comma ",".
 2. `idf.customAdapterTargetName` is used when `idf.adapterTargetName` is set to `custom`.
 3. `idf.flashBaudRate` is the baud rate value used for the **ESP-IDF: Flash your project** command and [ESP-IDF Debug](./DEBUGGING.md).
-   > **NOTE** The ESP-IDF Monitor default baud rate value is taken from your project's skdconfig `CONFIG_ESPTOOLPY_MONITOR_BAUD` (idf.py monitor' baud rate). This value can be override by setting the environment variable `IDF_MONITOR_BAUD` or `MONITORBAUD` in your system environment variables or this extension's `idf.customExtraVars` configuration setting.
-4. `idf.openOcdConfigs` is used to store an string array of openOCD scripts directory relative path config files to use with OpenOCD server. (Example: ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"]). More information [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target).
-5. `idf.port` (or `idf.portWin` in Windows) is used as the serial port value for the extension commands.
-6. `idf.openOcdDebugLevel`: Log level for openOCD server output from 0 to 4.
-7. `idf.openOcdLaunchArgs`: Launch arguments string array for openOCD. The resulting openOCD launch command looks like this: `openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}`.
+4. `idf.monitorBaudRate` is the ESP-IDF Monitor baud rate value and fallback from your project's skdconfig `CONFIG_ESPTOOLPY_MONITOR_BAUD` (idf.py monitor' baud rate). This value can also be override by setting the environment variable `IDF_MONITOR_BAUD` or `MONITORBAUD` in your system environment variables or this extension's `idf.customExtraVars` configuration setting.
+5. `idf.openOcdConfigs` is used to store an string array of openOCD scripts directory relative path config files to use with OpenOCD server. (Example: ["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"]). More information [here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target).
+6. `idf.port` (or `idf.portWin` in Windows) is used as the serial port value for the extension commands.
+7. `idf.openOcdDebugLevel`: Log level for openOCD server output from 0 to 4.
+8. `idf.openOcdLaunchArgs`: Launch arguments string array for openOCD. The resulting openOCD launch command looks like this: `openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}`.
 
 ## Code coverage Specific Settings
 

--- a/docs/tutorial/basic_use.md
+++ b/docs/tutorial/basic_use.md
@@ -61,7 +61,7 @@ The user will see a new terminal being launched with the flash output and a noti
 
 10. Now to start monitoring your device, use the **ESP-IDF: Monitor your device** command (<kbd>CTRL</kbd> <kbd>E</kbd> <kbd>M</kbd> keyboard shortcut). The user will see a new terminal being launched with the `idf.py monitor` output.
 
-> **NOTE** The ESP-IDF Monitor default baud rate value is taken from your project's skdconfig `CONFIG_ESPTOOLPY_MONITOR_BAUD` (idf.py monitor' baud rate). This value can be override by setting the environment variable `IDF_MONITOR_BAUD` or `MONITORBAUD` in your system environment variables or this extension's `idf.customExtraVars` configuration setting. Please review [ESP-IDF Settings](../SETTINGS.md)) to see how to modify `idf.customExtraVars`.
+> **NOTE** The ESP-IDF Monitor baud rate value is taken from `idf.monitorBaudRate` with fallback on your project's skdconfig `CONFIG_ESPTOOLPY_MONITOR_BAUD` (idf.py monitor' baud rate). This value can also be override by setting the environment variable `IDF_MONITOR_BAUD` or `MONITORBAUD` in your system environment variables or this extension's `idf.customExtraVars` configuration setting. Please review [ESP-IDF Settings](../SETTINGS.md)) to see how to modify `idf.customExtraVars`.
 
 <p>
   <img src="../../media/tutorials/basic_use/monitor.png" alt="Monitor" width="975">

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -69,6 +69,7 @@
   "param.openOcdLaunchArgs": "Arguments to launch openOCD from this extension",
   "param.port": "Path of selected device port",
   "param.flashBaudRate": "ESP-IDF Flash Baud rate",
+  "param.monitorBaudRate": "ESP-IDF Monitor Baud rate",
   "param.pythonBinPath": "Python absolute binary path used to execute ESP-IDF Python Scripts",
   "param.espIdfPath": "Path to locate ESP-IDF framework (IDF_PATH)",
   "param.espAdfPath": "Path to locate ESP-ADF framework (ADF_PATH)",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -68,6 +68,7 @@
   "param.openOcdConfigFilesList": "Lista de archivos de connfiguracion en el directorio OpenOCD Scripts",
   "param.openOcdLaunchArgs": "Argumentos para lanzar openOCD desde esta extensión",
   "param.flashBaudRate": "ESP-IDF Tasa de baudios para flash",
+  "param.monitorBaudRate": "ESP-IDF Tasa de baudios para monitoreo",
   "param.port": "Ruta del puerto serial del dispositivo ESP-IDF",
   "param.pythonBinPath": "Ruta absoluta del ejecutable Python para ESP-IDF",
   "param.toolsPath": "Ruta de las herramientas de ESP-IDF (IDF_TOOLS_PATH)",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -69,6 +69,7 @@
   "param.openOcdLaunchArgs": "Аргументы для запуска openOCD из этого расширения",
   "param.port": "Путь к выбранному порту устройства",
   "param.flashBaudRate": "Скорость загрузки прошивки ESP-IDF",
+  "param.monitorBaudRate": "Скорость передачи данных монитора ESP-IDF",
   "param.pythonBinPath": "Абсолютный путь интерпретатора Python для ESP-IDF",
   "param.espIdfPath": "Путь фреймворкa ESP-IDF (IDF_PATH)",
   "param.espAdfPath": "Путь фреймворка ESP-ADF (ADF_PATH)",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -68,6 +68,7 @@
   "param.openOcdConfigFilesList": "OpenOCD 脚本目录中的配置文件列表",
   "param.openOcdLaunchArgs": "从此扩展启动openOCD的参数",
   "param.flashBaudRate": "ESP-IDF 烧录波特率",
+  "param.monitorBaudRate": "ESP-IDF监视器波特率",
   "param.port": "选中的烧录端口路径",
   "param.pythonBinPath": "项目构建使用的 Python 解释器的绝对路径",
   "param.toolsPath": "IDF_TOOLS_PATH 的路径",

--- a/package.json
+++ b/package.json
@@ -462,6 +462,12 @@
             "description": "%param.flashBaudRate%",
             "scope": "resource"
           },
+          "idf.monitorBaudRate": {
+            "type": "string",
+            "default": "460800",
+            "description": "%param.monitorBaudRate%",
+            "scope": "resource"
+          },
           "idf.openOcdConfigs": {
             "type": "array",
             "default": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -68,6 +68,7 @@
   "param.openOcdConfigFilesList": "List of configuration files inside OpenOCD Scripts directory",
   "param.openOcdLaunchArgs": "Arguments to launch openOCD from this extension",
   "param.flashBaudRate": "ESP-IDF Flash Baud rate",
+  "param.monitorBaudRate": "ESP-IDF Monitor Baud rate",
   "param.port": "Path of selected device port",
   "param.pythonBinPath": "Python absolute binary path used to execute ESP-IDF Python Scripts",
   "param.espIdfPath": "Path to locate ESP-IDF framework (IDF_PATH)",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -144,6 +144,7 @@
     "param.openOcdConfigFilesList",
     "param.openOcdLaunchArgs",
     "param.flashBaudRate",
+    "param.monitorBaudRate",
     "param.port",
     "param.pythonBinPath",
     "param.espIdfPath",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1042,6 +1042,10 @@ export async function activate(context: vscode.ExtensionContext) {
           );
           paramName = "idf.flashBaudRate";
           break;
+        case "monitorBaudRate":
+          msg = "Enter monitor baud rate";
+          paramName = "idf.monitorBaudRate";
+          break;
         case "openOcdConfig":
           msg = locDic.localize(
             "extension.enterOpenOcdConfigMessage",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3170,6 +3170,10 @@ function createQemuMonitor(noReset: boolean = false) {
       noReset,
       serialPort
     );
+    if (monitorTerminal) {
+      monitorTerminal.sendText(ESP.CTRL_RBRACKET);
+      monitorTerminal.dispose();
+    }
     monitorTerminal = idfMonitor.start();
   });
 }
@@ -3209,6 +3213,10 @@ const buildFlashAndMonitor = async (runMonitor: boolean = true) => {
             message: "Launching monitor...",
             increment: 10,
           });
+          if (monitorTerminal) {
+            monitorTerminal.sendText(ESP.CTRL_RBRACKET);
+            monitorTerminal.dispose();
+          }
           createMonitor();
         }
       }
@@ -3318,6 +3326,10 @@ function createMonitor() {
 
 async function createIdfMonitor(noReset: boolean = false) {
   const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset);
+  if (monitorTerminal) {
+    monitorTerminal.sendText(ESP.CTRL_RBRACKET);
+    monitorTerminal.dispose();
+  }
   monitorTerminal = idfMonitor.start();
   if (noReset) {
     const idfPath = idfConf.readParameter(

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -65,6 +65,8 @@ export function parameterToProjectConfigMap(param: string) {
       return currentProjectConf.env;
     case "idf.flashBaudRate":
       return currentProjectConf.flashBaudRate;
+    case "idf.monitorBaudRate":
+      return currentProjectConf.monitorBaudRate;
     case "idf.openOcdDebugLevel":
       return currentProjectConf.openOCD.debugLevel;
     case "idf.openOcdConfigs":

--- a/src/project-conf/projectConfiguration.ts
+++ b/src/project-conf/projectConfiguration.ts
@@ -25,6 +25,7 @@ export interface ProjectConfElement {
   };
   env: { [key: string]: string };
   flashBaudRate: string;
+  monitorBaudRate: string;
   openOCD: {
     debugLevel: number;
     configs: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -372,12 +372,17 @@ export function getConfigValueFromSDKConfig(
 }
 
 export function getMonitorBaudRate(workspacePath: vscode.Uri) {
-  let sdkMonitorBaudRate: string = "";
+  let sdkMonitorBaudRate: string = idfConf.readParameter(
+    "idf.monitorBaudRate",
+    workspacePath
+  ) as string;
   try {
-    sdkMonitorBaudRate = getConfigValueFromSDKConfig(
-      "CONFIG_ESPTOOLPY_MONITOR_BAUD",
-      workspacePath
-    );
+    if (!sdkMonitorBaudRate) {
+      sdkMonitorBaudRate = getConfigValueFromSDKConfig(
+        "CONFIG_ESPTOOLPY_MONITOR_BAUD",
+        workspacePath
+      );
+    }
   } catch (error) {
     const errMsg = error.message
       ? error.message

--- a/src/views/project-conf/components/projectConfElem.vue
+++ b/src/views/project-conf/components/projectConfElem.vue
@@ -45,6 +45,12 @@
       :sections="['flashBaudRate']"
       :updateMethod="updateElement"
     />
+    <StringElement
+      title="Monitor baud rate"
+      :value.sync="el.monitorBaudRate"
+      :sections="['monitorBaudRate']"
+      :updateMethod="updateElement"
+    />
 
     <label class="is-size-4 has-text-weight-bold">OpenOCD</label>
     <div class="small-margin">

--- a/src/views/project-conf/store/index.ts
+++ b/src/views/project-conf/store/index.ts
@@ -45,6 +45,7 @@ export const projectConfigState: IState = {
     },
     env: {},
     flashBaudRate: "",
+    monitorBaudRate: "",
     openOCD: {
       debugLevel: 0,
       configs: [],
@@ -114,6 +115,7 @@ export const mutations: MutationTree<IState> = {
       },
       env: {},
       flashBaudRate: "",
+      monitorBaudRate: "",
       openOCD: {
         debugLevel: 0,
         configs: [],


### PR DESCRIPTION
## Description

Add `idf.monitorBaudRate` configuration setting to define IDF Monitor baud rate in the extension commands.

Delete existing IDF Monitor when re executing the IDF Monitor.

Fixes #926
Fix #903

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "settings.json" and update `idf.monitorBaudRate` to new value
2. Execute `ESP-IDF: Monitor your device` command to start IDF Monitor.
3. Observe results. Check that IDF Monitor is running with desired baud rate.
4. Try `Build, Flash and monitor` twice. The IDF Monitor should be delete and recreated.

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
