### PR TITLE
fix esp32h2 set target on idf446

### DIFF
--- a/src/espIdf/setTarget/setTargetInIdf.ts
+++ b/src/espIdf/setTarget/setTargetInIdf.ts
@@ -48,16 +48,17 @@ export async function setTargetInIDF(
     "idf.enableCCache",
     workspaceFolder.uri
   ) as boolean;
-  const setTargetArgs: string[] = [idfPy, "-B", buildDirPath];
+  const setTargetArgs: string[] = [idfPy];
+  if (selectedTarget.isPreview) {
+    setTargetArgs.push("--preview");
+  }
+  setTargetArgs.push("-B", buildDirPath);
   if (enableCCache) {
     modifiedEnv.IDF_CCACHE_ENABLE = "1";
   } else {
     modifiedEnv.IDF_CCACHE_ENABLE = undefined;
   }
   setTargetArgs.push("set-target", selectedTarget.target);
-  if (selectedTarget.isPreview) {
-    setTargetArgs.push("--preview");
-  }
   const pythonBinPath = readParameter(
     "idf.pythonBinPath",
     workspaceFolder.uri


### PR DESCRIPTION
## Description

Fix VSC-1201 for idf.py set-target esp32h2 on idf 4.4.6.

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Set Espressif device target" command.
2. Select esp32h2. 
3. Observe results. No errors should be found.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 4.4.6
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
