### PR TITLE
Add fix for version 5.1.0 or above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 gcovr
-idf-component-manager
 websocket_client

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -23,6 +23,7 @@ import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
 import { fileExists, spawn } from "../../utils";
 import { getProjectName } from "../../workspaceConfig";
+import * as utils from "../../utils";
 
 export class IDFSize {
   private readonly workspaceRoot: vscode.Uri;
@@ -62,10 +63,18 @@ export class IDFSize {
         "idfSize.overviewMsg",
         "Gathering Overview"
       );
+      const espIdfPath = idfConf.readParameter(
+        "idf.espIdfPath",
+        this.workspaceRoot
+      ) as string;
+      const version = await utils.getEspIdfFromCMake(espIdfPath);
+      const formatArgs = utils.isVersionGreaterOrEqual("5.1.0", version)
+        ? ["--format", "json"]
+        : ["--json"];
       const overview = await this.idfCommandInvoker([
         "idf_size.py",
         mapFilePath,
-        "--json",
+        ...formatArgs,
       ]);
       progress.report({ increment: 30, message: locMsg });
 
@@ -77,7 +86,7 @@ export class IDFSize {
         "idf_size.py",
         mapFilePath,
         "--archives",
-        "--json",
+        ...formatArgs,
       ]);
       progress.report({ increment: 30, message: locMsg });
 
@@ -89,7 +98,7 @@ export class IDFSize {
         "idf_size.py",
         mapFilePath,
         "--file",
-        "--json",
+        ...formatArgs,
       ]);
       progress.report({ increment: 30, message: locMsg });
 

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -68,7 +68,7 @@ export class IDFSize {
         this.workspaceRoot
       ) as string;
       const version = await utils.getEspIdfFromCMake(espIdfPath);
-      const formatArgs = utils.isVersionGreaterOrEqual("5.1.0", version)
+      const formatArgs = utils.compareVersion(version, "5.1.0") >= 0 
         ? ["--format", "json"]
         : ["--json"];
       const overview = await this.idfCommandInvoker([

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -68,9 +68,10 @@ export class IDFSize {
         this.workspaceRoot
       ) as string;
       const version = await utils.getEspIdfFromCMake(espIdfPath);
-      const formatArgs = utils.compareVersion(version, "5.1.0") >= 0 
-        ? ["--format", "json"]
-        : ["--json"];
+      const formatArgs =
+        utils.compareVersion(version, "5.1.0") >= 0
+          ? ["--format", "json"]
+          : ["--json"];
       const overview = await this.idfCommandInvoker([
         "idf_size.py",
         mapFilePath,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1198,3 +1198,19 @@ export function markdownToWebviewHtml(
   cleanHtml = cleanHtml.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
   return cleanHtml;
 }
+
+export function isVersionGreaterOrEqual(baseVersion, targetVersion) {
+  const baseParts = baseVersion.split(".").map(Number);
+  const targetParts = targetVersion.split(".").map(Number);
+
+  for (let i = 0; i < baseParts.length; i++) {
+    if (targetParts[i] > baseParts[i]) {
+      return true;
+    } else if (targetParts[i] < baseParts[i]) {
+      return false;
+    }
+  }
+
+  // If all parts are equal up to this point, then the targetVersion is >= baseVersion
+  return true;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1198,19 +1198,3 @@ export function markdownToWebviewHtml(
   cleanHtml = cleanHtml.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
   return cleanHtml;
 }
-
-export function isVersionGreaterOrEqual(baseVersion, targetVersion) {
-  const baseParts = baseVersion.split(".").map(Number);
-  const targetParts = targetVersion.split(".").map(Number);
-
-  for (let i = 0; i < baseParts.length; i++) {
-    if (targetParts[i] > baseParts[i]) {
-      return true;
-    } else if (targetParts[i] < baseParts[i]) {
-      return false;
-    }
-  }
-
-  // If all parts are equal up to this point, then the targetVersion is >= baseVersion
-  return true;
-}


### PR DESCRIPTION
## Description

Added dynamic arguments based on version being >= 5.1.0
For versions < 5.1.0 it will remain --json, but for >= it will be --format json

Fixes #1033 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

**Test 1**
1 - Configure for ESP IDF 5.1.0 or above
2 - Create a new project from the 'blink' template. Select a target
3 - Build project
4 - Run command 'Size analysis of the binaries'

**Test 2**
1 - Configure for ESP IDF version below 5.1.0
2 - Create a new project from the 'blink' template. Select a target
3 - Build project
4 - Run command 'Size analysis of the binaries'

EXPECT: Binary size analysis panel opens in VS Code

## How has this been tested?

I've tested as described above on windows 10.

**Test Configuration**:
* ESP-IDF Version: 5.1.0
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
