### PR TITLE
Add monitor timestamp settings (VSC-1130)

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -105,6 +105,8 @@ These settings are used to configure the [Code coverage](./COVERAGE.md) colors.
 | `idf.telemetry`                        | Enable Telemetry                                                               | User, Remote or Workspace |
 | `idf.deleteComponentsOnFullClean`      | Delete `managed_components` on full clean project command (default `false`)    | User, Remote or Workspace |
 | `idf.monitorNoReset`                   | Enable no-reset flag to IDF Monitor (default `false`)                          | User, Remote or Workspace |
+| `idf.monitorEnableTimestamps`          | Enable timestamps in IDF Monitor (default `false`)                             | User, Remote or Workspace |
+| `idf.monitorCustomTimestampFormat`     | Custom timestamp format in IDF Monitor                                         | User, Remote or Workspace |
 | `idf.monitorStartDelayBeforeDebug`     | Delay to start debug session after IDF monitor execution                       | User, Remote or Workspace |
 | `idf.enableStatusBar`                  | Show or hide the extension status bar items                                    | User, Remote or Workspace |
 | `idf.enableSizeTaskAfterBuildTask`     | Enable IDF Size task to be executed after IDF Build task                       | User, Remote or Workspace |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -122,6 +122,8 @@
   "param.enableCCache.title": "Enable CCache in build task",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
+  "param.monitorEnableTimestamps": "Enable timestamps in IDF Monitor",
+  "param.monitorCustomTimestampFormat": "Custom timestamp format in IDF Monitor",
   "param.customTerminalExecutable.title": "Custom executable for extensions tasks",
   "param.customTerminalExecutableArgs.title": "List of arguments for the custom executable for extension tasks",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -106,6 +106,8 @@
   "param.deleteComponentsOnFullClean": "Borrar managed_components en el comando limpiar proyecto",
   "param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración luego de IDF Monitor (ms)",
   "param.monitorNoReset": "Habilitar no-reset en el IDF Monitor",
+  "param.monitorEnableTimestamps": "Habilitar marcas de tiempo en IDF Monitor",
+  "param.monitorCustomTimestampFormat": "Formato de marca de tiempo personalizado en IDF Monitor",
   "param.enableStatusBar.title": "Habilitar elementos de la barra de estatus de la extension ESP-IDF",
   "param.enableSizeTaskAfterBuildTask.title": "Habilitar la tarea de IDF Size luego de la tarea IDF Build",
   "param.customTerminalExecutable.title": "Ejecutable personalizado para las tareas de la extensión ESP-IDF",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -106,6 +106,8 @@
   "param.deleteComponentsOnFullClean": "Удалить manage_components при полной очистке проекта.",
   "param.monitorStartDelayBeforeDebug": "Задержка запуска сеанса отладки после выполнения монитора IDF (мс)",
   "param.monitorNoReset": "Включить флаг отсутствия сброса для монитора IDF",
+  "param.monitorEnableTimestamps": "Включить временные метки в монитора IDF",
+  "param.monitorCustomTimestampFormat": "Пользовательский формат временной метки в монитора IDF",
   "param.enableStatusBar.title": "Включить элементы строки состояния расширения ESP-IDF",
   "param.enableSizeTaskAfterBuildTask.title": "Включить задачу размера IDF после задачи сборки",
   "view.components.name": "Компоненты проекта",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -106,6 +106,8 @@
   "param.deleteComponentsOnFullClean": "完全清除项目命令时删除managed_components",
   "param.monitorStartDelayBeforeDebug": "IDF监视器执行后延迟启动调试会话 (ms)",
   "param.monitorNoReset": "对IDF监视器启用无重置标志",
+  "param.monitorEnableTimestamps": "在IDF监视器中启用时间戳",
+  "param.monitorCustomTimestampFormat": "IDF监视器中的自定义时间戳格式",
   "param.enableStatusBar.title": "启用ESP-IDF扩展状态栏项目",
   "param.enableSizeTaskAfterBuildTask.title": "在生成任务后启用IDF大小任务",
   "view.components.name": "项目组件",

--- a/package.json
+++ b/package.json
@@ -847,6 +847,18 @@
             "scope": "resource",
             "description": "%param.monitorNoReset%"
           },
+          "idf.monitorEnableTimestamps": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "description": "%param.monitorEnableTimestamps%"
+          },
+          "idf.monitorCustomTimestampFormat": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "description": "%param.monitorCustomTimestampFormat%"
+          },
           "idf.enableStatusBar": {
             "type": "boolean",
             "description": "%param.enableStatusBar.title%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -103,6 +103,8 @@
   "param.sdkconfigDefaults": "List of sdkconfig default values for initial build configuration",
   "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
   "param.monitorNoReset": "Enable no-reset flag to IDF Monitor",
+  "param.monitorEnableTimestamps": "Enable timestamps in IDF Monitor",
+  "param.monitorCustomTimestampFormat": "Custom timestamp format in IDF Monitor",
   "param.enableStatusBar.title": "Enable ESP-IDF extension status bar items",
   "view.components.name": "Project Components",
   "configuration.title": "ESP-IDF",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -167,6 +167,8 @@
     "param.sdkconfigDefaults",
     "param.monitorStartDelayBeforeDebug",
     "param.monitorNoReset",
+    "param.monitorEnableTimestamps",
+    "param.monitorCustomTimestampFormat",
     "view.components.name",
     "configuration.title",
     "espIdf.apptrace.archive.refresh.title",

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -32,6 +32,8 @@ const locDic = new LocDictionary(__filename);
 export async function createNewIdfMonitor(
   workspaceFolder: Uri,
   noReset: boolean = false,
+  enableTimestamps: boolean = false,
+  customTimestampFormat: string = "",
   serialPort?: string
 ) {
   if (BuildTask.isBuilding || FlashTask.isFlashing) {
@@ -106,6 +108,8 @@ export async function createNewIdfMonitor(
     idfMonitorToolPath,
     idfVersion,
     noReset,
+    enableTimestamps,
+    customTimestampFormat,
     elfFilePath,
     workspaceFolder,
     toolchainPrefix,

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -26,6 +26,8 @@ export interface MonitorConfig {
   idfTarget: string;
   idfVersion: string;
   noReset: boolean;
+  enableTimestamps: boolean;
+  customTimestampFormat: string;
   port: string;
   pythonBinPath: string;
   toolchainPrefix: string;
@@ -74,6 +76,12 @@ export class IDFMonitor {
     ];
     if (this.config.noReset && this.config.idfVersion >= "5.0") {
       args.splice(2, 0, "--no-reset");
+    }
+    if (this.config.enableTimestamps) {
+      args.push("--timestamps");
+    }
+    if (this.config.customTimestampFormat.length > 0) {
+      args.push("--timestamp-format", JSON.stringify(this.config.customTimestampFormat));
     }
     if (this.config.idfVersion >= "4.3") {
       args.push("--target", this.config.idfTarget);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3218,7 +3218,11 @@ const flash = (
   });
 };
 
-function createQemuMonitor(noReset: boolean = false, enableTimestamps: boolean = false, customTimestampFormat: string = "") {
+function createQemuMonitor(
+  noReset: boolean = false,
+  enableTimestamps: boolean = false,
+  customTimestampFormat: string = ""
+) {
   PreCheck.perform([openFolderCheck], async () => {
     const isQemuLaunched = await qemuManager.isRunning();
     if (!isQemuLaunched) {
@@ -3399,8 +3403,17 @@ function createMonitor() {
   });
 }
 
-async function createIdfMonitor(noReset: boolean = false, enableTimestamps: boolean = false, customTimestampFormat: string = "") {
-  const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset, enableTimestamps, customTimestampFormat);
+async function createIdfMonitor(
+  noReset: boolean = false,
+  enableTimestamps: boolean = false,
+  customTimestampFormat: string = ""
+) {
+  const idfMonitor = await createNewIdfMonitor(
+    workspaceRoot,
+    noReset,
+    enableTimestamps,
+    customTimestampFormat
+  );
   if (monitorTerminal) {
     monitorTerminal.sendText(ESP.CTRL_RBRACKET);
     monitorTerminal.sendText(`exit`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2628,6 +2628,14 @@ export async function activate(context: vscode.ExtensionContext) {
           "idf.monitorNoReset",
           workspaceRoot
         ) as boolean;
+        const enableTimestamps = idfConf.readParameter(
+          "idf.monitorEnableTimestamps",
+          workspaceRoot
+        ) as boolean;
+        const customTimestampFormat = idfConf.readParameter(
+          "idf.monitorCustomTimestampFormat",
+          workspaceRoot
+        ) as string;
         const shellPath = idfConf.readParameter(
           "idf.customTerminalExecutable",
           workspaceRoot
@@ -2645,6 +2653,8 @@ export async function activate(context: vscode.ExtensionContext) {
           idfMonitorToolPath,
           idfVersion,
           noReset,
+          enableTimestamps,
+          customTimestampFormat,
           elfFilePath,
           wsPort,
           workspaceFolder: workspaceRoot,
@@ -3208,7 +3218,7 @@ const flash = (
   });
 };
 
-function createQemuMonitor(noReset: boolean = false) {
+function createQemuMonitor(noReset: boolean = false, enableTimestamps: boolean = false, customTimestampFormat: string = "") {
   PreCheck.perform([openFolderCheck], async () => {
     const isQemuLaunched = await qemuManager.isRunning();
     if (!isQemuLaunched) {
@@ -3223,6 +3233,8 @@ function createQemuMonitor(noReset: boolean = false) {
     const idfMonitor = await createNewIdfMonitor(
       workspaceRoot,
       noReset,
+      enableTimestamps,
+      customTimestampFormat,
       serialPort
     );
     if (monitorTerminal) {
@@ -3375,12 +3387,20 @@ function createMonitor() {
       "idf.monitorNoReset",
       workspaceRoot
     ) as boolean;
-    await createIdfMonitor(noReset);
+    const enableTimestamps = idfConf.readParameter(
+      "idf.monitorEnableTimestamps",
+      workspaceRoot
+    ) as boolean;
+    const customTimestampFormat = idfConf.readParameter(
+      "idf.monitorCustomTimestampFormat",
+      workspaceRoot
+    ) as string;
+    await createIdfMonitor(noReset, enableTimestamps, customTimestampFormat);
   });
 }
 
-async function createIdfMonitor(noReset: boolean = false) {
-  const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset);
+async function createIdfMonitor(noReset: boolean = false, enableTimestamps: boolean = false, customTimestampFormat: string = "") {
+  const idfMonitor = await createNewIdfMonitor(workspaceRoot, noReset, enableTimestamps, customTimestampFormat);
   if (monitorTerminal) {
     monitorTerminal.sendText(ESP.CTRL_RBRACKET);
     monitorTerminal.sendText(`exit`);


### PR DESCRIPTION
## Description

Adds settings to enable and customise timestamps in IDF Monitor.

Closes #975

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

1. Open VS Code settings
2. Alter monitorEnableTimestamps and/or monitorCustomTimestampFormat (eg. %Y-%m-%d %H:%M:%S)
3. Open IDF Monitor with an actively transmitting device attached and confirm that timestamps are appended and formatted as expected.

## How has this been tested?

Tested by opening IDF Monitor in an existing project, with ESP32 attached and transmitting over UART, and confirming expected behaviour with timestamps enabled, disabled, and with multiple format strings.

**Test Configuration**:
* ESP-IDF Version: master (1.6.3)
* OS (Windows,Linux and macOS): Linux (Ubuntu)

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
