### PR TITLE
fix duplicate python list add win compilerPath

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -358,7 +358,9 @@ export async function getUnixPythonList(workingDir: string) {
     );
     if (pyVersionsStr) {
       const resultList = pyVersionsStr.trim().split("\n");
-      return resultList;
+      const uniquePathsSet = new Set(resultList);
+      const uniquePathsArray = Array.from(uniquePathsSet);
+      return uniquePathsArray;
     }
   } catch (error) {
     Logger.errorNotify("Error looking for python in system", error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,8 +246,12 @@ export async function setCCppPropertiesJsonCompilerPath(
     let compilerRelativePath = compilerAbsolutePath.split(
       modifiedEnv.IDF_TOOLS_PATH
     )[1];
+    const settingToUse =
+      process.platform === "win32"
+        ? "${config:idf.toolsPathWin}"
+        : "${config:idf.toolsPath}";
     cCppPropertiesJson.configurations[0].compilerPath =
-      "${config:idf.toolsPath}" + compilerRelativePath;
+      settingToUse + compilerRelativePath;
     await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
       spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
     });


### PR DESCRIPTION
## Description

Make sure python paths list does not have duplicated in `ESP-IDF: Configure ESP-IDF extension` command.

Fix c_cpp_properties.json compilerPath command on Windows replacement when IDF_TARGET is changed.

Fixes #1083

Fixes #1073 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Configure ESP-IDF extension" and check that there is no duplicated python paths in the dropdown list.
2. Change IDF_TARGET using the `ESP-IDF: Set Espressif device target` command. Observe that compilerPath field in c_cpp_properties.json is updating with correct `${config:idf.toolsPathWin}\...` on Windows and `${config:idf.toolsPath}/...` on others.

- Expected behaviour:
* no duplicated python paths in the dropdown list in Setup wizard
* c_cpp_properties.json compilerPath is updated with correct path for toolchain path.

- Expected output:

## How has this been tested?

Manual testing on Windows 10.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Windows

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
