### PR TITLE
add enableSizeTaskAfterBuildTask setting

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -107,6 +107,7 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                       | User, Remote or Workspace |
 | `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                    | User, Remote or Workspace |
 | `idf.enableStatusBar`                  | Show or hide the extension status bar items                                 | User, Remote or Workspace |
+| `idf.enableSizeTaskAfterBuildTask`     | Enable IDF Size task to be executed after IDF Build task                    | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -102,6 +102,7 @@
   "param.deleteComponentsOnFullClean": "Delete managed_components on full clean project command",
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "param.enableStatusBar.title": "Enable ESP-IDF extension status bar items",
+  "param.enableSizeTaskAfterBuildTask.title": "Enable IDF Size task after build task",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -107,6 +107,7 @@
   "param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración luego de IDF Monitor (ms)",
   "param.monitorNoReset": "Habilitar no-reset en el IDF Monitor",
   "param.enableStatusBar.title": "Habilitar elementos de la barra de estatus de la extension ESP-IDF",
+  "param.enableSizeTaskAfterBuildTask.title": "Habilitar la tarea de IDF Size luego de la tarea IDF Build",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -107,6 +107,7 @@
   "param.monitorStartDelayBeforeDebug": "Задержка запуска сеанса отладки после выполнения монитора IDF (мс)",
   "param.monitorNoReset": "Включить флаг отсутствия сброса для монитора IDF",
   "param.enableStatusBar.title": "Включить элементы строки состояния расширения ESP-IDF",
+  "param.enableSizeTaskAfterBuildTask.title": "Включить задачу размера IDF после задачи сборки",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -107,6 +107,7 @@
   "param.monitorStartDelayBeforeDebug": "IDF监视器执行后延迟启动调试会话 (ms)",
   "param.monitorNoReset": "对IDF监视器启用无重置标志",
   "param.enableStatusBar.title": "启用ESP-IDF扩展状态栏项目",
+  "param.enableSizeTaskAfterBuildTask.title": "在生成任务后启用IDF大小任务",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -852,6 +852,12 @@
             "description": "%param.enableStatusBar.title%",
             "scope": "resource",
             "default": true
+          },
+          "idf.enableSizeTaskAfterBuildTask": {
+            "type": "boolean",
+            "description": "%param.enableSizeTaskAfterBuildTask.title%",
+            "scope": "resource",
+            "default": true
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -121,6 +121,7 @@
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
   "param.enableCCache.title": "Enable CCache in build task",
+  "param.enableSizeTaskAfterBuildTask.title": "Enable IDF Size task after build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -222,6 +222,7 @@
     "param.postFlashTask",
     "param.svdFile",
     "param.deleteComponentsOnFullClean",
-    "param.enableStatusBar.title"
+    "param.enableStatusBar.title",
+    "param.enableSizeTaskAfterBuildTask.title"
   ]
 }

--- a/src/build/buildCmd.ts
+++ b/src/build/buildCmd.ts
@@ -39,7 +39,6 @@ export async function buildCommand(
 ) {
   let continueFlag = true;
   const buildTask = new BuildTask(workspace);
-  const sizeTask = new IdfSizeTask(workspace);
   const customTask = new CustomTask(workspace);
   if (BuildTask.isBuilding || FlashTask.isFlashing) {
     const waitProcessIsFinishedMsg = locDic.localize(
@@ -61,20 +60,27 @@ export async function buildCommand(
     customTask.addCustomTask(CustomTaskType.PreBuild);
     await buildTask.build();
     await TaskManager.runTasks();
-    await sizeTask.getSizeInfo();
+    const enableSizeTask = (await readParameter(
+      "idf.enableSizeTaskAfterBuildTask",
+      workspace
+    )) as boolean;
+    if (enableSizeTask) {
+      const sizeTask = new IdfSizeTask(workspace);
+      await sizeTask.getSizeInfo();
+    }
     customTask.addCustomTask(CustomTaskType.PostBuild);
     await TaskManager.runTasks();
     if (flashType === ESP.FlashType.DFU) {
-      const buildPath = readParameter(
-        "idf.buildPath",
-        workspace
-      ) as string;
+      const buildPath = readParameter("idf.buildPath", workspace) as string;
       if (!(await pathExists(join(buildPath, "flasher_args.json")))) {
         return Logger.warnNotify(
           "flasher_args.json file is missing from the build directory, can't proceed, please build properly!!"
         );
       }
-      const adapterTargetName = readParameter("idf.adapterTargetName", workspace) as string;
+      const adapterTargetName = readParameter(
+        "idf.adapterTargetName",
+        workspace
+      ) as string;
       if (adapterTargetName !== "esp32s2" && adapterTargetName !== "esp32s3") {
         return Logger.warnNotify(
           `The selected device target "${adapterTargetName}" is not compatible for DFU, as a result the DFU.bin was not created.`


### PR DESCRIPTION
## Description

Add `idf.enableSizeTaskAfterBuildTask` to enable or disable the IDF Size task after the build task.

Fixes #954

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open any ESP-IDF project.
2. Click on "ESP-IDF: Build your project" command and check that the IDF Size task is executed. This is the default behavior.
3. Set `idf.enableSizeTaskAfterBuildTask: false` in settings.json.
4. Click on "ESP-IDF: Build your project" command and check that the IDF Size task is not executed.

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
