### PR TITLE
use monitor baud rate setting on version 5 or up

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -47,21 +47,21 @@ This is how the extension uses them:
 
 These settings are specific to the ESP32 Chip/ Board
 
-| Setting                                          | Description                                                                      | Scope                     |
-| ------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------- |
-| `idf.adapterTargetName`                          | ESP-IDF target Chip (Example: esp32)                                             |                           |
-| `idf.customAdapterTargetName`                    | Custom target name for ESP-IDF Debug Adapter                                     |                           |
-| `idf.flashBaudRate`                              | Flash Baud rate                                                                  |                           |
-| `idf.monitorBaudRate`                            | Monitor Baud rate                                                                |                           |
-| `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder              |                           |
-| `idf.openOcdLaunchArgs`                          | Launch arguments for OpenOCD before idf.openOcdDebugLevel and idf.openOcdConfigs |                           |
-| `idf.openOcdDebugLevel`                          | Set openOCD debug level (0-4) Default: 2                                         |                           |
-| `idf.port`                                       | Path of selected device port                                                     |                           |
-| `idf.portWin`                                    | Path of selected device port in Windows                                          |                           |
-| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`                | User, Remote or Workspace |
-| `idf.listDfuDevices`                             | List of DFU devices connected to USB                                             | User, Remote or Workspace |
-| `idf.selectedDfuDevicePath`                      | Selected DFU device connected to USB                                             | User, Remote or Workspace |
-| `idf.svdFilePath`                                | SVD file absolute path to resolve chip debug peripheral tree view                | User, Remote or Workspace |
+| Setting                                          | Description                                                                            | Scope                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------- |
+| `idf.adapterTargetName`                          | ESP-IDF target Chip (Example: esp32)                                                   |                           |
+| `idf.customAdapterTargetName`                    | Custom target name for ESP-IDF Debug Adapter                                           |                           |
+| `idf.flashBaudRate`                              | Flash Baud rate                                                                        |                           |
+| `idf.monitorBaudRate`                            | Monitor Baud rate (Empty by default to use sdkconfig CONFIG_ESP_CONSOLE_UART_BAUDRATE) |                           |
+| `idf.openOcdConfigs`                             | Configuration files for OpenOCD. Relative to OPENOCD_SCRIPTS folder                    |                           |
+| `idf.openOcdLaunchArgs`                          | Launch arguments for OpenOCD before idf.openOcdDebugLevel and idf.openOcdConfigs       |                           |
+| `idf.openOcdDebugLevel`                          | Set openOCD debug level (0-4) Default: 2                                               |                           |
+| `idf.port`                                       | Path of selected device port                                                           |                           |
+| `idf.portWin`                                    | Path of selected device port in Windows                                                |                           |
+| `openocd.jtag.command.force_unix_path_separator` | Forced to use `/` as path sep. for Win32 based OS instead of `\\`                      | User, Remote or Workspace |
+| `idf.listDfuDevices`                             | List of DFU devices connected to USB                                                   | User, Remote or Workspace |
+| `idf.selectedDfuDevicePath`                      | Selected DFU device connected to USB                                                   | User, Remote or Workspace |
+| `idf.svdFilePath`                                | SVD file absolute path to resolve chip debug peripheral tree view                      | User, Remote or Workspace |
 
 This is how the extension uses them:
 

--- a/package.json
+++ b/package.json
@@ -464,7 +464,7 @@
           },
           "idf.monitorBaudRate": {
             "type": "string",
-            "default": "115200",
+            "default": "",
             "description": "%param.monitorBaudRate%",
             "scope": "resource"
           },

--- a/package.json
+++ b/package.json
@@ -464,7 +464,7 @@
           },
           "idf.monitorBaudRate": {
             "type": "string",
-            "default": "460800",
+            "default": "115200",
             "description": "%param.monitorBaudRate%",
             "scope": "resource"
           },

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -71,7 +71,7 @@ export async function createNewIdfMonitor(
   }
   const idfPath = readParameter("idf.espIdfPath", workspaceFolder) as string;
   const idfVersion = await utils.getEspIdfFromCMake(idfPath);
-  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(workspaceFolder, idfVersion);
+  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(workspaceFolder);
   const idfMonitorToolPath = join(idfPath, "tools", "idf_monitor.py");
   if (!utils.canAccessFile(idfMonitorToolPath, R_OK)) {
     Logger.errorNotify(

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -59,7 +59,6 @@ export async function createNewIdfMonitor(
       new Error("NOT_SELECTED_PORT")
     );
   }
-  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(workspaceFolder);
   const pythonBinPath = readParameter(
     "idf.pythonBinPath",
     workspaceFolder
@@ -72,6 +71,7 @@ export async function createNewIdfMonitor(
   }
   const idfPath = readParameter("idf.espIdfPath", workspaceFolder) as string;
   const idfVersion = await utils.getEspIdfFromCMake(idfPath);
+  let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(workspaceFolder, idfVersion);
   const idfMonitorToolPath = join(idfPath, "tools", "idf_monitor.py");
   if (!utils.canAccessFile(idfMonitorToolPath, R_OK)) {
     Logger.errorNotify(

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -56,9 +56,9 @@ export class IDFMonitor {
     this.terminal.show();
     this.terminal.dispose = this.dispose.bind(this);
     const baudRateToUse =
+      this.config.baudRate ||
       modifiedEnv.IDF_MONITOR_BAUD ||
       modifiedEnv.MONITORBAUD ||
-      this.config.baudRate ||
       "115200";
     const args = [
       this.config.pythonBinPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2630,8 +2630,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const idfVersion = await utils.getEspIdfFromCMake(idfPath);
         let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
-          workspaceRoot,
-          idfVersion
+          workspaceRoot
         );
         const noReset = idfConf.readParameter(
           "idf.monitorNoReset",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2585,9 +2585,6 @@ export async function activate(context: vscode.ExtensionContext) {
             new Error("NOT_SELECTED_PORT")
           );
         }
-        let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
-          workspaceRoot
-        );
         const pythonBinPath = idfConf.readParameter(
           "idf.pythonBinPath",
           workspaceRoot
@@ -2632,6 +2629,10 @@ export async function activate(context: vscode.ExtensionContext) {
         const elfFilePath = path.join(buildDirPath, `${projectName}.elf`);
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const idfVersion = await utils.getEspIdfFromCMake(idfPath);
+        let sdkMonitorBaudRate: string = utils.getMonitorBaudRate(
+          workspaceRoot,
+          idfVersion
+        );
         const noReset = idfConf.readParameter(
           "idf.monitorNoReset",
           workspaceRoot

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -430,8 +430,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(sdkDeleteWatchDisposable);
 
-  vscode.window.onDidCloseTerminal(async (terminal: vscode.Terminal) => {
-  });
+  vscode.window.onDidCloseTerminal(async (terminal: vscode.Terminal) => {});
 
   registerIDFCommand("espIdf.createFiles", async () => {
     PreCheck.perform([openFolderCheck], async () => {
@@ -1272,7 +1271,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.debug.registerDebugAdapterTrackerFactory("espidf", {
     createDebugAdapterTracker(session: vscode.DebugSession) {
       return {
-        onWillReceiveMessage: (m) => { },
+        onWillReceiveMessage: (m) => {},
       };
     },
   });
@@ -1391,8 +1390,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-                ? error
-                : "Error installing Python requirements";
+              ? error
+              : "Error installing Python requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1457,8 +1456,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-                ? error
-                : "Error installing ESP-Matter Python Requirements";
+              ? error
+              : "Error installing ESP-Matter Python Requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1646,10 +1645,10 @@ export async function activate(context: vscode.ExtensionContext) {
               setupArgs = setupArgs
                 ? setupArgs
                 : await getSetupInitialValues(
-                  context.extensionPath,
-                  progress,
-                  workspaceRoot
-                );
+                    context.extensionPath,
+                    progress,
+                    workspaceRoot
+                  );
               SetupPanel.createOrShow(context.extensionPath, setupArgs);
             } catch (error) {
               Logger.errorNotify(error.message, error);
@@ -2045,8 +2044,8 @@ export async function activate(context: vscode.ExtensionContext) {
         typeof appTraceTreeDataProvider.appTraceButton.label === "string"
           ? appTraceTreeDataProvider.appTraceButton.label.match(/start/gi)
           : appTraceTreeDataProvider.appTraceButton.label.label.match(
-            /start/gi
-          );
+              /start/gi
+            );
       if (appTraceLabel) {
         await appTraceManager.start(workspaceRoot);
       } else {
@@ -2064,8 +2063,8 @@ export async function activate(context: vscode.ExtensionContext) {
           typeof appTraceTreeDataProvider.heapTraceButton.label === "string"
             ? appTraceTreeDataProvider.heapTraceButton.label.match(/start/gi)
             : appTraceTreeDataProvider.heapTraceButton.label.label.match(
-              /start/gi
-            );
+                /start/gi
+              );
         if (heapTraceLabel) {
           await gdbHeapTraceManager.start(workspaceRoot);
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -431,14 +431,6 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(sdkDeleteWatchDisposable);
 
   vscode.window.onDidCloseTerminal(async (terminal: vscode.Terminal) => {
-    const terminalPid = await terminal.processId;
-    const monitorTerminalPid = monitorTerminal
-      ? await monitorTerminal.processId
-      : -1;
-    if (monitorTerminalPid === terminalPid) {
-      monitorTerminal = undefined;
-      kill(monitorTerminalPid, "SIGKILL");
-    }
   });
 
   registerIDFCommand("espIdf.createFiles", async () => {
@@ -1280,7 +1272,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.debug.registerDebugAdapterTrackerFactory("espidf", {
     createDebugAdapterTracker(session: vscode.DebugSession) {
       return {
-        onWillReceiveMessage: (m) => {},
+        onWillReceiveMessage: (m) => { },
       };
     },
   });
@@ -1399,8 +1391,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-              ? error
-              : "Error installing Python requirements";
+                ? error
+                : "Error installing Python requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1465,8 +1457,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-              ? error
-              : "Error installing ESP-Matter Python Requirements";
+                ? error
+                : "Error installing ESP-Matter Python Requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1654,10 +1646,10 @@ export async function activate(context: vscode.ExtensionContext) {
               setupArgs = setupArgs
                 ? setupArgs
                 : await getSetupInitialValues(
-                    context.extensionPath,
-                    progress,
-                    workspaceRoot
-                  );
+                  context.extensionPath,
+                  progress,
+                  workspaceRoot
+                );
               SetupPanel.createOrShow(context.extensionPath, setupArgs);
             } catch (error) {
               Logger.errorNotify(error.message, error);
@@ -2053,8 +2045,8 @@ export async function activate(context: vscode.ExtensionContext) {
         typeof appTraceTreeDataProvider.appTraceButton.label === "string"
           ? appTraceTreeDataProvider.appTraceButton.label.match(/start/gi)
           : appTraceTreeDataProvider.appTraceButton.label.label.match(
-              /start/gi
-            );
+            /start/gi
+          );
       if (appTraceLabel) {
         await appTraceManager.start(workspaceRoot);
       } else {
@@ -2072,8 +2064,8 @@ export async function activate(context: vscode.ExtensionContext) {
           typeof appTraceTreeDataProvider.heapTraceButton.label === "string"
             ? appTraceTreeDataProvider.heapTraceButton.label.match(/start/gi)
             : appTraceTreeDataProvider.heapTraceButton.label.label.match(
-                /start/gi
-              );
+              /start/gi
+            );
         if (heapTraceLabel) {
           await gdbHeapTraceManager.start(workspaceRoot);
         } else {
@@ -3225,7 +3217,7 @@ function createQemuMonitor(noReset: boolean = false) {
     );
     if (monitorTerminal) {
       monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-      monitorTerminal.dispose();
+      monitorTerminal.sendText(`exit`);
     }
     monitorTerminal = idfMonitor.start();
   });
@@ -3268,7 +3260,7 @@ const buildFlashAndMonitor = async (runMonitor: boolean = true) => {
           });
           if (monitorTerminal) {
             monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-            monitorTerminal.dispose();
+            monitorTerminal.sendText(`exit`);
           }
           createMonitor();
         }
@@ -3381,7 +3373,7 @@ async function createIdfMonitor(noReset: boolean = false) {
   const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset);
   if (monitorTerminal) {
     monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-    monitorTerminal.dispose();
+    monitorTerminal.sendText(`exit`);
   }
   monitorTerminal = idfMonitor.start();
   if (noReset) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -372,30 +372,24 @@ export function getConfigValueFromSDKConfig(
   return match ? match[1] : "";
 }
 
-export function getMonitorBaudRate(
-  workspacePath: vscode.Uri,
-  idfVersion: string
-) {
+export function getMonitorBaudRate(workspacePath: vscode.Uri) {
   let sdkMonitorBaudRate = "";
-  if (idfVersion >= "5.0") {
+  try {
     sdkMonitorBaudRate = idfConf.readParameter(
       "idf.monitorBaudRate",
       workspacePath
     ) as string;
-  } else {
-    try {
-      if (!sdkMonitorBaudRate) {
-        sdkMonitorBaudRate = getConfigValueFromSDKConfig(
-          "CONFIG_ESPTOOLPY_MONITOR_BAUD",
-          workspacePath
-        );
-      }
-    } catch (error) {
-      const errMsg = error.message
-        ? error.message
-        : "Error reading CONFIG_ESPTOOLPY_MONITOR_BAUD from sdkconfig";
-      Logger.error(errMsg, error);
+    if (!sdkMonitorBaudRate) {
+      sdkMonitorBaudRate = getConfigValueFromSDKConfig(
+        "CONFIG_ESP_CONSOLE_UART_BAUDRATE",
+        workspacePath
+      );
     }
+  } catch (error) {
+    const errMsg = error.message
+      ? error.message
+      : "ERROR reading CONFIG_ESP_CONSOLE_UART_BAUDRATE from sdkconfig";
+    Logger.error(errMsg, error);
   }
   return sdkMonitorBaudRate;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -372,7 +372,10 @@ export function getConfigValueFromSDKConfig(
   return match ? match[1] : "";
 }
 
-export function getMonitorBaudRate(workspacePath: vscode.Uri, idfVersion: string) {
+export function getMonitorBaudRate(
+  workspacePath: vscode.Uri,
+  idfVersion: string
+) {
   let sdkMonitorBaudRate = "";
   if (idfVersion >= "5.0") {
     sdkMonitorBaudRate = idfConf.readParameter(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -372,23 +372,27 @@ export function getConfigValueFromSDKConfig(
   return match ? match[1] : "";
 }
 
-export function getMonitorBaudRate(workspacePath: vscode.Uri) {
-  let sdkMonitorBaudRate: string = idfConf.readParameter(
-    "idf.monitorBaudRate",
-    workspacePath
-  ) as string;
-  try {
-    if (!sdkMonitorBaudRate) {
-      sdkMonitorBaudRate = getConfigValueFromSDKConfig(
-        "CONFIG_ESPTOOLPY_MONITOR_BAUD",
-        workspacePath
-      );
+export function getMonitorBaudRate(workspacePath: vscode.Uri, idfVersion: string) {
+  let sdkMonitorBaudRate = "";
+  if (idfVersion >= "5.0") {
+    sdkMonitorBaudRate = idfConf.readParameter(
+      "idf.monitorBaudRate",
+      workspacePath
+    ) as string;
+  } else {
+    try {
+      if (!sdkMonitorBaudRate) {
+        sdkMonitorBaudRate = getConfigValueFromSDKConfig(
+          "CONFIG_ESPTOOLPY_MONITOR_BAUD",
+          workspacePath
+        );
+      }
+    } catch (error) {
+      const errMsg = error.message
+        ? error.message
+        : "Error reading CONFIG_ESPTOOLPY_MONITOR_BAUD from sdkconfig";
+      Logger.error(errMsg, error);
     }
-  } catch (error) {
-    const errMsg = error.message
-      ? error.message
-      : "Error reading CONFIG_ESPTOOLPY_MONITOR_BAUD from sdkconfig";
-    Logger.error(errMsg, error);
   }
   return sdkMonitorBaudRate;
 }


### PR DESCRIPTION
## Description

The `idf.monitorBaudRate` setting should be used for ESP-IDF version 5.0 or newer.

Fixes #963

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF Monitor your device" for ESP-IDF v.4.4
2. Check monitor baud rate being used is the same from sdkconfig value.
3. Click on "ESP-IDF Monitor your device" for ESP-IDF 5.0
4. Check monitor baud rate being used is the same from `idf.monitorBaudRate` value.

## How has this been tested?

Manual testing.

**Test Configuration**:
* ESP-IDF Version: 4.4 and 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
