### PR TITLE
fix resolve tasks manager

### DIFF
--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Friday, 27th September 2019 9:59:57 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ export class TaskManager {
     return new Promise<void>((resolve, reject) => {
       vscode.tasks.onDidEndTask((e) => {
         if (
-          e.execution.task.definition.taskId.indexOf(
+          e.execution && e.execution.task.definition.taskId.indexOf(
             newTask.definition.taskId
           ) !== -1
         ) {
@@ -83,10 +83,13 @@ export class TaskManager {
 
   public static async runTasks() {
     return new Promise<void>(async (resolve, reject) => {
+      if (TaskManager.tasks.length === 0) {
+        return resolve();
+      }
       let lastExecution = await vscode.tasks.executeTask(TaskManager.tasks[0]);
       const taskDisposable = vscode.tasks.onDidEndTaskProcess(async (e) => {
         if (
-          e.execution.task.definition.taskId.indexOf(
+          e.execution && e.execution.task.definition.taskId.indexOf(
             lastExecution.task.definition.taskId
           ) !== -1
         ) {

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -52,7 +52,8 @@ export class TaskManager {
     return new Promise<void>((resolve, reject) => {
       vscode.tasks.onDidEndTask((e) => {
         if (
-          e.execution && e.execution.task.definition.taskId.indexOf(
+          e.execution &&
+          e.execution.task.definition.taskId.indexOf(
             newTask.definition.taskId
           ) !== -1
         ) {
@@ -89,7 +90,8 @@ export class TaskManager {
       let lastExecution = await vscode.tasks.executeTask(TaskManager.tasks[0]);
       const taskDisposable = vscode.tasks.onDidEndTaskProcess(async (e) => {
         if (
-          e.execution && e.execution.task.definition.taskId.indexOf(
+          e.execution &&
+          e.execution.task.definition.taskId.indexOf(
             lastExecution.task.definition.taskId
           ) !== -1
         ) {


### PR DESCRIPTION
## Description

Fix tasks manager executing empty tasks. This happened when idf size task was disable.

Fixes #980

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Build your project" when `idf.enableSizeTaskAfterBuildTask` is false.
2. Execute action.
3. Observe results.

- Expected behaviour: 

Build notification is not hanging anymore. Same as IDF Size task is enable.

- Expected output:

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
