### PR TITLE
use older embed python for older that idf 5

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,10 @@ export namespace ESP {
       export const VERSION = "2.39.2";
       export const IDF_EMBED_GIT_URL = `https://dl.espressif.com/dl/idf-git/idf-git-${VERSION}-win64.zip`;
     }
+    export namespace OLD_IDF_EMBED_PYTHON {
+      export const VERSION = "3.8.7";
+      export const IDF_EMBED_PYTHON_URL = `https://dl.espressif.com/dl/idf-python/idf-python-${VERSION}-embed-win64.zip`;
+    }
     export namespace IDF_EMBED_PYTHON {
       export const VERSION = "3.11.2";
       export const IDF_EMBED_PYTHON_URL = `https://dl.espressif.com/dl/idf-python/idf-python-${VERSION}-embed-win64.zip`;

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -59,7 +59,7 @@ export class IdfToolsManager {
     private platformInfo: PlatformInformation,
     private toolsManagerChannel: vscode.OutputChannel,
     public espIdfPath: string
-  ) { }
+  ) {}
 
   public getPackageList(onReqPkgs?: string[]): Promise<IPackage[]> {
     return new Promise<IPackage[]>((resolve, reject) => {
@@ -158,10 +158,10 @@ export class IdfToolsManager {
       Object.getOwnPropertyNames(versions[0]).indexOf("any") > -1
         ? (versions[0]["any"] as IFileInfo)
         : Object.getOwnPropertyNames(versions[0]).indexOf(
-          this.platformInfo.platformToUse
-        ) > -1
-          ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
-          : (versions[0][this.platformInfo.fallbackPlatform] as IFileInfo);
+            this.platformInfo.platformToUse
+          ) > -1
+        ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
+        : (versions[0][this.platformInfo.fallbackPlatform] as IFileInfo);
     return linkInfo;
   }
 

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -59,7 +59,7 @@ export class IdfToolsManager {
     private platformInfo: PlatformInformation,
     private toolsManagerChannel: vscode.OutputChannel,
     public espIdfPath: string
-  ) {}
+  ) { }
 
   public getPackageList(onReqPkgs?: string[]): Promise<IPackage[]> {
     return new Promise<IPackage[]>((resolve, reject) => {
@@ -158,10 +158,10 @@ export class IdfToolsManager {
       Object.getOwnPropertyNames(versions[0]).indexOf("any") > -1
         ? (versions[0]["any"] as IFileInfo)
         : Object.getOwnPropertyNames(versions[0]).indexOf(
-            this.platformInfo.platformToUse
-          ) > -1
-        ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
-        : (versions[0][this.platformInfo.fallbackPlatform] as IFileInfo);
+          this.platformInfo.platformToUse
+        ) > -1
+          ? (versions[0][this.platformInfo.platformToUse] as IFileInfo)
+          : (versions[0][this.platformInfo.fallbackPlatform] as IFileInfo);
     return linkInfo;
   }
 
@@ -336,7 +336,7 @@ export class IdfToolsManager {
       const expectedVersions = pkgVersionsForPlatform.map((p) => p.name);
       let isToolVersionCorrect =
         expectedVersions.indexOf(versions[pkg.name]) > -1 ||
-        versions[pkg.name] === "No command version";
+        (versions[pkg.name] && versions[pkg.name] === "No command version");
       const versionToUse = this.getVersionToUse(pkg);
       let pkgExportedPath: string = "";
       let pkgVars = pkg.export_vars;

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -264,9 +264,8 @@ export class SetupPanel {
             });
             SetupPanel.postMessage({
               command: "setEspIdfErrorStatus",
-              errorMsg: `ESP-IDF is installed in ${
-                setupArgs.existingIdfSetups[message.selectedIdfSetup].idfPath
-              }`,
+              errorMsg: `ESP-IDF is installed in ${setupArgs.existingIdfSetups[message.selectedIdfSetup].idfPath
+                }`,
             });
             this.panel.webview.postMessage({
               command: "updateEspIdfToolsStatus",
@@ -375,7 +374,7 @@ export class SetupPanel {
             } else if (selectedIdfVersion.filename === "master") {
               idfVersion = "5.1";
             } else {
-              const matches = selectedIdfVersion.name.match(/v(.+)/g);
+              const matches = selectedIdfVersion.name.split(" ")[0].match(/v(.+)/);
               if (matches && matches.length) {
                 idfVersion = matches[1];
               } else {
@@ -391,8 +390,9 @@ export class SetupPanel {
             idfGitPath = embedPaths.idfGitPath;
             idfPythonPath = embedPaths.idfPythonPath;
           }
+          const pathToCheck = selectedIdfVersion.filename === "manual" ? espIdfPath : idfContainerPath;
           this.checkSpacesInPaths(
-            espIdfPath,
+            pathToCheck,
             toolsPath,
             idfGitPath,
             idfPythonPath

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -436,7 +436,8 @@ export class SetupPanel {
     );
     const updatedToolsInfo = toolsInfo.map((tool) => {
       const isToolVersionCorrect =
-        tool.expected.indexOf(foundVersions[tool.name]) > -1;
+        tool.expected.indexOf(foundVersions[tool.name]) > -1  ||
+        (foundVersions[tool.name] && foundVersions[tool.name] === "No command version");
       tool.doesToolExist = isToolVersionCorrect;
       if (isToolVersionCorrect) {
         tool.progress = "100.00%";

--- a/src/setup/embedGitPy.ts
+++ b/src/setup/embedGitPy.ts
@@ -168,10 +168,18 @@ export async function installIdfPython(
   const extractePyDestMsg = `Extracted ${idfPyDestPath} ...`;
   progress.report({ message: extractePyDestMsg });
   OutputChannel.appendLine(extractePyDestMsg);
-  await spawn(
-    join(idfPyDestPath, "python.exe"),
-    ["-m", "ensurepip", "--upgrade"],
-    { cwd: idfPyDestPath }
-  );
+  if (idfVersion >= "5.0") {
+    await spawn(
+      join(idfPyDestPath, "python.exe"),
+      ["-m", "ensurepip", "--upgrade"],
+      { cwd: idfPyDestPath }
+    );
+  } else {
+    await spawn(join(idfPyDestPath, "python.exe"),
+    ["-m", "pip", "install", "virtualenv"],
+    {cwd : idfPyDestPath}
+    );
+  }
+  
   return join(idfPyDestPath, "python.exe");
 }

--- a/src/setup/espIdfDownloadStep.ts
+++ b/src/setup/espIdfDownloadStep.ts
@@ -97,13 +97,9 @@ export async function expressInstall(
     const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
       espIdfPath
     );
-    const exportedToolsPaths = await idfToolsManager.exportPathsInString(
-      join(toolsPath, "tools"),
-      onReqPkgs
-    );
     const toolsInfo = await idfToolsManager.getRequiredToolsInfo(
       join(toolsPath, "tools"),
-      exportedToolsPaths,
+      undefined,
       onReqPkgs
     );
     SetupPanel.postMessage({

--- a/src/setup/toolsDownloadStep.ts
+++ b/src/setup/toolsDownloadStep.ts
@@ -43,7 +43,7 @@ export async function downloadIdfTools(
   );
   const requiredTools = await idfToolsManager.getRequiredToolsInfo(
     toolsPath,
-    exportPaths,
+    undefined,
     onReqPkgs
   );
   SetupPanel.postMessage({

--- a/src/views/setup/ToolsCustom.vue
+++ b/src/views/setup/ToolsCustom.vue
@@ -5,7 +5,10 @@
         <label for="idf-version-select" class="label">ESP-IDF Tools</label>
         <div class="control">
           <div class="select">
-            <select v-model="selectedIdfTools" data-config-id="select-esp-idf-tools">
+            <select
+              v-model="selectedIdfTools"
+              data-config-id="select-esp-idf-tools"
+            >
               <option value="toolsDownload">Download ESP-IDF Tools</option>
               <option value="toolsExisting">Use existing ESP-IDF Tools</option>
             </select>
@@ -92,6 +95,7 @@ export default class CustomSetup extends Vue {
   }
 
   mounted() {
+    this.checkEspIdfTools();
     const updatedToolsInfo = this.storeToolsResults.map((tool) => {
       if (tool.doesToolExist) {
         tool.progress = "100.00%";

--- a/src/views/setup/components/toolDownload.vue
+++ b/src/views/setup/components/toolDownload.vue
@@ -7,7 +7,7 @@
       </div>
     </div>
     <div class="progressText">
-      <span v-if="tool.progress === '100.00%'">
+      <span v-if="tool.progress === '100.00%' && isInstallationCompleted">
         <span>Checksum :</span>
         {{ tool.hashResult ? "OK" : "Invalid" }}
         <br />


### PR DESCRIPTION
## Description

Use Embed Python 3.8.7 for ESP-IDF < v5.0 

Fixes #1015

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Click on "Configure ESP-IDF extension" command
2. Install ESP-IDF v4.4.5 or older
3. Observe results. Check installed embed Python is 3.8.7 and virtual environment is created.
4. Click on "Configure ESP-IDF extension" command
5. Install ESP-IDF v5.0 or higher
6. Observe results. Check installed embed Python is 3.11.2 and virtual environment is created.

- Expected behaviour: Setup works correctly

- Expected output: Python 3.8.7 for IDF < 5.0 and 3.11.2 for IDF >= 5.0

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0, 4.4.5
* OS (Windows,Linux and macOS): Windows 10

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
