### PR TITLE
add idf enableStatusBar setting to show status bar

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -105,6 +105,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`) | User, Remote or Workspace |
 | `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                       | User, Remote or Workspace |
 | `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                    | User, Remote or Workspace |
+| `idf.enableStatusBar`                  | Show or hide the extension status bar items                                 | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -100,6 +100,7 @@
   "param.svdFile": "SVD file to resolve ESP-IDF Peripheral view in Debug view",
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
+  "param.enableStatusBar.title": "Enable ESP-IDF extension status bar items",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -105,6 +105,7 @@
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración luego de IDF Monitor (ms)",
   "param.monitorNoReset": "Habilitar no-reset en el IDF Monitor",
+  "param.enableStatusBar.title": "Habilitar elementos de la barra de estatus de la extension ESP-IDF",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -105,6 +105,7 @@
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "param.monitorStartDelayBeforeDebug": "Задержка запуска сеанса отладки после выполнения монитора IDF (мс)",
   "param.monitorNoReset": "Включить флаг отсутствия сброса для монитора IDF",
+  "param.enableStatusBar.title": "Включить элементы строки состояния расширения ESP-IDF",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -105,6 +105,7 @@
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "param.monitorStartDelayBeforeDebug": "IDF监视器执行后延迟启动调试会话 (ms)",
   "param.monitorNoReset": "对IDF监视器启用无重置标志",
+  "param.enableStatusBar.title": "启用ESP-IDF扩展状态栏项目",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -840,6 +840,12 @@
             "default": false,
             "scope": "resource",
             "description": "%param.monitorNoReset%"
+          },
+          "idf.enableStatusBar": {
+            "type": "boolean",
+            "description": "%param.enableStatusBar.title%",
+            "scope": "resource",
+            "default": true
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -102,6 +102,7 @@
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
+  "param.enableStatusBar.title": "Enable ESP-IDF extension status bar items",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -220,6 +220,7 @@
     "param.preFlashTask",
     "param.postFlashTask",
     "param.svdFile",
-    "param.deleteComponentsOnFullClean"
+    "param.deleteComponentsOnFullClean",
+    "param.enableStatusBar.title"
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,7 +257,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Create a status bar item with current workspace
 
   // Status Bar Item with common commands
-  statusBarItems = creatCmdsStatusBarItems();
+  statusBarItems = createCmdsStatusBarItems();
 
   // Create Kconfig Language Server Client
   KconfigLangClient.startKconfigLangServer(context);
@@ -298,8 +298,10 @@ export async function activate(context: vscode.ExtensionContext) {
   if (PreCheck.isWorkspaceFolderOpen()) {
     workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
     await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
-    statusBarItems["port"].text =
-      "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+    if (statusBarItems && statusBarItems["port"]) {
+      statusBarItems["port"].text =
+        "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+    }
     const coverageOptions = getCoverageOptions(workspaceRoot);
     covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
   }
@@ -353,8 +355,10 @@ export async function activate(context: vscode.ExtensionContext) {
             workspaceRoot,
             statusBarItems["target"]
           );
-          statusBarItems["port"].text =
-            "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+          if (statusBarItems && statusBarItems["port"]) {
+            statusBarItems["port"].text =
+              "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+          }
           const coverageOptions = getCoverageOptions(workspaceRoot);
           covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
           break;
@@ -773,8 +777,10 @@ export async function activate(context: vscode.ExtensionContext) {
           workspaceRoot,
           statusBarItems["target"]
         );
-        statusBarItems["port"].text =
-          "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+        if (statusBarItems && statusBarItems["port"]) {
+          statusBarItems["port"].text =
+            "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+        }
         updateIdfComponentsTree(workspaceRoot);
         const workspaceFolderInfo = {
           clickCommand: "espIdf.pickAWorkspaceFolder",
@@ -1081,7 +1087,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidChangeConfiguration(async (e) => {
     const winFlag = process.platform === "win32" ? "Win" : "";
-    if (e.affectsConfiguration("idf.openOcdConfigs")) {
+    if (e.affectsConfiguration("idf.enableStatusBar")) {
+      const enableStatusBar = idfConf.readParameter(
+        "idf.enableStatusBar",
+        workspaceRoot
+      ) as boolean;
+      if (enableStatusBar) {
+        statusBarItems = createCmdsStatusBarItems();
+      } else if (!enableStatusBar) {
+        for (let statusItem in statusBarItems) {
+          statusBarItems[statusItem].dispose();
+          statusBarItems[statusItem] = undefined;
+        }
+      }
+    } else if (e.affectsConfiguration("idf.openOcdConfigs")) {
       const openOcdConfigFilesList = idfConf.readParameter(
         "idf.openOcdConfigs",
         workspaceRoot
@@ -1105,7 +1124,9 @@ export async function activate(context: vscode.ExtensionContext) {
         target: idfTarget,
       } as IDebugAdapterConfig;
       debugAdapterManager.configureAdapter(debugAdapterConfig);
-      statusBarItems["target"].text = "$(circuit-board) " + idfTarget;
+      if (statusBarItems && statusBarItems["target"]) {
+        statusBarItems["target"].text = "$(circuit-board) " + idfTarget;
+      }
     } else if (e.affectsConfiguration("idf.espIdfPath" + winFlag)) {
       ESP.URL.Docs.IDF_INDEX = undefined;
     } else if (e.affectsConfiguration("idf.qemuTcpPort")) {
@@ -1113,8 +1134,10 @@ export async function activate(context: vscode.ExtensionContext) {
         tcpPort: idfConf.readParameter("idf.qemuTcpPort", workspaceRoot),
       } as IQemuOptions);
     } else if (e.affectsConfiguration("idf.port" + winFlag)) {
-      statusBarItems["port"].text =
-        "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+      if (statusBarItems && statusBarItems["port"]) {
+        statusBarItems["port"].text =
+          "$(plug) " + idfConf.readParameter("idf.port", workspaceRoot);
+      }
     } else if (e.affectsConfiguration("idf.customAdapterTargetName")) {
       let idfTarget = idfConf.readParameter(
         "idf.adapterTargetName",
@@ -1129,7 +1152,9 @@ export async function activate(context: vscode.ExtensionContext) {
           target: idfTarget,
         } as IDebugAdapterConfig;
         debugAdapterManager.configureAdapter(debugAdapterConfig);
-        statusBarItems["target"].text = "$(circuit-board) " + idfTarget;
+        if (statusBarItems && statusBarItems["target"]) {
+          statusBarItems["target"].text = "$(circuit-board) " + idfTarget;
+        }
       }
     } else if (e.affectsConfiguration("openocd.tcl.host")) {
       const tclHost = idfConf.readParameter(
@@ -1154,7 +1179,9 @@ export async function activate(context: vscode.ExtensionContext) {
         "idf.flashType",
         workspaceRoot
       ) as string;
-      statusBarItems["flashType"].text = `$(star-empty) ${flashType}`;
+      if (statusBarItems && statusBarItems["flashType"]) {
+        statusBarItems["flashType"].text = `$(star-empty) ${flashType}`;
+      }
     } else if (e.affectsConfiguration("idf.buildPath")) {
       updateIdfComponentsTree(workspaceRoot);
     }
@@ -2981,7 +3008,13 @@ function registerTreeProvidersForIDFExplorer(context: vscode.ExtensionContext) {
   );
 }
 
-function creatCmdsStatusBarItems() {
+function createCmdsStatusBarItems() {
+  const enableStatusBar = idfConf.readParameter(
+    "idf.enableStatusBar"
+  ) as boolean;
+  if (!enableStatusBar) {
+    return {};
+  }
   const port = idfConf.readParameter("idf.port", workspaceRoot) as string;
   let idfTarget = idfConf.readParameter("idf.adapterTargetName", workspaceRoot);
   let flashType = idfConf.readParameter(

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -22,7 +22,7 @@ import { Logger } from "./logger/logger";
 import * as utils from "./utils";
 import { getSDKConfigFilePath } from "./utils";
 
-export function initSelectedWorkspace(status: vscode.StatusBarItem) {
+export function initSelectedWorkspace(status?: vscode.StatusBarItem) {
   const workspaceRoot = vscode.workspace.workspaceFolders[0].uri;
   updateIdfComponentsTree(workspaceRoot);
   const workspaceFolderInfo = {
@@ -31,7 +31,9 @@ export function initSelectedWorkspace(status: vscode.StatusBarItem) {
     tooltip: vscode.workspace.workspaceFolders[0].uri.fsPath,
     text: "${file-directory}",
   };
-  utils.updateStatus(status, workspaceFolderInfo);
+  if (status) {
+    utils.updateStatus(status, workspaceFolderInfo);
+  }
   return workspaceRoot;
 }
 
@@ -79,7 +81,7 @@ export function getProjectName(buildDir: string): Promise<string> {
 
 export async function getIdfTargetFromSdkconfig(
   workspacePath: vscode.Uri,
-  statusItem: vscode.StatusBarItem
+  statusItem?: vscode.StatusBarItem
 ) {
   let sdkConfigPath = getSDKConfigFilePath(workspacePath);
   const doesSdkconfigExists = await pathExists(sdkConfigPath);
@@ -98,5 +100,7 @@ export async function getIdfTargetFromSdkconfig(
     vscode.ConfigurationTarget.WorkspaceFolder,
     workspacePath
   );
-  statusItem.text = "$(circuit-board) " + idfTarget;
+  if (statusItem) {
+    statusItem.text = "$(circuit-board) " + idfTarget;
+  }
 }


### PR DESCRIPTION
## Description

Add  `idf.enableStatusBar`configuration setting to show or hide the extension status bar items. This settings can be apply as User, workspace or workspace folder setting.

Fixes #927

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open `settings.json` and modify `idf.enableStatusBar` to `true` or `false`.
2. See status bar items appear and disappear
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual UI testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
