### PR TITLE
ESP-Matter: Zap installation no longer needed

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -245,68 +245,6 @@ export async function installEspMatterPyReqs(
   );
   return virtualEnvPython;
 }
-
-export async function installMatterZapCli(
-  espDir: string,
-  idfToolsDir: string,
-  espMatterDir: string,
-  pythonBinPath: string,
-  pyTracker?: PyReqLog,
-  channel?: OutputChannel,
-  cancelToken?: CancellationToken
-) {
-  const matterDir = path.join(
-    espMatterDir,
-    "connectedhomeip",
-    "connectedhomeip"
-  );
-
-  const modifiedEnv: { [key: string]: string } = <{ [key: string]: string }>(
-    Object.assign({}, process.env)
-  );
-  const opts = { env: modifiedEnv };
-  const pyEnvPath = await getPythonEnvPath(espDir, idfToolsDir, pythonBinPath);
-  const pyDir =
-    process.platform === "win32"
-      ? ["Scripts", "python.exe"]
-      : ["bin", "python"];
-  const virtualEnvPython = path.join(pyEnvPath, ...pyDir);
-
-  const pyFileDoesNotExists = " doesn't exist. Make sure the path is correct.";
-  const zapDownloadPyFile = path.join(
-    matterDir,
-    "scripts",
-    "tools",
-    "zap",
-    "zap_download.py"
-  );
-  if (!utils.canAccessFile(zapDownloadPyFile, constants.R_OK)) {
-    Logger.warnNotify(zapDownloadPyFile + pyFileDoesNotExists);
-    if (channel) {
-      channel.appendLine(zapDownloadPyFile + pyFileDoesNotExists);
-    }
-    throw new Error();
-  }
-  const installMatterZapCliPyPkgsMsg = `Installing zap-cli...\n`;
-  Logger.info(installMatterZapCliPyPkgsMsg);
-  if (pyTracker) {
-    pyTracker.Log = installMatterZapCliPyPkgsMsg;
-  }
-  if (channel) {
-    channel.appendLine(installMatterZapCliPyPkgsMsg + "\n");
-  }
-  return (
-    await execProcessWithLog(
-      `"${virtualEnvPython}" "${matterDir}/scripts/tools/zap/zap_download.py" --sdk-root "${matterDir}" --zap RELEASE --zap-version v2023.03.27-nightly --extract-root .zap  2>/dev/null | cut -d= -f2`,
-      matterDir,
-      pyTracker,
-      channel,
-      opts,
-      cancelToken
-    )
-  ).replace(/(\n|\r)+$/, "");
-}
-
 export async function execProcessWithLog(
   cmd: string,
   workDir: string,
@@ -329,7 +267,6 @@ export async function execProcessWithLog(
   if (channel) {
     channel.appendLine(processResult + "\n");
   }
-  return processResult;
 }
 
 export async function getPythonEnvPath(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -964,7 +964,12 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     );
     modifiedEnv.ZAP_INSTALL_PATH = path.join(
       modifiedEnv.ESP_MATTER_PATH,
-      ".zap"
+      "connectedhomeip",
+      "connectedhomeip",
+      ".environment",
+      "cipd",
+      "packages",
+      "zap"
     );
   }
 


### PR DESCRIPTION
## Description
Now is installed when bootstrapping Matter and the the installation path has changed, so `ZAP_INSTALL_PATH` has been also updated.

See https://github.com/espressif/esp-matter/commit/592e1358f3809893bb5fef919a561e513ce936c8


## Type of change
- Small change (non-breaking change which fixes an issue)

## Steps to test this pull request

Launch ESP-Matter install command, then try to build an esp-matter project.

## How has this been tested?

Same than above.

**Test Configuration**:
* ESP-IDF Version: 4.4.3
* OS (Windows,Linux and macOS): Linux

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- Verified on all platforms
  - [X] Linux
  - [ ] macOS
