### PR TITLE
add boards filtered by idf target

### DIFF
--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -100,9 +100,15 @@ export function getOpenOcdScripts(workspace: Uri): string {
   return openOcdScriptsPath;
 }
 
-export async function getBoards(openOcdScriptsPath: string = "") {
+export async function getBoards(
+  idfTarget: string = "",
+  openOcdScriptsPath: string = ""
+) {
   if (!openOcdScriptsPath) {
-    return defaultBoards;
+    const filteredDefaultBoards = defaultBoards.filter((b) => {
+      return b.target === idfTarget;
+    });
+    return idfTarget ? filteredDefaultBoards : defaultBoards;
   }
   const openOcdEspConfig = join(openOcdScriptsPath, "esp-config.json");
   try {
@@ -131,9 +137,15 @@ export async function getBoards(openOcdScriptsPath: string = "") {
       configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32.cfg"],
     } as IdfBoard;
     espBoards.push(emptyBoard);
-    return espBoards;
+    const filteredEspBoards = espBoards.filter((b) => {
+      return b.target === idfTarget;
+    });
+    return idfTarget ? filteredEspBoards : espBoards;
   } catch (error) {
     Logger.error(error.message, error);
-    return defaultBoards;
+    const filteredDefaultBoards = defaultBoards.filter((b) => {
+      return b.target === idfTarget;
+    });
+    return idfTarget ? filteredDefaultBoards : defaultBoards;
   }
 }

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -46,8 +46,6 @@ export async function setIdfTarget(placeHolderMsg: string) {
     },
     async (progress: Progress<{ message: string; increment: number }>) => {
       try {
-        const openOcdScriptsPath = getOpenOcdScripts(workspaceFolder.uri);
-        const boards = await getBoards(openOcdScriptsPath);
         const targetsFromIdf = await getTargetsFromEspIdf(workspaceFolder.uri);
         const selectedTarget = await window.showQuickPick(targetsFromIdf);
         if (!selectedTarget) {
@@ -87,11 +85,9 @@ export async function setIdfTarget(placeHolderMsg: string) {
           configurationTarget,
           workspaceFolder.uri
         );
-
-        const boardsForTarget = boards.filter(
-          (b) => b.target === selectedTarget.target
-        );
-        const choices = boardsForTarget.map((b) => {
+        const openOcdScriptsPath = getOpenOcdScripts(workspaceFolder.uri);
+        const boards = await getBoards(selectedTarget.target, openOcdScriptsPath);
+        const choices = boards.map((b) => {
           return {
             description: `${b.description} (${b.configFiles})`,
             label: b.name,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1852,7 +1852,17 @@ export async function activate(context: vscode.ExtensionContext) {
   registerIDFCommand("espIdf.selectOpenOcdConfigFiles", async () => {
     try {
       const openOcdScriptsPath = getOpenOcdScripts(workspaceRoot);
-      const boards = await getBoards(openOcdScriptsPath);
+      let idfTarget = idfConf.readParameter(
+        "idf.adapterTargetName",
+        workspaceRoot
+      ) as string;
+      if (idfTarget === "custom") {
+        idfTarget = idfConf.readParameter(
+          "idf.customAdapterTargetName",
+          workspaceRoot
+        ) as string;
+      }
+      const boards = await getBoards(idfTarget, openOcdScriptsPath);
       const choices = boards.map((b) => {
         return {
           description: `${b.description} (${b.configFiles})`,

--- a/src/test/oocdBoards.test.ts
+++ b/src/test/oocdBoards.test.ts
@@ -43,7 +43,7 @@ suite("OpenOCD Board tests", () => {
   });
 
   test("OpenOCD Boards method", async () => {
-    const boards = await getBoards(openOcdScriptsPath);
+    const boards = await getBoards(boardJsonObj.boards[0].target, openOcdScriptsPath);
     assert.equal(boards[0].name, boardJsonObj.boards[0].name);
     assert.equal(boards[0].description, boardJsonObj.boards[0].description);
     assert.equal(boards[0].target, boardJsonObj.boards[0].target);


### PR DESCRIPTION
## Description

Filter OpenOCD board by IDF_TARGET

Fixes VSC-1240

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Select OpenOCD Board configuration"
2. Execute action.
3. Observe results. Should only see board by current IDF_TARGET

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
