### PR TITLE
add custom terminal executable settings

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -92,22 +92,24 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 
 ## Extension Behaviour Settings
 
-| Setting ID                             | Description                                                                 | Scope                     |
-| -------------------------------------- | --------------------------------------------------------------------------- | ------------------------- |
-| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)               | User, Remote or Workspace |
-| `idf.flashType`                        | Preferred flash method. DFU, UART or JTAG                                   |                           |
-| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                     |                           |
-| `idf.notificationSilentMode`           | Silent all notifications messages and show tasks output (default `true`)    | User, Remote or Workspace |
-| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation                   | User, Remote or Workspace |
-| `idf.saveScope`                        | Where to save extension settings                                            | User, Remote or Workspace |
-| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)                  |                           |
-| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                   |                           |
-| `idf.telemetry`                        | Enable Telemetry                                                            | User, Remote or Workspace |
-| `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`) | User, Remote or Workspace |
-| `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                       | User, Remote or Workspace |
-| `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                    | User, Remote or Workspace |
-| `idf.enableStatusBar`                  | Show or hide the extension status bar items                                 | User, Remote or Workspace |
-| `idf.enableSizeTaskAfterBuildTask`     | Enable IDF Size task to be executed after IDF Build task                    | User, Remote or Workspace |
+| Setting ID                             | Description                                                                    | Scope                     |
+| -------------------------------------- | ------------------------------------------------------------------------------ | ------------------------- |
+| `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)                  | User, Remote or Workspace |
+| `idf.flashType`                        | Preferred flash method. DFU, UART or JTAG                                      |                           |
+| `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                        |                           |
+| `idf.notificationSilentMode`           | Silent all notifications messages and show tasks output (default `true`)       | User, Remote or Workspace |
+| `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration window on extension activation                      | User, Remote or Workspace |
+| `idf.saveScope`                        | Where to save extension settings                                               | User, Remote or Workspace |
+| `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)                     |                           |
+| `idf.useIDFKconfigStyle`               | Enable style validation for Kconfig files                                      |                           |
+| `idf.telemetry`                        | Enable Telemetry                                                               | User, Remote or Workspace |
+| `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`)    | User, Remote or Workspace |
+| `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                          | User, Remote or Workspace |
+| `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                       | User, Remote or Workspace |
+| `idf.enableStatusBar`                  | Show or hide the extension status bar items                                    | User, Remote or Workspace |
+| `idf.enableSizeTaskAfterBuildTask`     | Enable IDF Size task to be executed after IDF Build task                       | User, Remote or Workspace |
+| `idf.customTerminalExecutable`         | Absolute path to shell terminal executable to use (default to vscode Terminal) | User, Remote or Workspace |
+| `idf.customTerminalExecutableArgs`     | Shell arguments for idf.customTerminalExecutable                               | User, Remote or Workspace |
 
 ## Custom tasks for build and flash tasks
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -122,6 +122,8 @@
   "param.enableCCache.title": "Enable CCache in build task",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
+  "param.customTerminalExecutable.title": "Custom executable for extensions tasks",
+  "param.customTerminalExecutableArgs.title": "List of arguments for the custom executable for extension tasks",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -108,6 +108,8 @@
   "param.monitorNoReset": "Habilitar no-reset en el IDF Monitor",
   "param.enableStatusBar.title": "Habilitar elementos de la barra de estatus de la extension ESP-IDF",
   "param.enableSizeTaskAfterBuildTask.title": "Habilitar la tarea de IDF Size luego de la tarea IDF Build",
+  "param.customTerminalExecutable.title": "Ejecutable personalizado para las tareas de la extensión ESP-IDF",
+  "param.customTerminalExecutableArgs.title": "Lista de argumentos para el ejecutble personalizado de tareas de la extensión ESP-IDF",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -122,6 +122,8 @@
   "param.notificationSilentMode": "Отключите все уведомления расширения ESP-IDF (за исключением уведомлений об ошибках)",
   "param.saveScope": "Куда сохранять конфигурацию с помощью команд ESP-IDF с числовым значением vscode.ConfigurationTarget. Глобально = 1, Рабочая область = 2, Папка рабочей области = 3",
   "param.rainmaker.api.server_url": "URL облачного сервера ESP-Rainmaker",
+  "param.customTerminalExecutable.title": "Пользовательский исполняемый файл для задач расширения",
+  "param.customTerminalExecutableArgs.title": "Список аргументов для пользовательского исполняемого файла для задач расширения",
   "esp.rainmaker.backend.sync.title": "Синхронизация с облачным сервером ESP-Rainmaker",
   "esp.rainmaker.backend.connect.title": "Подключится к облачному серверу ESP-Rainmaker",
   "esp.rainmaker.backend.logout.title": "Отвязать аккаунт Rainmaker",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -122,6 +122,8 @@
   "param.notificationSilentMode": "禁用所有 ESP-IDF 扩展通知(排除错误通知)",
   "param.saveScope": "将 ESP-IDF 命令将配置保存到 vscode.ConfigurationTarget。全局 = 1, 工作区= 2, 工作区文件夹=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker 云服务器地址",
+  "param.customTerminalExecutable.title": "用于扩展任务的自定义可执行文件",
+  "param.customTerminalExecutableArgs.title": "扩展任务的自定义可执行文件的参数列表",
   "esp.rainmaker.backend.sync.title": "同步到 ESP-Rainmaker 云服务器",
   "esp.rainmaker.backend.connect.title": "连接到 ESP-Rainmaker 云服务器",
   "esp.rainmaker.backend.logout.title": "取消关联 ESP-Rainmaker 帐户",

--- a/package.json
+++ b/package.json
@@ -858,6 +858,18 @@
             "description": "%param.enableSizeTaskAfterBuildTask.title%",
             "scope": "resource",
             "default": true
+          },
+          "idf.customTerminalExecutable": {
+            "type": "string",
+            "description": "%param.customTerminalExecutable.title%",
+            "scope": "resource",
+            "default": ""
+          },
+          "idf.customTerminalExecutableArgs": {
+            "type": "array",
+            "description": "%param.customTerminalExecutableArgs.title%",
+            "scope": "resource",
+            "default": []
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -120,6 +120,8 @@
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",
   "param.enableIdfComponentManager.title": "Enable IDF Component Manager in build task",
+  "param.customTerminalExecutable.title": "Custom executable for extensions tasks",
+  "param.customTerminalExecutableArgs.title": "List of arguments for the custom executable for extension tasks",
   "param.enableCCache.title": "Enable CCache in build task",
   "param.enableSizeTaskAfterBuildTask.title": "Enable IDF Size task after build task",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -131,6 +131,22 @@ export class BuildTask {
       cwd: this.buildDirPath,
       env: modifiedEnv,
     };
+    const shellExecutablePath = idfConf.readParameter(
+      "idf.customTerminalExecutable",
+      this.curWorkspace
+    ) as string;
+    const shellExecutableArgs = idfConf.readParameter(
+      "idf.customTerminalExecutableArgs",
+      this.curWorkspace
+    ) as string[];
+    if (shellExecutablePath) {
+      options.executable = shellExecutablePath;
+    }
+
+    if (shellExecutableArgs && shellExecutableArgs.length) {
+      options.shellArgs = shellExecutableArgs;
+    }
+
     const isSilentMode = idfConf.readParameter(
       "idf.notificationSilentMode",
       this.curWorkspace
@@ -235,6 +251,21 @@ export class BuildTask {
       cwd: this.curWorkspace.fsPath,
       env: modifiedEnv,
     };
+
+    const shellExecutablePath = idfConf.readParameter(
+      "idf.customTerminalExecutable",
+      this.curWorkspace
+    ) as string;
+    const shellExecutableArgs = idfConf.readParameter(
+      "idf.customTerminalExecutableArgs",
+      this.curWorkspace
+    ) as string[];
+    if (shellExecutablePath) {
+      options.executable = shellExecutablePath;
+    }
+    if (shellExecutableArgs && shellExecutableArgs.length) {
+      options.shellArgs = shellExecutableArgs;
+    }
 
     const isSilentMode = idfConf.readParameter(
       "idf.notificationSilentMode",

--- a/src/customTasks/customTaskProvider.ts
+++ b/src/customTasks/customTaskProvider.ts
@@ -87,6 +87,20 @@ export class CustomTask {
       cwd: this.currentWorkspace.fsPath,
       env: modifiedEnv,
     };
+    const shellExecutablePath = readParameter(
+      "idf.customTerminalExecutable",
+      this.currentWorkspace
+    ) as string;
+    const shellExecutableArgs = readParameter(
+      "idf.customTerminalExecutableArgs",
+      this.currentWorkspace
+    ) as string[];
+    if (shellExecutablePath) {
+      options.executable = shellExecutablePath;
+    }
+    if (shellExecutableArgs && shellExecutableArgs.length) {
+      options.shellArgs = shellExecutableArgs;
+    }
     const isSilentMode = readParameter(
       "idf.notificationSilentMode",
       this.currentWorkspace

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -90,6 +90,14 @@ export async function createNewIdfMonitor(
   const projectName = await getProjectName(buildDirPath);
   const elfFilePath = join(buildDirPath, `${projectName}.elf`);
   const toolchainPrefix = utils.getToolchainToolName(idfTarget, "");
+  const shellPath = readParameter(
+    "idf.customTerminalExecutable",
+    workspaceFolder
+  ) as string;
+  const shellExecutableArgs = readParameter(
+    "idf.customTerminalExecutableArgs",
+    workspaceFolder
+  ) as string[];
   const monitor = new IDFMonitor({
     port,
     baudRate: sdkMonitorBaudRate,
@@ -101,6 +109,8 @@ export async function createNewIdfMonitor(
     elfFilePath,
     workspaceFolder,
     toolchainPrefix,
+    shellPath,
+    shellExecutableArgs
   });
   return monitor;
 }

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -31,6 +31,8 @@ export interface MonitorConfig {
   toolchainPrefix: string;
   wsPort?: number;
   workspaceFolder: Uri;
+  shellPath: string;
+  shellExecutableArgs: string[];
 }
 
 export class IDFMonitor {
@@ -50,8 +52,8 @@ export class IDFMonitor {
         modifiedEnv.IDF_PATH ||
         process.cwd(),
       strictEnv: true,
-      shellArgs: [],
-      shellPath: env.shell,
+      shellArgs: this.config.shellExecutableArgs || [],
+      shellPath: this.config.shellPath || env.shell,
     });
     this.terminal.show();
     this.terminal.dispose = this.dispose.bind(this);

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -72,6 +72,20 @@ export class IdfSizeTask {
       cwd: this.curWorkspace.fsPath,
       env: modifiedEnv,
     };
+    const shellExecutablePath = readParameter(
+      "idf.customTerminalExecutable",
+      this.curWorkspace
+    ) as string;
+    const shellExecutableArgs = readParameter(
+      "idf.customTerminalExecutableArgs",
+      this.curWorkspace
+    ) as string[];
+    if (shellExecutablePath) {
+      options.executable = shellExecutablePath;
+    }
+    if (shellExecutableArgs && shellExecutableArgs.length) {
+      options.shellArgs = shellExecutableArgs;
+    }
     const sizeExecution = await this.getShellExecution(options);
     const isSilentMode = readParameter(
       "idf.notificationSilentMode",

--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -81,6 +81,21 @@ export class EspMatterCloning extends AbstractCloning {
     const shellOptions: ShellExecutionOptions = {
       cwd: workingDir,
     };
+    const shellExecutablePath = readParameter(
+      "idf.customTerminalExecutable",
+      this.currWorkspace
+    ) as string;
+    const shellExecutableArgs = readParameter(
+      "idf.customTerminalExecutableArgs",
+      this.currWorkspace
+    ) as string[];
+    if (shellExecutablePath) {
+      shellOptions.executable = shellExecutablePath;
+    }
+    if (shellExecutableArgs && shellExecutableArgs.length) {
+      shellOptions.shellArgs = shellExecutableArgs;
+    }
+    
     const buildGnExec = this.getShellExecution(bootstrapFilePath, shellOptions);
     const isSilentMode = readParameter("idf.notificationSilentMode", this.currWorkspace);
     const showTaskOutput = isSilentMode

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2628,6 +2628,14 @@ export async function activate(context: vscode.ExtensionContext) {
           "idf.monitorNoReset",
           workspaceRoot
         ) as boolean;
+        const shellPath = idfConf.readParameter(
+          "idf.customTerminalExecutable",
+          workspaceRoot
+        ) as string;
+        const shellExecutableArgs = idfConf.readParameter(
+          "idf.customTerminalExecutableArgs",
+          workspaceRoot
+        ) as string[];
         const monitor = new IDFMonitor({
           port,
           baudRate: sdkMonitorBaudRate,
@@ -2640,6 +2648,8 @@ export async function activate(context: vscode.ExtensionContext) {
           elfFilePath,
           wsPort,
           workspaceFolder: workspaceRoot,
+          shellPath,
+          shellExecutableArgs,
         });
         if (wsServer) {
           wsServer.close();

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -30,6 +30,8 @@ export function getConfigurationSettings(
     espIdfPath: conf.get("idf.espIdfPath" + winFlag),
     espMdfPath: conf.get("idf.espMdfPath" + winFlag),
     espMatterPath: conf.get("idf.espMatterPath" + winFlag),
+    customTerminalExecutable: conf.get("idf.customTerminalExecutable"),
+    customTerminalExecutableArgs: conf.get("idf.customTerminalExecutableArgs"),
     customExtraPaths: conf.get("idf.customExtraPaths"),
     customExtraVars: conf.get("idf.customExtraVars"),
     pythonBinPath: conf.get("idf.pythonBinPath" + winFlag),

--- a/src/support/initReportObj.ts
+++ b/src/support/initReportObj.ts
@@ -27,6 +27,8 @@ export function initializeReportObject() {
     espMatterPath: undefined,
     customExtraPaths: undefined,
     customExtraVars: undefined,
+    customTerminalExecutable: undefined,
+    customTerminalExecutableArgs: undefined,
     pythonBinPath: undefined,
     pythonPackages: undefined,
     serialPort: undefined,

--- a/src/support/types.ts
+++ b/src/support/types.ts
@@ -43,6 +43,8 @@ export class Configuration {
   openOcdConfigs: string[];
   toolsPath: string;
   gitPath: string;
+  customTerminalExecutable: string;
+  customTerminalExecutableArgs: string[];
 }
 
 export class ConfigurationSpacesValidation {

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -56,6 +56,15 @@ export async function writeTextReport(
   output += `OpenOCD Configs (idf.openOcdConfigs) ${reportedResult.configurationSettings.openOcdConfigs}${EOL}`;
   output += `ESP-IDF Tools Path (idf.toolsPath) ${reportedResult.configurationSettings.toolsPath}${EOL}`;
   output += `Git Path (idf.gitPath) ${reportedResult.configurationSettings.gitPath}${EOL}`;
+  if (reportedResult.configurationSettings.customTerminalExecutable) {
+    output += `Custom terminal executable (idf.customTerminalExecutable) ${reportedResult.configurationSettings.customTerminalExecutable}${EOL}`;
+  }
+  if (reportedResult.configurationSettings.customTerminalExecutableArgs) {
+    output += `Custom terminal executable args (idf.customTerminalExecutableArgs)${EOL}`;
+    for (let k = 0; k < reportedResult.configurationSettings.customTerminalExecutableArgs.length; k++) {
+      output += `    ${k}: ${reportedResult.configurationSettings.customTerminalExecutableArgs[k]}${EOL}`;
+    }
+  }
   output += `-------------------------------------------------------- Configurations access -------------------------------------------------------------${EOL}`;
   output += `Access to ESP-ADF Path (idf.espAdfPath) ${reportedResult.configurationAccess.espAdfPath}${EOL}`;
   output += `Access to ESP-IDF Path (idf.espIdfPath) ${reportedResult.configurationAccess.espIdfPath}${EOL}`;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -59,11 +59,8 @@ export async function writeTextReport(
   if (reportedResult.configurationSettings.customTerminalExecutable) {
     output += `Custom terminal executable (idf.customTerminalExecutable) ${reportedResult.configurationSettings.customTerminalExecutable}${EOL}`;
   }
-  if (reportedResult.configurationSettings.customTerminalExecutableArgs && Object.keys(reportedResult.configurationSettings.customTerminalExecutableArgs)) {
-    output += `Custom terminal executable args (idf.customTerminalExecutableArgs)${EOL}`;
-    for (let k = 0; k < reportedResult.configurationSettings.customTerminalExecutableArgs.length; k++) {
-      output += `    ${k}: ${reportedResult.configurationSettings.customTerminalExecutableArgs[k]}${EOL}`;
-    }
+  if (reportedResult.configurationSettings.customTerminalExecutableArgs && reportedResult.configurationSettings.customTerminalExecutableArgs.length) {
+    output += `Custom terminal executable args (idf.customTerminalExecutableArgs)${reportedResult.configurationSettings.customTerminalExecutableArgs}${EOL}`;
   }
   output += `-------------------------------------------------------- Configurations access -------------------------------------------------------------${EOL}`;
   output += `Access to ESP-ADF Path (idf.espAdfPath) ${reportedResult.configurationAccess.espAdfPath}${EOL}`;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -59,7 +59,7 @@ export async function writeTextReport(
   if (reportedResult.configurationSettings.customTerminalExecutable) {
     output += `Custom terminal executable (idf.customTerminalExecutable) ${reportedResult.configurationSettings.customTerminalExecutable}${EOL}`;
   }
-  if (reportedResult.configurationSettings.customTerminalExecutableArgs) {
+  if (reportedResult.configurationSettings.customTerminalExecutableArgs && Object.keys(reportedResult.configurationSettings.customTerminalExecutableArgs)) {
     output += `Custom terminal executable args (idf.customTerminalExecutableArgs)${EOL}`;
     for (let k = 0; k < reportedResult.configurationSettings.customTerminalExecutableArgs.length; k++) {
       output += `    ${k}: ${reportedResult.configurationSettings.customTerminalExecutableArgs[k]}${EOL}`;


### PR DESCRIPTION
## Description

Add `idf.customTerminalExecutable` and `idf.customTerminalExecutableArgs` to customize the shell executable and shell arguments used in the extension tasks. By default it will use the vscode configured terminal.

Added them also to `ESP-IDF: Doctor command` output.

Shell arguments are also required as specified in VSCODE API for `ShellExecutionOptions` :

>   * The arguments to be passed to the shell executable used to run the task. Most shells
     * require special arguments to execute a command. For  example `bash` requires the `-c`
     * argument to execute a command, `PowerShell` requires `-Command` and `cmd` requires both
     * `/d` and `/c`.

Fixes #935

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Monitor your device" with `idf.customTerminalExecutable` not defined.
2. Execute action. 
3. Observe results. You should see in the output that terminal used is the same as vscode configured terminal.
4. Set `idf.customTerminalExecutable` in settings.json to any custom terminal like `/bin/bash` and required `idf.customTerminalExecutableArgs` like `["-c" ]` for Bash or corresponding for commands.
5. Click on "ESP-IDF: Monitor your device" and `ESP-IDF: Build your project` commands. Check in the output that is using the custom terminal executable.

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
