### PR TITLE
Increase input width in menu config

### DIFF
--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -207,6 +207,9 @@ input[type="number"]::-webkit-inner-spin-button {
   transition: max-height 0.2s ease-out;
   margin: 10px;
 }
+.input {
+  width: 30rem;
+}
 .input,
 .select {
   border-color: var(--vscode-input-background);


### PR DESCRIPTION
## Description

Increase the width of the inputs inside SDK Configuration Editor

Fixes [#984](https://github.com/espressif/vscode-esp-idf-extension/issues/984)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open VSCode Command Palette (CTRL/command for Mac + SHIFT + P) and run `ESP-IDF: SDK Configuration Editor (menuconfig)`
2. Text input fields should be bigger than previous version

Previous version:
<img width="1258" alt="before" src="https://github.com/espressif/vscode-esp-idf-extension/assets/25748706/96bd08f5-c056-4c2e-8834-b06468084e20">

Updated version:
<img width="1258" alt="after" src="https://github.com/espressif/vscode-esp-idf-extension/assets/25748706/3ad9151a-3930-45dc-9dec-c371049ce2de">

## How has this been tested?

Used command: ESP-IDF: SDK Configuration Editor (menuconfig) 

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): MacOs

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
