### PR TITLE
remove virtualenv install from extension

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -85,24 +85,6 @@ export async function installPythonEnvFromIdfTools(
   const pyEnvPath = await getPythonEnvPath(espDir, idfToolsDir, pythonBinPath);
 
   await execProcessWithLog(
-    `"${pythonBinPath}" -m pip install --user virtualenv`,
-    idfToolsDir,
-    pyTracker,
-    channel,
-    { env: modifiedEnv },
-    cancelToken
-  );
-
-  await execProcessWithLog(
-    `"${pythonBinPath}" -m virtualenv "${pyEnvPath}" -p "${pythonBinPath}"`,
-    idfToolsDir,
-    pyTracker,
-    channel,
-    { env: modifiedEnv },
-    cancelToken
-  );
-
-  await execProcessWithLog(
     `"${pythonBinPath}" "${idfToolsPyPath}" install-python-env`,
     idfToolsDir,
     pyTracker,


### PR DESCRIPTION
## Description

Remove virtualenv install from extension setup process.

Fixes #919 
Fix #949

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Click on "Configure ESP-IDF extension" command.
2. Execute setup process using Python 3.11.
3. Observe results. Install setup should work.

## How has this been tested?

Manual test of setup install

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
