### PR TITLE
rm video link from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,6 @@
 
 # [ESP-IDF VS Code Extension's](http://github.com/espressif/vscode-esp-idf-extension) Changelog
 
-> We have opened a [survey link](https://bit.ly/3iNCFyY), please submit your valuable feedbacks. Thanks 👏
-
-<a href="https://youtu.be/Lc6ausiKvQM">
-
-  <p align="center">
-    <img src="./media/youtube_tutorial_preview.png" alt="Quick User Guide for the ESP-IDF VS Code Extension" width="1024">
-  </p>
-</a>
-
 ---
 
 All notable changes to the "Espressif IDF" extension will be documented in this file.


### PR DESCRIPTION
## Description

Remove YouTube video link from changelog

Fixes #1058

## Type of change

- This change requires a documentation update

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
