### PR TITLE
Fix for issue #1092 (VSC-1257)

### DIFF
--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -204,8 +204,9 @@ export class IdfToolsManager {
     pathsToVerify: string,
     logToChannel: boolean = true
   ) {
-    const pathNameInEnv: string =
-      process.platform === "win32" ? "Path" : "PATH";
+    const pathNameInEnv: string = Object.keys(process.env).find(
+      (k) => k.toUpperCase() == "PATH"
+    );
     let modifiedPath = process.env[pathNameInEnv];
     if (
       process.env[pathNameInEnv] &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -978,12 +978,9 @@ export function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     "partition_table"
   )}`;
 
-  let pathNameInEnv: string;
-  if (process.platform === "win32") {
-    pathNameInEnv = "Path";
-  } else {
-    pathNameInEnv = "PATH";
-  }
+  let pathNameInEnv: string = Object.keys(process.env).find(
+    (k) => k.toUpperCase() == "PATH"
+  );
   if (pathToGitDir) {
     modifiedEnv[pathNameInEnv] =
       pathToGitDir + path.delimiter + modifiedEnv[pathNameInEnv];


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes #1092 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Configure extension with the existing ESP-IDF + installed tools on Windows 11, there should be no errors complaining that the tools are not found at the specified correct paths

## How has this been tested?

This has been tested on my VSCode with the existing ESP-IDF + installed tools on Windows 11

## Dependent components impacted by this PR:

- src/idfToolsManager.ts
- src/utils.ts

## Checklist
- [*] PR Self Reviewed
- [*] Applied Code formatting
- [*] Not Added Documentation (irrelevant)
- [*] Not Added Unit Test (irrelevant)
- [ ] Verified on all platforms - Windows,Linux and macOS (verified only on Windows, as I am not using other OSes at the moment)
