### PR TITLE
fix sdkconfig defaults in build compiler args

### DIFF
--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -188,7 +188,7 @@ export class BuildTask {
         sdkconfigDefaults.length
       ) {
         compilerArgs.push(
-          `-DSDKCONFIG_DEFAULTS="${sdkconfigDefaults.join(";")}"`
+          `-DSDKCONFIG_DEFAULTS=${sdkconfigDefaults.join(";")}`
         );
       }
 

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -183,7 +183,7 @@ export class BuildTask {
         (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
 
       if (
-        compilerArgs.indexOf("SDKCONFIG_DEFAULTS") !== -1 &&
+        compilerArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&
         sdkconfigDefaults &&
         sdkconfigDefaults.length
       ) {

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -188,7 +188,7 @@ export class BuildTask {
         sdkconfigDefaults.length
       ) {
         compilerArgs.push(
-          `-DSDKCONFIG_DEFAULTS=${sdkconfigDefaults.join(";")}`
+          `-DSDKCONFIG_DEFAULTS='${sdkconfigDefaults.join(";")}'`
         );
       }
 

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -188,8 +188,7 @@ export class BuildTask {
         sdkconfigDefaults.length
       ) {
         compilerArgs.push(
-          "-D",
-          `SDKCONFIG_DEFAULTS="${sdkconfigDefaults.join(";")}"`
+          `-DSDKCONFIG_DEFAULTS="${sdkconfigDefaults.join(";")}"`
         );
       }
 

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -232,7 +232,7 @@ export class BuildTask {
     const buildPresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,
-      clear: cmakeCacheExists,
+      clear: false,
       panel: vscode.TaskPanelKind.Shared,
     } as vscode.TaskPresentationOptions;
     TaskManager.addTask(


### PR DESCRIPTION
## Description

Fix SDKCONFIG_DEFAULTS in compiler args not being pushed to compiler arguments list.

Fixes #1074 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Create a project that uses multiple sdkconfig as SDKCONFIG_DEFAULTS like the https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config example
2. Click on "ESP-IDF: Build your project" with `"idf.sdkconfigDefaults": ["sdkconfig.prod_common", "sdkconfig.prod1"]` in your **.vscode/settings.json** .
3. See build output in terminal. Check `-DSDKCONFIG_DEFAULTS="sdkconfig.prod_common;sdkconfig.prod1"` was part built command.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
