### PR TITLE
Add consistency messages for flashing

### DIFF
--- a/src/build/buildCmd.ts
+++ b/src/build/buildCmd.ts
@@ -71,7 +71,7 @@ export async function buildCommand(
       ) as string;
       if (!(await pathExists(join(buildPath, "flasher_args.json")))) {
         return Logger.warnNotify(
-          "flasher_args.json file is missing from the build directory, can't proceed, please build properly!!"
+          "flasher_args.json file is missing from the build directory, can't proceed, please build properly!"
         );
       }
       const adapterTargetName = readParameter("idf.adapterTargetName", workspace) as string;

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -188,7 +188,7 @@ export class DebugAdapterManager extends EventEmitter {
       this.adapter.stderr.on("data", (data) => {
         data = typeof data === "string" ? Buffer.from(data) : data;
         this.sendToOutputChannel(data);
-        OutputChannel.append(data.toString(), "Debug Adapter");
+        OutputChannel.appendLine(data.toString(), "Debug Adapter");
         Logger.info(data.toString());
         this.emit("error", data, this.chan);
       });
@@ -196,7 +196,7 @@ export class DebugAdapterManager extends EventEmitter {
       this.adapter.stdout.on("data", (data) => {
         data = typeof data === "string" ? Buffer.from(data) : data;
         this.sendToOutputChannel(data);
-        OutputChannel.append(data.toString(), "Debug Adapter");
+        OutputChannel.appendLine(data.toString(), "Debug Adapter");
         Logger.info(data.toString());
         this.emit("data", this.chan);
         if (data.toString().trim().endsWith("DEBUG_ADAPTER_READY2CONNECT")) {

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -224,10 +224,10 @@ export class OpenOCDManager extends EventEmitter {
         )}`;
         const err = new Error(errorMsg);
         Logger.errorNotify(errorMsg + `\n❌ ${errStr}`, err);
-        OutputChannel.append(`❌ ${errStr}`, "OpenOCD");
+        OutputChannel.appendLine(`❌ ${errStr}`, "OpenOCD");
         this.emit("error", err, this.chan);
       }
-      OutputChannel.append(errStr, "OpenOCD");
+      OutputChannel.appendLine(errStr, "OpenOCD");
       Logger.info(errStr);
     });
     this.server.stdout.on("data", (data) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -549,9 +549,9 @@ export async function activate(context: vscode.ExtensionContext) {
       ) as string;
       const buildDirExists = await utils.dirExistPromise(buildDir);
       if (!buildDirExists) {
-        return Logger.warnNotify(
-          `There is no build directory to clean, exiting!`
-        );
+        const errStr = "There is no build directory to clean, exiting!";
+        OutputChannel.appendLineAndShow(errStr);
+        return Logger.warnNotify(errStr);
       }
       if (ConfserverProcess.exists()) {
         const closingSDKConfigMsg = `Trying to delete the build folder. Closing existing SDK Configuration editor process...`;
@@ -565,14 +565,14 @@ export async function activate(context: vscode.ExtensionContext) {
         constants.R_OK
       );
       if (!doesCmakeCacheExists) {
-        return Logger.warnNotify(
-          `There is no CMakeCache.txt. Please try to delete the build directory manually.`
-        );
+        const errStr = `There is no CMakeCache.txt. Please try to delete the build directory manually.`;
+        OutputChannel.appendLineAndShow(errStr);
+        return Logger.warnNotify(errStr);
       }
       if (BuildTask.isBuilding || FlashTask.isFlashing) {
-        return Logger.warnNotify(
-          `There is a build or flash task running. Wait for it to finish or cancel them before clean.`
-        );
+        const errStr = `There is a build or flash task running. Wait for it to finish or cancel them before clean.`;
+        OutputChannel.appendLineAndShow(errStr);
+        return Logger.warnNotify(errStr);
       }
 
       try {
@@ -592,6 +592,7 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         }
       } catch (error) {
+        OutputChannel.appendLineAndShow(error.message);
         Logger.errorNotify(error.message, error);
       }
     });
@@ -2429,7 +2430,7 @@ export async function activate(context: vscode.ExtensionContext) {
             accountDetails.password
           );
           await rainMakerTreeDataProvider.refresh();
-          Logger.infoNotify("Rainmaker Cloud Linking Success!!");
+          Logger.infoNotify("Rainmaker Cloud Linking Success!");
         } catch (error) {
           return Logger.errorNotify(
             "Failed to login with Rainmaker Cloud, double check your id and password",
@@ -2949,7 +2950,7 @@ export async function activate(context: vscode.ExtensionContext) {
               await RainmakerAPIClient.exchangeCodeForTokens(code);
               await rainMakerTreeDataProvider.refresh();
               Logger.infoNotify(
-                "Rainmaker Cloud is connected successfully (via OAuth)!!"
+                "Rainmaker Cloud is connected successfully (via OAuth)!"
               );
             }
           );

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -26,14 +26,15 @@ import { CustomTask, CustomTaskType } from "../customTasks/customTaskProvider";
 import { TaskManager } from "../taskManager";
 import { Uri } from "vscode";
 import { join } from "path";
+import { OutputChannel } from "../logger/outputChannel";
 
 export async function jtagFlashCommand(workspace: Uri) {
   let continueFlag = true;
   const isOpenOCDLaunched = await OpenOCDManager.init().promptUserToLaunchOpenOCDServer();
   if (!isOpenOCDLaunched) {
-    return Logger.warnNotify(
-      "Can't perform JTag flash, because OpenOCD server is not running!!"
-    );
+    const errStr = "Can't perform JTag flash, because OpenOCD server is not running!";
+    OutputChannel.appendLineAndShow(errStr, "Flash");
+    return Logger.warnNotify(errStr);
   }
   FlashTask.isFlashing = true;
   const host = readParameter("openocd.tcl.host", workspace);
@@ -60,9 +61,12 @@ export async function jtagFlashCommand(workspace: Uri) {
     );
     customTask.addCustomTask(CustomTaskType.PostFlash);
     await customTask.runTasks(CustomTaskType.PostFlash);
-    Logger.infoNotify("⚡️ Flashed Successfully (JTag)");
+    const msg = "⚡️ Flashed Successfully (JTag)";
+    OutputChannel.appendLineAndShow(msg, "Flash");
+    Logger.infoNotify(msg);
   } catch (msg) {
     OpenOCDManager.init().showOutputChannel(true);
+    OutputChannel.appendLine(msg, "Flash");
     Logger.errorNotify(msg, new Error("JTAG_FLASH_FAILED"));
     continueFlag = false;
   }

--- a/src/logger/outputChannel.ts
+++ b/src/logger/outputChannel.ts
@@ -38,6 +38,11 @@ export class OutputChannel {
     OutputChannel.instance.append(message);
   }
 
+  public static appendLineAndShow(message: string, name?: string) {
+    OutputChannel.appendLine(message, name || undefined);
+    OutputChannel.show();
+  }
+
   public static end() {
     OutputChannel.checkInitialized();
     OutputChannel.instance.dispose();

--- a/src/qemu/mergeFlashBin.ts
+++ b/src/qemu/mergeFlashBin.ts
@@ -59,7 +59,7 @@ export async function validateReqs(
   const flasherArgsJsonExists = await pathExists(flasherArgsJsonPath);
   if (!flasherArgsJsonExists) {
     throw new Error(
-      "flasher_args.json file is missing from the build directory, can't proceed, please build properly!!"
+      "flasher_args.json file is missing from the build directory, can't proceed, please build properly!"
     );
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,7 +138,7 @@ export function spawn(
   let buff = Buffer.alloc(0);
   const sendToOutputChannel = (data: Buffer) => {
     buff = Buffer.concat([buff, data]);
-    OutputChannel.append(data.toString());
+    OutputChannel.appendLine(data.toString());
   };
   return new Promise((resolve, reject) => {
     options.cwd = options.cwd || path.resolve(path.join(__dirname, ".."));


### PR DESCRIPTION
## Description

- Flashing will always display output window when finished
- Remove extra "!" from messages
- Add same message behaviour for "Full Clean" command as in Flashing
- Fix OutChannel messages, add new line before Tag

Fixes [#966 ](https://github.com/espressif/vscode-esp-idf-extension/issues/966)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Flash a project to a chip. 

- Expected behaviour:

Output windows should be shown with either an error message / successful message, depending on flash outcome. (Previously the behaviour would be different. E.g.: for UART and DFU, "Output" window was not displayed after flashing was finished / unsuccessful, while for JTAG the "Output" windows would be shown)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Flashed successfully with JTAG  (Output window got focused and displayed relevant message after process finished)
- Flashed successfully with UART (Output window got focused and displayed relevant message after process finished)
- Flashed successfully with DFU (Output window got focused and displayed relevant message after process finished)
- Flashed unsuccessfully with JTAG (Output window got focused and displayed relevant message after process finished)
- Flashed unsuccessfully with UART (Output window got focused and displayed relevant message after process finished)
- Flashed unsuccessfully with DFU (Output window got focused and displayed relevant message after process finished)

**Test Configuration**:
* ESP-IDF Version: 5.1.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ x ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
