### PR TITLE
Remove idf component manager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 gcovr
-idf-component-manager
 websocket_client


### PR DESCRIPTION
## Description

Removes the idf component manager from extension's requirements.txt

Fixes #1044

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Run ESP-IDF: Configure ESP-IDF Extension
2. Install 4.4.5 idf version
3. No issues during setup

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested it as described above on the following os:
Windows 10, Linux and Mac

**Test Configuration**:
* ESP-IDF Version: 4.4.5, 5.0, 5,1, master
* OS (Windows,Linux and macOS): Windows, Linux, Mac

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
