### PR TITLE
extension auto configuration

### DIFF
--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -228,7 +228,7 @@ export class IdfToolsManager {
       const binVersionResponse = await utils.execChildProcess(
         versionCmd,
         process.cwd(),
-        this.toolsManagerChannel,
+        logToChannel ? this.toolsManagerChannel: undefined,
         {
           env: modifiedEnv,
           maxBuffer: 500 * 1024,

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -122,12 +122,16 @@ export class IdfToolsManager {
     });
   }
 
-  public async verifyPackages(pathsToVerify: string, onReqPkgs?: string[]) {
+  public async verifyPackages(
+    pathsToVerify: string,
+    onReqPkgs?: string[],
+    logToChannel: boolean = true
+  ) {
     const pkgs = await this.getPackageList(onReqPkgs);
     const promiseArr: { [key: string]: string } = {};
     const names = pkgs.map((pkg) => pkg.name);
     const promises = pkgs.map((p) =>
-      this.checkBinariesVersion(p, pathsToVerify)
+      this.checkBinariesVersion(p, pathsToVerify, logToChannel)
     );
     const versionExistsArr = await Promise.all(promises);
     names.forEach((pkgName, i) => (promiseArr[pkgName] = versionExistsArr[i]));
@@ -195,7 +199,11 @@ export class IdfToolsManager {
     return versions.length > 0 ? versions[0].name : undefined;
   }
 
-  public async checkBinariesVersion(pkg: IPackage, pathsToVerify: string) {
+  public async checkBinariesVersion(
+    pkg: IPackage,
+    pathsToVerify: string,
+    logToChannel: boolean = true
+  ) {
     const pathNameInEnv: string =
       process.platform === "win32" ? "Path" : "PATH";
     let modifiedPath = process.env[pathNameInEnv];
@@ -246,8 +254,10 @@ export class IdfToolsManager {
       return "No match";
     } catch (error) {
       const errMsg = `Error checking ${pkg.name} version`;
-      this.toolsManagerChannel.appendLine(errMsg);
-      this.toolsManagerChannel.appendLine(error);
+      if (logToChannel) {
+        this.toolsManagerChannel.appendLine(errMsg);
+        this.toolsManagerChannel.appendLine(error);
+      }
       Logger.error(errMsg, error);
       return errMsg;
     }
@@ -315,11 +325,16 @@ export class IdfToolsManager {
   public async getRequiredToolsInfo(
     basePath?: string,
     pathToVerify?: string,
-    onReqPkgs?: string[]
+    onReqPkgs?: string[],
+    logToChannel: boolean = true
   ) {
     let versions: { [key: string]: string } = {};
     if (pathToVerify) {
-      versions = await this.verifyPackages(pathToVerify, onReqPkgs);
+      versions = await this.verifyPackages(
+        pathToVerify,
+        onReqPkgs,
+        logToChannel
+      );
     }
     const packages = await this.getPackageList(onReqPkgs);
     const idfToolsList = packages.map((pkg) => {

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -228,7 +228,7 @@ export class IdfToolsManager {
       const binVersionResponse = await utils.execChildProcess(
         versionCmd,
         process.cwd(),
-        logToChannel ? this.toolsManagerChannel: undefined,
+        logToChannel ? this.toolsManagerChannel : undefined,
         {
           env: modifiedEnv,
           maxBuffer: 500 * 1024,

--- a/src/setup/existingIdfSetups.ts
+++ b/src/setup/existingIdfSetups.ts
@@ -23,7 +23,7 @@ import { IdfSetup } from "../views/setup/types";
 import { getIdfMd5sum, loadEspIdfJson } from "./espIdfJson";
 import { checkIdfSetup } from "./setupValidation/espIdfSetup";
 
-export async function getPreviousIdfSetups() {
+export async function getPreviousIdfSetups(logToChannel: boolean = true) {
   const setupKeys = ESP.GlobalConfiguration.store.getIdfSetupKeys();
   const idfSetups: IdfSetup[] = [];
   for (let idfSetupKey of setupKeys) {
@@ -33,7 +33,7 @@ export async function getPreviousIdfSetups() {
     );
     if (idfSetup && idfSetup.idfPath) {
       try {
-        idfSetup.isValid = await checkIdfSetup(idfSetup);
+        idfSetup.isValid = await checkIdfSetup(idfSetup, logToChannel);
         idfSetup.version = await getEspIdfFromCMake(idfSetup.idfPath);
         idfSetups.push(idfSetup);
       } catch (err) {
@@ -41,7 +41,7 @@ export async function getPreviousIdfSetups() {
           ? err.message
           : "Error checkIdfSetup in getPreviousIdfSetups";
         Logger.error(msg, err);
-        ESP.GlobalConfiguration.store.clearIdfSetup(idfSetup.id)
+        ESP.GlobalConfiguration.store.clearIdfSetup(idfSetup.id);
       }
     }
   }
@@ -105,7 +105,7 @@ export async function loadIdfSetupsFromEspIdfJson(toolsPath: string) {
         isValid: false,
       } as IdfSetup;
       try {
-        setupConf.isValid = await checkIdfSetup(setupConf);
+        setupConf.isValid = await checkIdfSetup(setupConf, false);
       } catch (err) {
         const msg = err.message
           ? err.message

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -131,7 +131,7 @@ export async function getSetupInitialValues(
   const espIdfTagsList = await getEspIdfTags();
   progress.report({ increment: 10, message: "Getting Python versions..." });
   const pythonVersions = await getPythonList(extensionPath);
-  const idfSetups = await getPreviousIdfSetups();
+  const idfSetups = await getPreviousIdfSetups(false);
   const setupInitArgs = {
     espIdfVersionsList,
     espIdfTagsList,

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -284,7 +284,8 @@ export async function isCurrentInstallValid(workspaceFolder: Uri) {
   const toolsInfo = await idfToolsManager.getRequiredToolsInfo(
     path.join(toolsPath, "tools"),
     extraPaths,
-    extraReqPaths
+    extraReqPaths,
+    false
   );
   const failedToolsResult = toolsInfo.filter(
     (tInfo) =>

--- a/src/setup/setupValidation/espIdfSetup.ts
+++ b/src/setup/setupValidation/espIdfSetup.ts
@@ -57,7 +57,8 @@ export async function useIdfSetupSettings(
   );
 }
 
-export async function checkIdfSetup(setupConf: IdfSetup) {
+export async function checkIdfSetup(setupConf: IdfSetup,
+  logToChannel: boolean = true) {
   try {
     if (!setupConf.idfPath) {
       return false;
@@ -76,7 +77,8 @@ export async function checkIdfSetup(setupConf: IdfSetup) {
     const toolsInfo = await idfToolsManager.getRequiredToolsInfo(
       join(setupConf.toolsPath, "tools"),
       exportedToolsPaths,
-      ["cmake", "ninja"]
+      ["cmake", "ninja"],
+      logToChannel
     );
 
     const failedToolsResult = toolsInfo.filter(


### PR DESCRIPTION
## Description

Review extension initial load which will try to auto configure the extension based on defaults settings for IDF_PATH and IDF_TOOLS_PATH. Will show options from `esp-idf.json` if available.


Fixes VSC-1219

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Install extension without any previous settings.json for IDF. See extension self configuration and show options to configure in case no valid setup is found.

## How has this been tested?

Manual testing installing the extension on fresh environment without setup

**Test Configuration**:
* ESP-IDF Version: any
* OS (Windows,Linux and macOS): any

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
