### PR TITLE
remove win esp-matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 
 3. The **Install ESP-ADF** will clone ESP-ADF inside the selected directory and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows) configuration setting.
 
-4. The **Install ESP-Matter** will clone ESP-Matter inside the selected directory and set `idf.espMatterPath` (`idf.espMatterPathWin` in Windows) configuration setting. The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter.
+4. The **Install ESP-Matter** will clone ESP-Matter inside the selected directory and set `idf.espMatterPath` configuration setting. The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter. **ESP-Matter is not supported in Windows**.
 
 5. The **Install ESP-MDF** will clone ESP-MDF inside the selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
 

--- a/docs/HARDWARE_SUPPORT.md
+++ b/docs/HARDWARE_SUPPORT.md
@@ -23,7 +23,7 @@ In addition to ESP-IDF chips, there are several boards configurations files impl
 
 - [Espressif Mesh Development Framework (ESP-MDF)](https://github.com/espressif/esp-mdf) to develop with the [ESP-WIFI-MESH](https://docs.espressif.com/projects/esp-idf/en/stable/api-guides/mesh.html) networking protocol. The **Install ESP-MDF** will clone ESP-MDF to a selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
 
-- [Espressif Matter Framework (ESP-Matter)](https://github.com/espressif/esp-matter) to develop with the [Matter](https://buildwithmatter.com/) unified IP-based connectivity protocol. The **Install ESP-Matter** will clone ESP-Matter to a selected directory and set `idf.espMatterPath` (`idf.espMatterPathWin` in Windows) configuration setting.
+- [Espressif Matter Framework (ESP-Matter)](https://github.com/espressif/esp-matter) to develop with the [Matter](https://buildwithmatter.com/) unified IP-based connectivity protocol. The **Install ESP-Matter** will clone ESP-Matter to a selected directory and set `idf.espMatterPath` configuration setting. **ESP-Matter is not supported in Windows**.
 
 - [Espressif Rainmaker](https://github.com/espressif/esp-rainmaker) can be clone with the **Install ESP-Rainmaker** to a selected and set `idf.espRainmakerPath` (`idf.espRainmakerPathWin` in Windows) configuration setting.
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -145,20 +145,19 @@ These settings are specific to [Application Log Tracing](./HEAP_TRACING.md).
 
 These settings allow to support additional frameworks together with ESP-IDF:
 
-| Setting ID                | Description                                                      |
-| ------------------------- | ---------------------------------------------------------------- |
-| `idf.espAdfPath`          | Path to locate ESP-ADF framework (ADF_PATH)                      |
-| `idf.espAdfPathWin`       | Path to locate ESP-ADF framework in Windows (ADF_PATH)           |
-| `idf.espMdfPath`          | Path to locate ESP-MDF framework (MDF_PATH)                      |
-| `idf.espMdfPathWin`       | Path to locate ESP-MDF framework in Windows (MDF_PATH)           |
-| `idf.espMatterPath`       | Path to locate ESP-Matter framework (ESP_MATTER_PATH)            |
-| `idf.espMatterPathWin`    | Path to locate ESP-Matter framework in Windows (ESP_MATTER_PATH) |
-| `idf.espRainmakerPath`    | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH)  |
-| `idf.espRainmakerPathWin` | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH)  |
+| Setting ID                | Description                                                     |
+| ------------------------- | --------------------------------------------------------------- |
+| `idf.espAdfPath`          | Path to locate ESP-ADF framework (ADF_PATH)                     |
+| `idf.espAdfPathWin`       | Path to locate ESP-ADF framework in Windows (ADF_PATH)          |
+| `idf.espMdfPath`          | Path to locate ESP-MDF framework (MDF_PATH)                     |
+| `idf.espMdfPathWin`       | Path to locate ESP-MDF framework in Windows (MDF_PATH)          |
+| `idf.espMatterPath`       | Path to locate ESP-Matter framework (ESP_MATTER_PATH)           |
+| `idf.espRainmakerPath`    | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH) |
+| `idf.espRainmakerPathWin` | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH) |
 
 The **Install ESP-ADF** command will clone ESP-ADF and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows).
 The **Install ESP-MDF** command will clone ESP-MDF and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows).
-The **Install ESP-Matter** command will clone ESP-Matter and set `idf.espMatterPath` (`idf.espMatterPathWin` in Windows). The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter.
+The **Install ESP-Matter** command will clone ESP-Matter and set `idf.espMatterPath`. The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter. ESP-Matter is not supported in Windows.
 The **Install ESP-Rainmaker** command will clone ESP-Rainmaker and set `idf.espRainmakerPath` (`idf.espRainmakerPathWin` in Windows) configuration setting.
 
 The **Show Examples Projects** command allows you create a new project using one of the examples in ESP-IDF, ESP-ADF, ESP-Matter or ESP-MDF directory if related configuration settings are set, or to create projects from examples found in the Component Registry.

--- a/docs/tutorial/additional_frameworks.md
+++ b/docs/tutorial/additional_frameworks.md
@@ -8,7 +8,7 @@ Besides ESP-IDF, you can install other frameworks to extend the extension functi
 
 2. [Espressif Mesh Development Framework (ESP-MDF)](https://github.com/espressif/esp-mdf) with this extension using the **Install ESP-MDF** command, which will clone ESP-MDF to the selected directory and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows) configuration setting.
 
-3. [Espressif Matter Framework (ESP-Matter)](https://github.com/espressif/esp-matter) with this extension using the **Install ESP-Matter** command, which will clone ESP-Matter to the selected directory and set `idf.espMatterPath` (`idf.espMatterPathWin` in Windows) configuration setting. The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter.
+3. [Espressif Matter Framework (ESP-Matter)](https://github.com/espressif/esp-matter) with this extension using the **Install ESP-Matter** command, which will clone ESP-Matter to the selected directory and set `idf.espMatterPath` configuration setting. The **Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)** is used to define the device path for ESP-Matter. **ESP-Matter is not supported in Windows**.
 
 4. [Espressif Rainmaker](https://github.com/espressif/esp-rainmaker) can be clone with the **Install ESP-Rainmaker** to a selected and set `idf.espRainmakerPath` (`idf.espRainmakerPathWin` in Windows) configuration setting.
 

--- a/package.json
+++ b/package.json
@@ -427,12 +427,6 @@
             "description": "%param.espMdfPath%",
             "scope": "resource"
           },
-          "idf.espMatterPathWin": {
-            "type": "string",
-            "default": "${env:ESP_MATTER_PATH}",
-            "description": "%param.espMatterPath%",
-            "scope": "resource"
-          },
           "idf.toolsPathWin": {
             "type": "string",
             "default": "${env:IDF_TOOLS_PATH}",

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,7 +55,6 @@ export namespace ESP {
     "idf.buildPath",
     "idf.espIdfPath",
     "idf.espAdfPath",
-    "idf.espMatterPath",
     "idf.espMdfPath",
     "idf.espRainmakerPath",
     "idf.gitPath",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -701,15 +701,21 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.getEspMdf", async () => getEspMdf(workspaceRoot));
 
-  registerIDFCommand("espIdf.getEspMatter", async () =>
-    getEspMatter(workspaceRoot)
-  );
+  registerIDFCommand("espIdf.getEspMatter", async () => {
+    if (process.platform === "win32") {
+      return Logger.infoNotify(`ESP-Matter is not available for Windows.`);
+    }
+    getEspMatter(workspaceRoot);
+  });
 
   registerIDFCommand("espIdf.getEspRainmaker", async () =>
     getEspRainmaker(workspaceRoot)
   );
 
   registerIDFCommand("espIdf.setMatterDevicePath", async () => {
+    if (process.platform === "win32") {
+      return Logger.infoNotify(`ESP-Matter is not available for Windows.`);
+    }
     const configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder;
     let workspaceFolder = await vscode.window.showWorkspaceFolderPick({
       placeHolder: `Pick Workspace Folder to which settings should be applied`,
@@ -1421,6 +1427,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.installEspMatterPyReqs", () => {
+    if (process.platform === "win32") {
+      return Logger.infoNotify(`ESP-Matter is not available for Windows.`);
+    }
     return PreCheck.perform([openFolderCheck], async () => {
       vscode.window.withProgress(
         {
@@ -1682,7 +1691,18 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
-  registerIDFCommand("espIdf.examples.start", () => {
+  registerIDFCommand("espIdf.examples.start", async () => {
+    const pickItems = await getFrameworksPickItems();
+    if (!pickItems || pickItems.length == 0) {
+      return Logger.infoNotify("No ESP-IDF frameworks found");
+    }
+    const examplesFolder = await vscode.window.showQuickPick(pickItems, {
+      placeHolder: "Select framework to use",
+    });
+    if (!examplesFolder) {
+      Logger.infoNotify("No framework selected to load examples.");
+      return;
+    }
     try {
       vscode.window.withProgress(
         {
@@ -1694,78 +1714,6 @@ export async function activate(context: vscode.ExtensionContext) {
           progress: vscode.Progress<{ message: string; increment: number }>
         ) => {
           try {
-            const espIdfPath = idfConf.readParameter(
-              "idf.espIdfPath",
-              workspaceRoot
-            ) as string;
-            const espAdfPath = idfConf.readParameter(
-              "idf.espAdfPath",
-              workspaceRoot
-            ) as string;
-            const espMdfPath = idfConf.readParameter(
-              "idf.espMdfPath",
-              workspaceRoot
-            ) as string;
-            const matterPathDir = idfConf.readParameter(
-              "idf.espMatterPath"
-            ) as string;
-            const rainmakerPathDir = idfConf.readParameter(
-              "idf.espRainmakerPath"
-            ) as string;
-
-            const pickItems = [];
-            const doesIdfPathExists = await utils.dirExistPromise(espIdfPath);
-            if (doesIdfPathExists) {
-              pickItems.push({
-                description: "ESP-IDF",
-                label: `Use current ESP-IDF (${espIdfPath})`,
-                target: espIdfPath,
-              });
-            }
-            const doesAdfPathExists = await utils.dirExistPromise(espAdfPath);
-            if (doesAdfPathExists) {
-              pickItems.push({
-                description: "ESP-ADF",
-                label: `Use current ESP-ADF (${espAdfPath})`,
-                target: espAdfPath,
-              });
-            }
-            const doesMdfPathExists = await utils.dirExistPromise(espMdfPath);
-            if (doesMdfPathExists) {
-              pickItems.push({
-                description: "ESP-MDF",
-                label: `Use current ESP-MDF (${espMdfPath})`,
-                target: espMdfPath,
-              });
-            }
-            const doesMatterPathExists = await utils.dirExistPromise(
-              matterPathDir
-            );
-            if (doesMatterPathExists) {
-              pickItems.push({
-                description: "ESP-Matter",
-                label: `Use current ESP-Matter (${matterPathDir})`,
-                target: matterPathDir,
-              });
-            }
-            const doesEspRainmakerPathExists = await utils.dirExistPromise(
-              rainmakerPathDir
-            );
-            if (doesEspRainmakerPathExists) {
-              pickItems.push({
-                description: "ESP-Rainmaker",
-                label: `Use current ESP-Rainmaker (${rainmakerPathDir})`,
-                target: rainmakerPathDir,
-              });
-            }
-            const examplesFolder = await vscode.window.showQuickPick(
-              pickItems,
-              { placeHolder: "Select framework to use" }
-            );
-            if (!examplesFolder) {
-              Logger.infoNotify("No framework selected to load examples.");
-              return;
-            }
             const doesFolderExist = await utils.dirExistPromise(
               examplesFolder.target
             );
@@ -3011,6 +2959,76 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   });
   await checkExtensionSettings(context.extensionPath, workspaceRoot);
+}
+
+async function getFrameworksPickItems() {
+  const espIdfPath = idfConf.readParameter(
+    "idf.espIdfPath",
+    workspaceRoot
+  ) as string;
+  const espAdfPath = idfConf.readParameter(
+    "idf.espAdfPath",
+    workspaceRoot
+  ) as string;
+  const espMdfPath = idfConf.readParameter(
+    "idf.espMdfPath",
+    workspaceRoot
+  ) as string;
+  const matterPathDir = idfConf.readParameter("idf.espMatterPath") as string;
+  const rainmakerPathDir = idfConf.readParameter(
+    "idf.espRainmakerPath"
+  ) as string;
+
+  const pickItems = [];
+  try {
+    const doesIdfPathExists = await utils.dirExistPromise(espIdfPath);
+    if (doesIdfPathExists) {
+      pickItems.push({
+        description: "ESP-IDF",
+        label: `Use current ESP-IDF (${espIdfPath})`,
+        target: espIdfPath,
+      });
+    }
+    const doesAdfPathExists = await utils.dirExistPromise(espAdfPath);
+    if (doesAdfPathExists) {
+      pickItems.push({
+        description: "ESP-ADF",
+        label: `Use current ESP-ADF (${espAdfPath})`,
+        target: espAdfPath,
+      });
+    }
+    const doesMdfPathExists = await utils.dirExistPromise(espMdfPath);
+    if (doesMdfPathExists) {
+      pickItems.push({
+        description: "ESP-MDF",
+        label: `Use current ESP-MDF (${espMdfPath})`,
+        target: espMdfPath,
+      });
+    }
+    const doesMatterPathExists = await utils.dirExistPromise(matterPathDir);
+    if (doesMatterPathExists) {
+      pickItems.push({
+        description: "ESP-Matter",
+        label: `Use current ESP-Matter (${matterPathDir})`,
+        target: matterPathDir,
+      });
+    }
+    const doesEspRainmakerPathExists = await utils.dirExistPromise(
+      rainmakerPathDir
+    );
+    if (doesEspRainmakerPathExists) {
+      pickItems.push({
+        description: "ESP-Rainmaker",
+        label: `Use current ESP-Rainmaker (${rainmakerPathDir})`,
+        target: rainmakerPathDir,
+      });
+    }
+  } catch (error) {
+    const errMsg = error.message ? error.message : "Error getting frameworks";
+    Logger.errorNotify(errMsg, error);
+    return pickItems;
+  }
+  return pickItems;
 }
 
 function validateInputForRainmakerDeviceParam(

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -29,7 +29,7 @@ export function getConfigurationSettings(
     espAdfPath: conf.get("idf.espAdfPath" + winFlag),
     espIdfPath: conf.get("idf.espIdfPath" + winFlag),
     espMdfPath: conf.get("idf.espMdfPath" + winFlag),
-    espMatterPath: conf.get("idf.espMatterPath" + winFlag),
+    espMatterPath: conf.get("idf.espMatterPath"),
     customTerminalExecutable: conf.get("idf.customTerminalExecutable"),
     customTerminalExecutableArgs: conf.get("idf.customTerminalExecutableArgs"),
     customExtraPaths: conf.get("idf.customExtraPaths"),


### PR DESCRIPTION
## Description

Remove ESP-Matter setting for Windows and add validation for ESP-Matter command that is not available in Windows.

Remove Examples QuickPick from Progress Notification.

Fixes #1049

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- 
## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-Matter" related command in Windows.
2. Execute action. The command should show that this is only available on Windows.
3. Observe results.

- Expected behaviour:

- Expected output:
Message  shown that this is not available on Windows.

## How has this been tested?

Tested Manually

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
