### PR TITLE
Create a project from external components

### DIFF
--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -21,6 +21,8 @@ import * as utils from "../utils";
 import { createExamplesHtml } from "./createExamplesHtml";
 import { ESP } from "../config";
 import { getExamplesList, IExampleCategory } from "./Example";
+import { ComponentManagerUIPanel } from "../component-manager/panel";
+import { OutputChannel } from "../logger/outputChannel";
 
 const locDic = new LocDictionary("ExamplesPanel");
 
@@ -159,6 +161,14 @@ export class ExamplesPlanel {
             }
           }
           break;
+        case "showRegistry":
+          const emptyURI: vscode.Uri = undefined;
+          try {
+            ComponentManagerUIPanel.show(extensionPath, emptyURI);
+          } catch (error) {
+            OutputChannel.appendLine(error.message);
+            Logger.errorNotify(error.message, error);
+          }
         default:
           return;
       }

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -297,6 +297,7 @@ export class NewProjectPanel {
             }
           }
         } catch (error) {
+          OutputChannel.appendLine(error.message);
           Logger.errorNotify(error.message, error);
         }
       }

--- a/src/views/examples/Examples.vue
+++ b/src/views/examples/Examples.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="examples-window">
     <div id="sidenav" class="content">
+      <p>For external components examples, check <a v-on:click="showRegistry">IDF Component Registry</a></p>
       <ul>
         <ExampleList :node="exampleRootPath" :key="exampleRootPath.name" />
       </ul>
@@ -45,6 +46,7 @@ export default class Examples extends Vue {
   @State("selectedExample") private storeSelectedExample;
   @Action("openExample") private storeOpenExample;
   @Action private getExamplesList;
+  @Action private showRegistry;
 
   get selectedExample() {
     return this.storeSelectedExample;

--- a/src/views/examples/store/index.ts
+++ b/src/views/examples/store/index.ts
@@ -66,6 +66,11 @@ export const mutations: MutationTree<IState> = {
 };
 
 export const actions: ActionTree<IState, any> = {
+  showRegistry() {
+    vscode.postMessage({
+      command: "showRegistry",
+    });
+  },
   getExamplesList() {
     vscode.postMessage({ command: "getExamplesList" });
   },


### PR DESCRIPTION
## Description

Users are now able to create projects from the examples that can be found in [Component Registry](https://components.espressif.com/components). 

- [x] Link that opens "Component Registry" was added in the webview of "ESP-IDF: Show Example Projects"
- [] Button for creating projects from examples was added in the "Component Registry" webview

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Steps to test this pull request

1. Open Command Palette (CTRL + SHIFT + P) in VSCode and type ESP-IDF: Show Example Projects
2. Press the top left link "IDF Component Registry"
3. Search for a component that has examples
4. ...wip

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
