### PR TITLE
add execPath as config variable

### DIFF
--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -263,6 +263,9 @@ export function resolveVariables(
     if (scope && match.indexOf("workspaceFolder") > 0) {
       return scope instanceof vscode.Uri ? scope.fsPath : scope.uri.fsPath;
     }
+    if (match.indexOf("execPath") > 0) {
+      return process.execPath;
+    }
     return match;
   });
 }


### PR DESCRIPTION
## Description

Add `${execPath}` as supported variable substitution in configuration settings. 

Fixes [IDF #11559](https://github.com/espressif/esp-idf/issues/11559)

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Use `${execPath}` in a configuration setting and run one of the extension commands with it.
2. Execute action.
3. Observe results. The variable should be replaced properly.

## How has this been tested?

Manual testing using `idf.customTask` and executing custom task

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
