### PR TITLE
add setup cmd install and reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Get HTML Coverage Report for project                    |                                        |                                           |
 | Import ESP-IDF Project                                  |                                        |                                           |
 | Install ESP-ADF                                         |                                        |                                           |
+| Install ESP-IDF                                         |                                        |                                           |
 | Install ESP-IDF Python Packages                         |                                        |                                           |
 | Install ESP-MDF                                         |                                        |                                           |
 | Install ESP-Matter                                      |                                        |                                           |
@@ -161,6 +162,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Unit Test: Install ESP-IDF PyTest requirements          |                                        |                                           |
 | Remove Editor coverage                                  |                                        |                                           |
 | Run ESP-IDF-SBOM vulnerability check                    |                                        |                                           |
+| Use ESP-IDF setup from IDF Installer                    |                                        |                                           |
 
 # About commands
 

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -66,6 +66,8 @@
   "espIdf.unitTest.installPyTest.title": "Unit Test: Install ESP-IDF PyTest  requirements",
   "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
   "espIdf.createSbom.title": "Run ESP-IDF-SBOM vulnerability check",
+  "espIdf.installEspIdf.title": "Install ESP-IDF",
+  "espIdf.useEspIdfJsonSetup.title": "Use ESP-IDF setup from IDF Installer",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -68,6 +68,8 @@
   "espIdf.clearSavedIdfSetups.title": "Limpiar configuraciones de IDF guardadas",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Unit Test: Construir y programar la app unit test app para pruebas",
   "espIdf.unitTest.installPyTest.title": "Unit Test: Instalar requerimientos ESP-IDF PyTest",
+  "espIdf.installEspIdf.title": "Instalar ESP-IDF",
+  "espIdf.useEspIdfJsonSetup.title": "Usar la configuracion ESP-IDF del Instalador IDF",
   "debug.initConfig.name": "Lanzar Depuracion ESP-IDF:",
   "debug.initConfig.description": "Nueva configuración para proyectos ESP-IDF",
   "param.adapterTargetName": "Target para el ESP-IDF Debug Adapter",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -66,6 +66,8 @@
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Модульный тест: сборка и запуск приложения модульного тестирования для тестирования.",
   "espIdf.unitTest.installPyTest.title": "Модульный тест: установите требования ESP-IDF PyTest",
   "espIdf.createSbom.title": "Запустите проверку уязвимостей ESP-IDF-SBOM.",
+  "espIdf.installEspIdf.title": "Установите ESP-IDF",
+  "espIdf.useEspIdfJsonSetup.title": "Используйте настройку ESP-IDF из установщика IDF.",
   "esp.component-manager.ui.show.title": "Показать реестр компонентов",
   "esp.component-manager.cli.addDependencyError": "Ошибка при добавлении зависимости к компоненту",
   "debug.initConfig.name": "Отладка запуск",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -66,6 +66,8 @@
   "espIdf.unitTest.buildFlashUnitTestApp.title": "单元测试：构建并闪存用于测试的单元测试应用程序",
   "espIdf.unitTest.installPyTest.title": "单元测试：安装ESP-IDF PyTest要求",
   "espIdf.createSbom.title": "运行ESP-IDF-SBOM漏洞检查",
+  "espIdf.installEspIdf.title": "安装ESP-IDF",
+  "espIdf.useEspIdfJsonSetup.title": "使用IDF安装程序中的ESP-IDF设置",
   "esp.component-manager.ui.show.title": "显示组件注册表",
   "esp.component-manager.cli.addDependencyError": "向组件添加依赖项时遇到错误",
   "debug.initConfig.name": "ESP-IDF调试 启动",

--- a/package.json
+++ b/package.json
@@ -1381,12 +1381,12 @@
       },
       {
         "command": "espIdf.installEspIdf",
-        "title": "Install ESP-IDF command",
+        "title": "%espIdf.installEspIdf.title%",
         "category": "ESP-IDF"
       },
       {
         "command": "espIdf.useEspIdfJsonSetup",
-        "title": "Use ESP-IDF setup",
+        "title": "%espIdf.useEspIdfJsonSetup.title%",
         "category": "ESP-IDF"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1378,6 +1378,16 @@
         "command": "espIdf.createSbom",
         "title": "%espIdf.createSbom.title%",
         "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.installEspIdf",
+        "title": "Install ESP-IDF command",
+        "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.useEspIdfJsonSetup",
+        "title": "Use ESP-IDF setup",
+        "category": "ESP-IDF"
       }
     ],
     "breakpoints": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -66,6 +66,8 @@
   "espIdf.projectConf.title": "Select project configuration",
   "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
   "espIdf.createSbom.title": "Run ESP-IDF-SBOM vulnerability check",
+  "espIdf.installEspIdf.title": "Install ESP-IDF",
+  "espIdf.useEspIdfJsonSetup.title": "Use ESP-IDF setup from IDF Installer",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -144,6 +144,8 @@
     "espIdf.unitTest.buildFlashUnitTestApp.title",
     "espIdf.unitTest.installPyTest.title",
     "espIdf.createSbom.title",
+    "espIdf.installEspIdf.title",
+    "espIdf.useEspIdfJsonSetup.title",
     "debug.initConfig.name",
     "debug.initConfig.description",
     "param.adapterTargetName",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,6 +145,7 @@ import { getFileList, getTestComponents } from "./espIdf/unitTest/utils";
 import { saveDefSdkconfig } from "./espIdf/menuconfig/saveDefConfig";
 import { createSBOM, installEspSBOM } from "./espBom";
 import { getEspHomeKitSdk } from "./espHomekit/espHomekitDownload";
+import { downloadEspIdf, useExistingEspIdfJsonSetup } from "./setup/cmd";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -2284,6 +2285,14 @@ export async function activate(context: vscode.ExtensionContext) {
         Logger.errorNotify(error.message, error);
       }
     });
+  });
+
+  registerIDFCommand("espIdf.installEspIdf", async () => {
+    await downloadEspIdf(context.extensionUri);
+  });
+
+  registerIDFCommand("espIdf.useEspIdfJsonSetup", async () => {
+    await useExistingEspIdfJsonSetup();
   });
 
   registerIDFCommand("espIdf.importProject", async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2288,11 +2288,11 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.installEspIdf", async () => {
-    await downloadEspIdf(context);
+    await downloadEspIdf(context, workspaceRoot);
   });
 
   registerIDFCommand("espIdf.useEspIdfJsonSetup", async () => {
-    await useExistingEspIdfJsonSetup();
+    await useExistingEspIdfJsonSetup(workspaceRoot);
   });
 
   registerIDFCommand("espIdf.importProject", async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2288,7 +2288,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.installEspIdf", async () => {
-    await downloadEspIdf(context.extensionUri);
+    await downloadEspIdf(context);
   });
 
   registerIDFCommand("espIdf.useEspIdfJsonSetup", async () => {

--- a/src/setup/cmd.ts
+++ b/src/setup/cmd.ts
@@ -47,7 +47,7 @@ export async function useExistingEspIdfJsonSetup() {
     process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
   let toolsPath = join(containerPath, ".espressif");
   const actualToolsPath = await openFolder(
-    "Where to save ESP-IDF Tools? (IDF_TOOLS_PATH)"
+    "Choose ESP-IDF Tools (.espressif directory)"
   );
   if (actualToolsPath) {
     toolsPath = actualToolsPath;
@@ -62,7 +62,7 @@ export async function useExistingEspIdfJsonSetup() {
   const idfSetups = await loadIdfSetupsFromEspIdfJson(toolsPath);
   if (!idfSetups) {
     OutputChannel.appendLineAndShow("No IDF Setups found");
-     return;
+    return;
   }
   let quickPickItems = idfSetups.map((idfSetup) => {
     return {

--- a/src/setup/cmd.ts
+++ b/src/setup/cmd.ts
@@ -1,0 +1,250 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 21st August 2023 3:30:23 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CancellationToken,
+  ConfigurationTarget,
+  Progress,
+  ProgressLocation,
+  Uri,
+  window,
+} from "vscode";
+import { getEspIdfVersions } from "./espIdfVersionList";
+import { Logger } from "../logger/logger";
+import { ESP } from "../config";
+import { downloadInstallIdfVersion } from "./espIdfDownload";
+import { IdfToolsManager } from "../idfToolsManager";
+import { join } from "path";
+import { saveSettings } from "./setupInit";
+import { getUnixPythonList, installExtensionPyReqs, installPythonEnvFromIdfTools } from "../pythonManager";
+import { loadIdfSetupsFromEspIdfJson } from "./existingIdfSetups";
+import { OutputChannel } from "../logger/outputChannel";
+import { downloadEspIdfTools } from "./toolInstall";
+import { isBinInPath } from "../utils";
+
+export async function useExistingEspIdfJsonSetup() {
+  const containerPath =
+    process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
+  const toolsPath = join(containerPath, ".espressif");
+  const idfSetups = await loadIdfSetupsFromEspIdfJson(toolsPath);
+  let quickPickItems = idfSetups.map((idfSetup) => {
+    return {
+      description: idfSetup.idfPath,
+      label: idfSetup.version,
+      target: idfSetup.id,
+      ...idfSetup,
+    };
+  });
+  const espIdfVersion = await window.showQuickPick(quickPickItems, {
+    placeHolder: "Select ESP-IDF version",
+  });
+  if (!espIdfVersion) {
+    Logger.infoNotify("No ESP-IDF version selected.");
+    return;
+  }
+  const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
+    espIdfVersion.idfPath
+  );
+  const exportedToolsPaths = await idfToolsManager.exportPathsInString(
+    join(toolsPath, "tools"),
+    ["cmake", "ninja"]
+  );
+  const exportedVars = await idfToolsManager.exportVars(
+    join(toolsPath, "tools")
+  );
+  await saveSettings(
+    espIdfVersion.idfPath,
+    espIdfVersion.python,
+    exportedToolsPaths,
+    exportedVars,
+    toolsPath,
+    espIdfVersion.gitPath,
+    ConfigurationTarget.Global
+  );
+}
+
+export async function downloadEspIdf(extensionPath: Uri) {
+  const espIdfVersions = await getEspIdfVersions(extensionPath.fsPath);
+
+  let quickPickItems = espIdfVersions.map((k) => {
+    return {
+      description: k.filename,
+      label: k.name,
+      target: k.filename,
+      ...k,
+    };
+  });
+  const espIdfVersion = await window.showQuickPick(quickPickItems, {
+    placeHolder: "Select ESP-IDF version",
+  });
+  if (!espIdfVersion) {
+    Logger.infoNotify("No ESP-IDF version selected.");
+    return;
+  }
+
+  const mirror = await window.showQuickPick(
+    [
+      {
+        description: "Mirror",
+        label: "Espressif",
+        target: ESP.IdfMirror.Espressif,
+      },
+      {
+        description: "Mirror",
+        label: "Github",
+        target: ESP.IdfMirror.Github,
+      },
+    ],
+    { placeHolder: "Select download mirror" }
+  );
+
+  if (!mirror) {
+    Logger.infoNotify("No mirror selected.");
+    return;
+  }
+  const containerPath =
+    process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
+
+  const destPath = join(containerPath, "esp");
+  const toolsPath = join(containerPath, ".espressif");
+  let idfGitPath = "git";
+  let idfPythonPath = "";
+
+  window.withProgress(
+    {
+      cancellable: true,
+      location: ProgressLocation.Notification,
+      title: "Installing ESP-IDF",
+    },
+    async (
+      progress: Progress<{
+        message: string;
+        increment: number;
+      }>,
+      cancelToken: CancellationToken
+    ) => {
+      let onReqPkgs = [];
+      if (process.platform === "win32") {
+        const embedPaths = await this.installEmbedPyGit(
+          toolsPath,
+          progress,
+          cancelToken
+        );
+        idfGitPath = embedPaths.idfGitPath;
+        idfPythonPath = embedPaths.idfPythonPath;
+        const canAccessCMake = await isBinInPath(
+          "cmake",
+          extensionPath.fsPath,
+          process.env
+        );
+  
+        if (canAccessCMake === "") {
+          onReqPkgs = onReqPkgs
+            ? [...onReqPkgs, "cmake"]
+            : ["cmake"];
+        }
+  
+        const canAccessNinja = await isBinInPath(
+          "ninja",
+          extensionPath.fsPath,
+          process.env
+        );
+  
+        if (canAccessNinja === "") {
+          onReqPkgs = onReqPkgs
+            ? [...onReqPkgs, "ninja"]
+            : ["ninja"];
+        }
+      } else {
+        const pythonList = await getUnixPythonList(toolsPath);
+        let pythonItems = pythonList.map((pyVer) => {
+          return {
+            description: "",
+            label: pyVer,
+            target: pyVer,
+          };
+        });
+        const selectPyVersion = await window.showQuickPick(pythonItems, {
+          placeHolder: "Select ESP-IDF version",
+        });
+
+        if (!selectPyVersion) {
+          return;
+        }
+        idfPythonPath = selectPyVersion.target;
+      }
+
+      const espIdfPath = await downloadInstallIdfVersion(
+        espIdfVersion,
+        destPath,
+        mirror.target,
+        idfGitPath,
+        progress,
+        cancelToken
+      );
+      const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
+        espIdfPath
+      );
+      const exportedToolsPaths = await idfToolsManager.exportPathsInString(
+        join(toolsPath, "tools"),
+        ["cmake", "ninja"]
+      );
+      const exportedVars = await idfToolsManager.exportVars(
+        join(toolsPath, "tools")
+      );
+
+      await downloadEspIdfTools(
+        toolsPath,
+        idfToolsManager,
+        mirror.target,
+        progress,
+        idfPythonPath,
+        cancelToken,
+        onReqPkgs
+      );
+
+      const virtualEnvPath = await installPythonEnvFromIdfTools(
+        espIdfPath,
+        toolsPath,
+        undefined,
+        idfPythonPath,
+        idfGitPath,
+        OutputChannel.init(),
+        cancelToken
+      );
+
+      await installExtensionPyReqs(
+        virtualEnvPath,
+        espIdfPath,
+        toolsPath,
+        undefined,
+        OutputChannel.init()
+      );
+
+      await saveSettings(
+        espIdfPath,
+        virtualEnvPath,
+        exportedToolsPaths,
+        exportedVars,
+        toolsPath,
+        idfGitPath,
+        ConfigurationTarget.Global
+      );
+    }
+  );
+}

--- a/src/setup/cmd.ts
+++ b/src/setup/cmd.ts
@@ -22,6 +22,7 @@ import {
   ExtensionContext,
   Progress,
   ProgressLocation,
+  Uri,
   window,
 } from "vscode";
 import { getEspIdfVersions } from "./espIdfVersionList";
@@ -42,7 +43,7 @@ import { downloadEspIdfTools } from "./toolInstall";
 import { isBinInPath } from "../utils";
 import { pathExists } from "fs-extra";
 
-export async function useExistingEspIdfJsonSetup() {
+export async function useExistingEspIdfJsonSetup(workspaceFolder: Uri) {
   const containerPath =
     process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
   let toolsPath = join(containerPath, ".espressif");
@@ -97,7 +98,8 @@ export async function useExistingEspIdfJsonSetup() {
     exportedVars,
     toolsPath,
     espIdfVersion.gitPath,
-    ConfigurationTarget.Global
+    ConfigurationTarget.WorkspaceFolder,
+    workspaceFolder
   );
 }
 
@@ -115,7 +117,10 @@ export async function openFolder(openLabel: string) {
   }
 }
 
-export async function downloadEspIdf(context: ExtensionContext) {
+export async function downloadEspIdf(
+  context: ExtensionContext,
+  workspaceFolder: Uri
+) {
   const espIdfVersions = await getEspIdfVersions(context.extensionPath);
 
   let quickPickItems = espIdfVersions.map((k) => {
@@ -300,7 +305,8 @@ export async function downloadEspIdf(context: ExtensionContext) {
         exportedVars,
         toolsPath,
         idfGitPath,
-        ConfigurationTarget.Global
+        ConfigurationTarget.WorkspaceFolder,
+        workspaceFolder
       );
     }
   );

--- a/src/setup/cmd.ts
+++ b/src/setup/cmd.ts
@@ -19,9 +19,9 @@
 import {
   CancellationToken,
   ConfigurationTarget,
+  ExtensionContext,
   Progress,
   ProgressLocation,
-  Uri,
   window,
 } from "vscode";
 import { getEspIdfVersions } from "./espIdfVersionList";
@@ -115,8 +115,8 @@ export async function openFolder(openLabel: string) {
   }
 }
 
-export async function downloadEspIdf(extensionPath: Uri) {
-  const espIdfVersions = await getEspIdfVersions(extensionPath.fsPath);
+export async function downloadEspIdf(context: ExtensionContext) {
+  const espIdfVersions = await getEspIdfVersions(context.extensionPath);
 
   let quickPickItems = espIdfVersions.map((k) => {
     return {
@@ -204,7 +204,7 @@ export async function downloadEspIdf(extensionPath: Uri) {
         idfPythonPath = embedPaths.idfPythonPath;
         const canAccessCMake = await isBinInPath(
           "cmake",
-          extensionPath.fsPath,
+          context.extensionPath,
           process.env
         );
 
@@ -214,7 +214,7 @@ export async function downloadEspIdf(extensionPath: Uri) {
 
         const canAccessNinja = await isBinInPath(
           "ninja",
-          extensionPath.fsPath,
+          context.extensionPath,
           process.env
         );
 
@@ -222,7 +222,7 @@ export async function downloadEspIdf(extensionPath: Uri) {
           onReqPkgs = onReqPkgs ? [...onReqPkgs, "ninja"] : ["ninja"];
         }
       } else {
-        const pythonList = await getUnixPythonList(extensionPath.fsPath);
+        const pythonList = await getUnixPythonList(context.extensionPath);
         let pythonItems = pythonList.map((pyVer) => {
           return {
             description: "",
@@ -271,6 +271,7 @@ export async function downloadEspIdf(extensionPath: Uri) {
         undefined,
         idfPythonPath,
         idfGitPath,
+        context,
         OutputChannel.init(),
         cancelToken
       );

--- a/src/setup/existingIdfSetups.ts
+++ b/src/setup/existingIdfSetups.ts
@@ -116,5 +116,7 @@ export async function loadIdfSetupsFromEspIdfJson(toolsPath: string) {
       idfSetups.push(setupConf);
     }
     return idfSetups;
+  } else {
+    return [];
   }
 }


### PR DESCRIPTION
## Description

Add command to use IDF setup from IDF_TOOLS_PATH/esp_idf.json and command to install ESP-IDF in default location without setting paths.

**ESP-IDF: Use ESP-IDF setup from IDF Installer** can be used to load IDF Setup installed with IDF Installer's esp-idf.json in IDF_TOOLS_PATH.

**ESP-IDF: Install ESP-IDF** can be used to install ESP-IDF and tools without UI, just write the progress in the Output Channel and save settings in the global user settings.json.

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on **ESP-IDF: Use ESP-IDF setup from IDF Installer** and select the `$HOME/.espressif` or `%USERPROFILE%\.espressif`
2. Choose one of the existing IDF setup
3. Observe results. Settings should be saved and the extension should be able to build and do other commands.
4. Click **ESP-IDF: Install ESP-IDF** command, choose ESP-IDF path and IDF Tools path. 
5. See the progress in the ESP-IDF output channel.
6. Observe results. Settings should be saved and the extension should be able to build and do other commands.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
