### PR TITLE
Change compiler path to user relative path

### DIFF
--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -74,12 +74,16 @@ suite("Project tests", () => {
     const templateCCppPropertiesJsonJson = await readJson(
       join(templateFolder, ".vscode", "c_cpp_properties.json")
     );
-    const compilerPath = await isBinInPath(
+    const compilerAbsolutePath = await isBinInPath(
       "xtensa-esp32-elf-gcc",
       targetFolder,
       process.env
     );
-    templateCCppPropertiesJsonJson.configurations[0].compilerPath = compilerPath;
+    let compilerRelativePath = compilerAbsolutePath.split(
+      process.env.IDF_TOOLS_PATH
+    )[1];
+    templateCCppPropertiesJsonJson.configurations[0].compilerPath =
+      "${config:idf.toolsPath}" + compilerRelativePath;
     const targetCCppPropertiesJsonJson = await readJson(
       join(targetFolder, ".vscode", "c_cpp_properties.json")
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,15 +236,18 @@ export async function setCCppPropertiesJsonCompilerPath(
     curWorkspaceFsPath.fsPath,
     modifiedEnv
   );
-  
+
   const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
   if (
     cCppPropertiesJson &&
     cCppPropertiesJson.configurations &&
     cCppPropertiesJson.configurations.length
   ) {
-    let compilerRelativePath = compilerAbsolutePath.split(modifiedEnv.IDF_TOOLS_PATH)[1];
-    cCppPropertiesJson.configurations[0].compilerPath = "${config:idf.toolsPath}" + compilerRelativePath;
+    let compilerRelativePath = compilerAbsolutePath.split(
+      modifiedEnv.IDF_TOOLS_PATH
+    )[1];
+    cCppPropertiesJson.configurations[0].compilerPath =
+      "${config:idf.toolsPath}" + compilerRelativePath;
     await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
       spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,18 +231,20 @@ export async function setCCppPropertiesJsonCompilerPath(
   const modifiedEnv = appendIdfAndToolsToPath(curWorkspaceFsPath);
   const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
   const gccTool = getToolchainToolName(idfTarget, "gcc");
-  const compilerPath = await isBinInPath(
+  const compilerAbsolutePath = await isBinInPath(
     gccTool,
     curWorkspaceFsPath.fsPath,
     modifiedEnv
   );
+  
   const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
   if (
     cCppPropertiesJson &&
     cCppPropertiesJson.configurations &&
     cCppPropertiesJson.configurations.length
   ) {
-    cCppPropertiesJson.configurations[0].compilerPath = compilerPath;
+    let compilerRelativePath = compilerAbsolutePath.split(modifiedEnv.IDF_TOOLS_PATH)[1];
+    cCppPropertiesJson.configurations[0].compilerPath = "${config:idf.toolsPath}" + compilerRelativePath;
     await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
       spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
     });


### PR DESCRIPTION
## Description

Changes `compilerPath` property in c_cpp_properties.json file from .vscode folder to use relative path.

Fixes #1010
Fixes [VSC-1156](https://jira.espressif.com:8443/browse/VSC-1156)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output:

1. Make new project using esp-idf examples.
2. When folder is created for project, verify in .vscode folder the c_cpp_properties.json has the compilerPath contains ${config:idf.toolsPath} in it's path and it's not just an absolute path.

- Expected behaviour:
All functionalities should work the same

## How has this been tested?

Like the ones described above.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
