### PR TITLE
add custom offset for flash binaries

### DIFF
--- a/src/espIdf/partition-table/partitionFlasher.ts
+++ b/src/espIdf/partition-table/partitionFlasher.ts
@@ -21,6 +21,7 @@ import { Progress, ProgressLocation, Uri, window } from "vscode";
 import { readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { appendIdfAndToolsToPath, spawn } from "../../utils";
+import { OutputChannel } from "../../logger/outputChannel";
 
 export async function flashBinaryToPartition(
   offset: string,
@@ -50,7 +51,7 @@ export async function flashBinaryToPartition(
           "esptool.py"
         );
 
-        await spawn(
+        const flashingOutput = await spawn(
           pythonBinPath,
           [esptoolPath, "-p", serialPort, "write_flash", offset, binPath],
           {
@@ -64,7 +65,7 @@ export async function flashBinaryToPartition(
       } catch (error) {
         let msg = error.message
           ? error.message
-          : "Error getting partitions from device";
+          : "Error flashing binary to device";
         Logger.errorNotify(msg, error);
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,6 +138,7 @@ export function spawn(
   let buff = Buffer.alloc(0);
   const sendToOutputChannel = (data: Buffer) => {
     buff = Buffer.concat([buff, data]);
+    OutputChannel.append(data.toString());
   };
   return new Promise((resolve, reject) => {
     options.cwd = options.cwd || path.resolve(path.join(__dirname, ".."));


### PR DESCRIPTION
## Description

Add the option for custom offset for flashing a binary to a given hexadecimal offset.

Fixes #934

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Right click on a binary (.bin) and  run the "Flash binary to partition..." command.
2. Select custom offset and enter as hexadecimal value (example 0x8000).
3. See the output in the ESP-IDF Output channel of the visual studio code.
4. Observe results.

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
