### PR TITLE
update notification mode to enum add saveScope change message

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Select port to use                                      | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>P</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>P</kbd> |
 | Select OpenOCD Board Configuration                      |                                        |                                           |
 | Select where to save configuration settings             |                                        |                                           |
+| Select output and notification mode                     |                                        |                                           |
 | Set default sdkconfig file in project                   |                                        |                                           |
 | Set Espressif device target                             |                                        |                                           |
 | Set ESP-MATTER Device Path (ESP_MATTER_DEVICE_PATH)     |                                        |                                           |

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -97,7 +97,7 @@ These settings are used to configure the [Code Coverage](./COVERAGE.md) colors.
 | `idf.enableUpdateSrcsToCMakeListsFile` | Enable update source files in CMakeLists.txt (default `true`)                   | User, Remote or Workspace |
 | `idf.flashType`                        | Preferred flash method. DFU, UART or JTAG                                       |                           |
 | `idf.launchMonitorOnDebugSession`      | Launch ESP-IDF Monitor along with ESP-IDF Debug session                         |                           |
-| `idf.notificationSilentMode`           | Silent all notifications messages and show tasks output (default `true`)        | User, Remote or Workspace |
+| `idf.notificationMode`                 | ESP-IDF extension notifications and output focus mode. (default `All`)          | User, Remote or Workspace |
 | `idf.showOnboardingOnInit`             | Show ESP-IDF Configuration Window on extension activation                       | User, Remote or Workspace |
 | `idf.saveScope`                        | Where to save extension settings                                                | User, Remote or Workspace |
 | `idf.saveBeforeBuild`                  | Save all the edited files before building (default `true`)                      |                           |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -6,6 +6,7 @@
   "espIdf.setPath.title": "Configure Paths",
   "espIdf.setTarget.title": "Set Espressif Device Target",
   "espIdf.selectConfTarget.title": "Select where to Save Configuration Settings",
+  "espIdf.selectNotificationMode.title": "Select Output and Notification Mode",
   "espIdf.configDevice.title": "Device Configuration",
   "espIdf.menuconfig.start.title": "SDK Configuration editor (Menuconfig)",
   "espIdf.cmakeListsEditor.start.title": "CMakeLists.txt Editor",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -117,7 +117,7 @@
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
   "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways",
-  "param.notificationSilentMode": "Disable all ESP-IDF extension notifications (excluding error notifications)",
+  "param.notificationMode": "ESP-IDF extension notifications and output focus mode.",
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -5,6 +5,7 @@
   "espIdf.createVsCodeFolder.title": "ESP-IDF: Agregar carpeta de configuración vscode",
   "espIdf.setPath.title": "ESP-IDF: Configurar rutas ESP-IDF",
   "espIdf.selectConfTarget.title": "ESP-IDF: Selecciona donde almacenar tu configuración",
+  "espIdf.selectNotificationMode.title": "Selecciona el modo de salida de texto y notificaciones",
   "espIdf.setTarget.title": "ESP-IDF: Selecciona el dispositivo Espressif a utilizar",
   "espIdf.configDevice.title": "ESP-IDF: Configuración del dispositivo",
   "espIdf.menuconfig.start.title": "ESP-IDF: Editor de Configuración SDK (menuconfig)",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -126,7 +126,7 @@
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
   "param.saveBeforeBuildDescription": "Guarde todos los archivos editados en el espacio de trabajo antes de continuar con la compilación, aunque si no guarda los archivos, se compilará de todos modos",
-  "param.notificationSilentMode": "Deshabilitar las notificaciones de la extensión ESP-IDF (excluyendo notficaciones de errores)",
+  "param.notificationMode": "Modo de enfoque de texto de salida de las tareas y notificaciones de la extensión ESP-IDF",
   "param.saveScope": "Dónde se almacena las configuraciones para comandos ESP-IDF usando enum vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "URL del servidor ESP-Rainmaker API",
   "esp.rainmaker.backend.sync.title": "Sincronizar con el servidor ESP-Rainmaker",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -124,7 +124,7 @@
   "trace.wait4halt.description": "wait4halt будет установлен для трассировки приложения",
   "trace.skip_size.description": "skip_size будет установлен для трассировки приложения",
   "param.saveBeforeBuildDescription": "Сохранить все отредактированные файлы в рабочей области, прежде чем продолжить сборку. Хотя, проект будет собран, даже если не удается сохранить файлы",
-  "param.notificationSilentMode": "Отключите все уведомления расширения ESP-IDF (за исключением уведомлений об ошибках)",
+  "param.notificationMode": "Уведомления о расширении ESP-IDF и режим фокусировки вывода.",
   "param.saveScope": "Куда сохранять конфигурацию с помощью команд ESP-IDF с числовым значением vscode.ConfigurationTarget. Глобально = 1, Рабочая область = 2, Папка рабочей области = 3",
   "param.rainmaker.api.server_url": "URL облачного сервера ESP-Rainmaker",
   "param.customTerminalExecutable.title": "Пользовательский исполняемый файл для задач расширения",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -6,6 +6,7 @@
   "espIdf.setPath.title": "Настроить пути",
   "espIdf.setTarget.title": "Установить целевое устройство Espressif",
   "espIdf.selectConfTarget.title": "Выбрать место для сохранения настроек конфигурации",
+  "espIdf.selectNotificationMode.title": "Выберите режим вывода и уведомления",
   "espIdf.configDevice.title": "Конфигурация устройства",
   "espIdf.menuconfig.start.title": "Редактор конфигурации SDK (menuconfig)",
   "espIdf.cmakeListsEditor.start.title": "CMakeLists.txt Редактор",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -5,6 +5,7 @@
   "espIdf.createVsCodeFolder.title": "ESP-IDF: 添加 vscode 配置文件夹",
   "espIdf.setPath.title": "ESP-IDF ：配置路径",
   "espIdf.selectConfTarget.title": "ESP-IDF ：选择保存配置设置的位置",
+  "espIdf.selectNotificationMode.title": "选择输出和通知模式",
   "espIdf.setTarget.title": "ESP-IDF: 设置 espressif 目标芯片",
   "espIdf.configDevice.title": "ESP-IDF ：配置设备",
   "espIdf.menuconfig.start.title": "ESP-IDF: SDK 配置编辑器 (menuconfig)",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -124,7 +124,7 @@
   "trace.wait4halt.description": "apptrace：设置 wait4halt",
   "trace.skip_size.description": "apptrace：设置 skip_size",
   "param.saveBeforeBuildDescription": "在构建之前保存所有工作区中正在编辑的文件。即使无法保存文件，也一定会进行构建",
-  "param.notificationSilentMode": "禁用所有 ESP-IDF 扩展通知(排除错误通知)",
+  "param.notificationMode": "ESP-IDF扩展通知和输出聚焦模式",
   "param.saveScope": "将 ESP-IDF 命令将配置保存到 vscode.ConfigurationTarget。全局 = 1, 工作区= 2, 工作区文件夹=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker 云服务器地址",
   "param.customTerminalExecutable.title": "用于扩展任务的自定义可执行文件",

--- a/package.json
+++ b/package.json
@@ -1312,6 +1312,11 @@
         "command": "espIdf.clearSavedIdfSetups",
         "title": "%espIdf.clearSavedIdfSetups.title%",
         "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.selectNotificationMode",
+        "title": "%espIdf.selectNotificationMode.title%",
+        "category": "ESP-IDF"
       }
     ],
     "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -616,6 +616,7 @@
           },
           "idf.notificationMode": {
             "type": "string",
+            "scope": "resource",
             "enum": [
               "Silent",
               "Notifications",

--- a/package.json
+++ b/package.json
@@ -614,10 +614,22 @@
             "scope": "resource",
             "description": "%param.saveBeforeBuildDescription%"
           },
-          "idf.notificationSilentMode": {
-            "type": "boolean",
-            "default": true,
-            "description": "%param.notificationSilentMode%"
+          "idf.notificationMode": {
+            "type": "string",
+            "enum": [
+              "Silent",
+              "Notifications",
+              "Output",
+              "All"
+            ],
+            "enumDescriptions": [
+              "Show no notifications and do not focus tasks output.",
+              "Show notifications but do not focus tasks output.",
+              "Do not show notifications but focus tasks output",
+              "Show notifications and focus tasks output."
+            ],
+            "default": "All",
+            "description": "%param.notificationMode%"
           },
           "idf.saveScope": {
             "type": "number",
@@ -632,7 +644,8 @@
               "Workspace",
               "WorkspaceFolder"
             ],
-            "description": "%param.saveScope%"
+            "description": "%param.saveScope%",
+            "scope": "application"
           },
           "idf.telemetry": {
             "title": "Enable Telemetry",

--- a/package.json
+++ b/package.json
@@ -625,7 +625,7 @@
             "enumDescriptions": [
               "Show no notifications and do not focus tasks output.",
               "Show notifications but do not focus tasks output.",
-              "Do not show notifications but focus tasks output",
+              "Do not show notifications but focus tasks output.",
               "Show notifications and focus tasks output."
             ],
             "default": "All",

--- a/package.nls.json
+++ b/package.nls.json
@@ -119,7 +119,7 @@
   "trace.wait4halt.description": "wait4halt will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
   "param.saveBeforeBuildDescription": "Save all the edited files in the workspace before proceeding with the build, although if fail to save files it will build anyways",
-  "param.notificationSilentMode": "Disable all ESP-IDF extension notifications (excluding errors)",
+  "param.notificationMode": "ESP-IDF extension notifications and output focus mode.",
   "param.saveScope": "Where to save configuration with ESP-IDF commands with number value as vscode.ConfigurationTarget. Global = 1, Workspace= 2, WorkspaceFolder=3",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.launchMonitorOnDebugSession.title": "Start IDF Monitor along with ESP-IDF Debug Adapter session",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,6 +5,7 @@
   "espIdf.createVsCodeFolder.title": "Add .vscode Configuration Folder",
   "espIdf.setPath.title": "Configure Paths",
   "espIdf.selectConfTarget.title": "Select where to Save Configuration Settings",
+  "espIdf.selectNotificationMode.title": "Select Output and Notification Mode",
   "espIdf.setTarget.title": "Set Espressif Device Target",
   "espIdf.configDevice.title": "Device Configuration",
   "espIdf.menuconfig.start.title": "SDK Configuration Editor (Menuconfig)",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -182,7 +182,7 @@
     "trace.wait4halt.description",
     "trace.skip_size.description",
     "param.saveBeforeBuildDescription",
-    "param.notificationSilentMode",
+    "param.notificationMode",
     "param.saveScope",
     "param.rainmaker.api.server_url",
     "esp.rainmaker.backend.sync.title",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -80,6 +80,7 @@
     "espIdf.setPath.title",
     "espIdf.createIdfTerminal.title",
     "espIdf.selectConfTarget.title",
+    "espIdf.selectNotificationMode.title",
     "espIdf.setTarget.title",
     "espIdf.configDevice.title",
     "espIdf.menuconfig.start.title",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -151,13 +151,15 @@ export class BuildTask {
       (w) => w.uri === this.curWorkspace
     );
 
-    const isSilentMode = idfConf.readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = idfConf.readParameter(
+      "idf.notificationMode",
       this.curWorkspace
-    ) as boolean;
-    const showTaskOutput = isSilentMode
-      ? vscode.TaskRevealKind.Always
-      : vscode.TaskRevealKind.Silent;
+    ) as string;
+    const showTaskOutput =
+      notificationMode === idfConf.NotificationMode.All ||
+      notificationMode === idfConf.NotificationMode.Output
+        ? vscode.TaskRevealKind.Always
+        : vscode.TaskRevealKind.Silent;
 
     if (!cmakeCacheExists) {
       let compilerArgs = (idfConf.readParameter(
@@ -274,13 +276,15 @@ export class BuildTask {
       (w) => w.uri === this.curWorkspace
     );
 
-    const isSilentMode = idfConf.readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = idfConf.readParameter(
+      "idf.notificationMode",
       this.curWorkspace
-    );
-    const showTaskOutput = isSilentMode
-      ? vscode.TaskRevealKind.Always
-      : vscode.TaskRevealKind.Silent;
+    ) as string;
+    const showTaskOutput =
+      notificationMode === idfConf.NotificationMode.All ||
+      notificationMode === idfConf.NotificationMode.Output
+        ? vscode.TaskRevealKind.Always
+        : vscode.TaskRevealKind.Silent;
 
     const writeExecution = this.dfuShellExecution(options);
     const buildPresentationOptions = {

--- a/src/customTasks/customTaskProvider.ts
+++ b/src/customTasks/customTaskProvider.ts
@@ -26,7 +26,7 @@ import {
   Uri,
   workspace,
 } from "vscode";
-import { readParameter } from "../idfConfiguration";
+import { NotificationMode, readParameter } from "../idfConfiguration";
 import { TaskManager } from "../taskManager";
 import { appendIdfAndToolsToPath } from "../utils";
 
@@ -102,19 +102,21 @@ export class CustomTask {
     if (shellExecutableArgs && shellExecutableArgs.length) {
       options.shellArgs = shellExecutableArgs;
     }
-    const isSilentMode = readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = readParameter(
+      "idf.notificationMode",
       this.currentWorkspace
-    ) as boolean;
-    const showTaskOutput = isSilentMode
-      ? TaskRevealKind.Always
-      : TaskRevealKind.Silent;
+    ) as string;
+    const showTaskOutput =
+      notificationMode === NotificationMode.All ||
+      notificationMode === NotificationMode.Output
+        ? TaskRevealKind.Always
+        : TaskRevealKind.Silent;
     const customExecution = this.getProcessExecution(cmd, options);
     const customTaskPresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,
       clear: false,
-      panel: TaskPanelKind.Dedicated
+      panel: TaskPanelKind.Dedicated,
     } as TaskPresentationOptions;
     const curWorkspaceFolder = workspace.workspaceFolders.find(
       (w) => w.uri === this.currentWorkspace

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -28,7 +28,7 @@ import {
   Uri,
   workspace,
 } from "vscode";
-import { readParameter } from "../../idfConfiguration";
+import { NotificationMode, readParameter } from "../../idfConfiguration";
 import { TaskManager } from "../../taskManager";
 import { appendIdfAndToolsToPath } from "../../utils";
 import { getProjectName } from "../../workspaceConfig";
@@ -85,16 +85,18 @@ export class IdfSizeTask {
       options.shellArgs = shellExecutableArgs;
     }
     const sizeExecution = await this.getShellExecution(options);
-    const isSilentMode = readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = readParameter(
+      "idf.notificationMode",
       this.curWorkspace
-    ) as boolean;
+    ) as string;
     const curWorkspaceFolder = workspace.workspaceFolders.find(
       (w) => w.uri === this.curWorkspace
     );
-    const showTaskOutput = isSilentMode
-      ? TaskRevealKind.Always
-      : TaskRevealKind.Silent;
+    const showTaskOutput =
+      notificationMode === NotificationMode.All ||
+      notificationMode === NotificationMode.Output
+        ? TaskRevealKind.Always
+        : TaskRevealKind.Silent;
     const sizePresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,

--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -33,7 +33,7 @@ import {
   workspace,
 } from "vscode";
 import { AbstractCloning } from "../common/abstractCloning";
-import { readParameter } from "../idfConfiguration";
+import { NotificationMode, readParameter } from "../idfConfiguration";
 import { Logger } from "../logger/logger";
 import { TaskManager } from "../taskManager";
 import { OutputChannel } from "../logger/outputChannel";
@@ -109,13 +109,15 @@ export class EspMatterCloning extends AbstractCloning {
     );
 
     const buildGnExec = this.getShellExecution(bootstrapFilePath, shellOptions);
-    const isSilentMode = readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = readParameter(
+      "idf.notificationMode",
       this.currWorkspace
-    );
-    const showTaskOutput = isSilentMode
-      ? TaskRevealKind.Always
-      : TaskRevealKind.Silent;
+    ) as string;
+    const showTaskOutput =
+      notificationMode === NotificationMode.All ||
+      notificationMode === NotificationMode.Output
+        ? TaskRevealKind.Always
+        : TaskRevealKind.Silent;
 
     const matterBootstrapPresentationOptions = {
       reveal: showTaskOutput,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -827,14 +827,49 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.selectConfTarget", async () => {
-    const confTarget = await idfConf.chooseConfigurationTarget();
+    await idfConf.chooseConfigurationTarget();
+  });
 
-    const dictTarget = {
-      1: "Global",
-      2: "Workspace",
-      3: "Workspace Folder",
-    };
-    Logger.infoNotify(`Save location has changed to ${dictTarget[confTarget]}`);
+  registerIDFCommand("espIdf.selectNotificationMode", async () => {
+    const notificationTarget = await vscode.window.showQuickPick(
+      [
+        {
+          description: "Show no notifications and do not focus tasks output.",
+          label: "Silent",
+          target: "Silent",
+        },
+        {
+          description: "Show notifications but do not focus tasks output.",
+          label: "Notifications",
+          target: "Notifications",
+        },
+        {
+          description: "Do not show notifications but focus tasks output.",
+          label: "Output",
+          target: "Output",
+        },
+        {
+          description: "Show notifications and focus tasks output.",
+          label: "All",
+          target: "All",
+        },
+      ],
+      { placeHolder: "Select the output and notification mode" }
+    );
+    if (!notificationTarget) {
+      return;
+    }
+    const saveScope = idfConf.readParameter("idf.saveScope");
+
+    await idfConf.writeParameter(
+      "idf.notificationMode",
+      notificationTarget.target,
+      saveScope,
+      workspaceRoot
+    );
+    Logger.infoNotify(
+      `Notification mode has changed to ${notificationTarget.label}`
+    );
   });
 
   registerIDFCommand("espIdf.clearSavedIdfSetups", async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -826,8 +826,15 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
-  registerIDFCommand("espIdf.selectConfTarget", () => {
-    idfConf.chooseConfigurationTarget();
+  registerIDFCommand("espIdf.selectConfTarget", async () => {
+    const confTarget = await idfConf.chooseConfigurationTarget();
+
+    const dictTarget = {
+      1: "Global",
+      2: "Workspace",
+      3: "Workspace Folder",
+    };
+    Logger.infoNotify(`Save location has changed to ${dictTarget[confTarget]}`);
   });
 
   registerIDFCommand("espIdf.clearSavedIdfSetups", async () => {

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -81,16 +81,18 @@ export class FlashTask {
       throw new Error("ALREADY_FLASHING");
     }
     this.verifyArgs();
-    const isSilentMode = idfConf.readParameter(
-      "idf.notificationSilentMode",
+    const notificationMode = idfConf.readParameter(
+      "idf.notificationMode",
       this.workspaceUri
-    ) as boolean;
+    ) as string;
     const curWorkspaceFolder = vscode.workspace.workspaceFolders.find(
       (w) => w.uri === this.workspaceUri
     );
-    const showTaskOutput = isSilentMode
-      ? vscode.TaskRevealKind.Always
-      : vscode.TaskRevealKind.Silent;
+    const showTaskOutput =
+      notificationMode === idfConf.NotificationMode.All ||
+      notificationMode === idfConf.NotificationMode.Output
+        ? vscode.TaskRevealKind.Always
+        : vscode.TaskRevealKind.Silent;
     let flashExecution: vscode.ShellExecution | vscode.ProcessExecution;
     switch (flashType) {
       case "UART":

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -148,6 +148,7 @@ export async function chooseConfigurationTarget() {
     confTarget.target,
     vscode.ConfigurationTarget.Global
   );
+  Logger.infoNotify(`Save location has changed to ${confTarget.description}`);
   return confTarget.target;
 }
 

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -20,6 +20,13 @@ import { ProjectConfElement } from "./project-conf/projectConfiguration";
 
 const locDic = new LocDictionary(__filename);
 
+export enum NotificationMode {
+  Silent = "Silent",
+  Notifications = "Notifications",
+  Output = "Output",
+  All = "All",
+}
+
 export function addWinIfRequired(param: string) {
   const winFlag = process.platform === "win32" ? "Win" : "";
   for (const platDepConf of ESP.platformDepConfigurations) {

--- a/src/qemu/mergeFlashBin.ts
+++ b/src/qemu/mergeFlashBin.ts
@@ -32,7 +32,7 @@ import {
 } from "vscode";
 import { FlashModel } from "../flash/flashModel";
 import { createFlashModel } from "../flash/flashModelBuilder";
-import { readParameter } from "../idfConfiguration";
+import { NotificationMode, readParameter } from "../idfConfiguration";
 import { Logger } from "../logger/logger";
 import { TaskManager } from "../taskManager";
 import { appendIdfAndToolsToPath, canAccessFile } from "../utils";
@@ -103,13 +103,15 @@ export async function mergeFlashBinaries(
     }
   }
 
-  const isSilentMode = readParameter(
-    "idf.notificationSilentMode",
+  const notificationMode = readParameter(
+    "idf.notificationMode",
     wsFolder
-  ) as boolean;
-  const showTaskOutput = isSilentMode
-    ? TaskRevealKind.Always
-    : TaskRevealKind.Silent;
+  ) as string;
+  const showTaskOutput =
+    notificationMode === NotificationMode.All ||
+    notificationMode === NotificationMode.Output
+      ? TaskRevealKind.Always
+      : TaskRevealKind.Silent;
   const mergeExecution = await getMergeExecution(
     buildDirPath,
     esptoolPath,

--- a/src/userNotificationManager/userNotificationManager.ts
+++ b/src/userNotificationManager/userNotificationManager.ts
@@ -32,10 +32,13 @@ export default class UserNotificationManagerTransport extends winston.Transport 
     metadata?: any,
     callback?: (arg1, arg2) => void
   ) {
-    const isSilentMode = idfConf.readParameter(
-      "idf.notificationSilentMode"
-    ) as boolean;
-    if (metadata && metadata.user && !isSilentMode) {
+    const notificationMode = idfConf.readParameter(
+      "idf.notificationMode"
+    ) as string;
+    const enableNotification =
+      notificationMode === idfConf.NotificationMode.All ||
+      notificationMode === idfConf.NotificationMode.Notifications;
+    if (metadata && metadata.user && enableNotification) {
       if (level === "info") {
         vscode.window.showInformationMessage(message);
       } else if (level === "warn") {

--- a/testFiles/testWorkspace/.vscode/settings.json
+++ b/testFiles/testWorkspace/.vscode/settings.json
@@ -15,5 +15,5 @@
   "idf.customExtraVars": {
     "OPENOCD_SCRIPTS": "${env:OPENOCD_SCRIPTS}"
   },
-  "idf.notificationMode": "Silent"
+  "idf.notificationMode": "Output"
 }

--- a/testFiles/testWorkspace/.vscode/settings.json
+++ b/testFiles/testWorkspace/.vscode/settings.json
@@ -15,5 +15,5 @@
   "idf.customExtraVars": {
     "OPENOCD_SCRIPTS": "${env:OPENOCD_SCRIPTS}"
   },
-  "idf.notificationSilentMode": true
+  "idf.notificationMode": "Silent"
 }


### PR DESCRIPTION
## Description

Add notification for `ESP-IDF: Select where to save configuration settings` command on successful update.

Modify `idf.notificationSilentMode` to `idf.notificationMode`  to allow 4 modes of user notifications and output focus: All, Notifications only, output focus only or Silent. Add `ESP-IDF: Select output and notification mode` to select notification mode.

Fixes VSC-1225

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on `ESP-IDF: Select where to save configuration settings` and see success notification
2. Click on `ESP-IDF: Select output and notification mode`, select notification and output mode.
3. Execute extension actions such as build, flash, idf size and other extension tasks.
4. Observe output focus when `idf.notificationMode` is set to `All` or` Output`.
5. Observe notifications when `idf.notificationMode` is set to `All` or `Notification`.

- Expected behaviour:
* Notification are shown when when `idf.notificationMode` is set to `All` or `Notification`.
* Task Output is focused when when `idf.notificationMode` is set to `All` or `Output`.
* `ESP-IDF: Select where to save configuration settings will show notification message when used.


**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): All

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [x] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
