### PR TITLE
fix size gui rm util package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1445,7 +1445,6 @@
     "sanitize-html": "^2.7.0",
     "tar-fs": "^2.0.0",
     "tree-kill": "^1.2.2",
-    "util": "^0.12.5",
     "vscode-languageclient": "^5.2.1",
     "vscode-languageserver": "^5.2.1",
     "vscode-nls": "^4.0.0",

--- a/src/views/size/components/ArchiveItemColumn.vue
+++ b/src/views/size/components/ArchiveItemColumn.vue
@@ -12,7 +12,6 @@
 </template>
 
 <script lang="ts">
-import { isNumber } from "util";
 import { Component, Prop, Vue } from "vue-property-decorator";
 
 @Component
@@ -21,7 +20,7 @@ export default class ArchiveItemColumn extends Vue {
   @Prop() propName: string;
 
   convertToKB(byte: number) {
-    return isNumber(byte) ? Math.round(byte / 1024) : 0;
+    return typeof byte === "number" ? Math.round(byte / 1024) : 0;
   }
 }
 </script>

--- a/src/views/size/components/FileTable.vue
+++ b/src/views/size/components/FileTable.vue
@@ -58,14 +58,13 @@
 </template>
 
 <script lang="ts">
-import { isNumber } from "util";
 import { Component, Prop, Vue } from "vue-property-decorator";
 
 @Component
 export default class FileTable extends Vue {
   @Prop() archiveInfo;
   convertToSpacedString(byte: number) {
-    return isNumber(byte) ? byte.toLocaleString("en-US").replace(/,/g, " ") : 0;
+    return typeof byte === "number" ? byte.toLocaleString("en-US").replace(/,/g, " ") : 0;
   }
 
   getArchiveFileProp(fileInfo, firstProp, secondProp) {

--- a/src/views/size/components/Overview.vue
+++ b/src/views/size/components/Overview.vue
@@ -54,7 +54,6 @@
 </template>
 
 <script lang="ts">
-import { isNumber } from "util";
 import { Component, Vue } from "vue-property-decorator";
 import { State } from "vuex-class";
 
@@ -63,7 +62,7 @@ export default class Overview extends Vue {
   @State("overviewData") storeOverviewData;
 
   convertToKB(byte: number) {
-    return isNumber(byte) ? Math.round(byte / 1024) : 0;
+    return typeof byte === "number" ? Math.round(byte / 1024) : 0;
   }
 
   get overviewData() {

--- a/src/views/size/components/ProgressBar.vue
+++ b/src/views/size/components/ProgressBar.vue
@@ -28,7 +28,6 @@
 </template>
 
 <script lang="ts">
-import { isNumber } from "util";
 import { Component, Prop, Vue } from "vue-property-decorator";
 
 @Component
@@ -39,7 +38,7 @@ export default class ProgressBar extends Vue {
   @Prop() name: string;
 
   convertToKB(byte: number) {
-    return isNumber(byte) ? Math.round(byte / 1024) : 0;
+    return typeof byte === "number" ? Math.round(byte / 1024) : 0;
   }
 
   progressBarColorClass(ratio: number) {

--- a/src/views/size/main.ts
+++ b/src/views/size/main.ts
@@ -28,7 +28,6 @@ import search from "@iconify-icons/codicon/search";
 import fileZip from "@iconify-icons/codicon/file-zip";
 import chevronDown from "@iconify-icons/codicon/chevron-down";
 import chevronUp from "@iconify-icons/codicon/chevron-up";
-import { isNumber } from "util";
 IconifyIcon.addIcon("symbol-event", symbolEvent);
 IconifyIcon.addIcon("refresh", refresh);
 IconifyIcon.addIcon("server", server);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -178,7 +178,6 @@ const webViewConfig = {
     },
     fallback: {
       "os": require.resolve("os-browserify/browser"),
-      "util": require.resolve("util"),
       "path": require.resolve("path-browserify")
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,11 +865,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
 axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -2399,13 +2394,6 @@ follow-redirects@^1.13.2, follow-redirects@^1.14.0, follow-redirects@^1.14.8:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
-for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
-
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2537,15 +2525,6 @@ get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
   integrity sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.3"
-
-get-intrinsic@^1.1.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
-  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -2704,13 +2683,6 @@ glogg@^1.0.0:
   integrity sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
   dependencies:
     sparkles "^1.0.0"
-
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
 
 got@^11.8.6:
   version "11.8.6"
@@ -3154,11 +3126,6 @@ is-buffer@^1.1.5, is-buffer@~1.1.6:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.3:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
-  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
-
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -3255,13 +3222,6 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -3392,17 +3352,6 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
     has-symbols "^1.0.2"
-
-is-typed-array@^1.1.10, is-typed-array@^1.1.3:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
-  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
 
 is-unc-path@^1.0.0:
   version "1.0.0"
@@ -6143,17 +6092,6 @@ util.promisify@1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-util@^0.12.5:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -6543,18 +6481,6 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
-
-which-typed-array@^1.1.2:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
-  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.10"
 
 which@2.0.2, which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Description

Fix UI of `ESP-IDF Size analysis of binaries` web view by removing deprecated `util` package

Fixes #938 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF Size analysis of binaries" command
2. Check the size analysis is shown


## How has this been tested?

Manual test in UI

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): Windows MacOS and Linux

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
