### PR TITLE
add save-defconfig cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Open NVS Partition Editor                               |                                        |                                           |
 | Pick a workspace folder                                 |                                        |                                           |
 | Remove Editor coverage                                  |                                        |                                           |
+| Save Default SDKCONFIG file (save-defconfig)            |                                        |                                           |
 | SDK Configuration editor                                | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>G</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>G</kbd> |
 | Search in documentation...                              | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>Q</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>Q</kbd> |
 | Select Flash Method                                     |                                        |                                           |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -63,6 +63,7 @@
   "espIdf.clearSavedIdfSetups.title": "Clear saved IDF setups",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Unit Test: Build and flash unit test app for testing",
   "espIdf.unitTest.installPyTest.title": "Unit Test: Install ESP-IDF PyTest  requirements",
+  "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -62,6 +62,7 @@
   "espIdf.welcome.title": "Bienvenido/a",
   "espIdf.projectConfigurationEditor.title": "Abrir configuracion de proyecto",
   "espIdf.projectConf.title": "Selecciona la configuración del proyecto",
+  "espIdf.saveDefSdkconfig.title": "ESP-IDF: Guardar archivo SDKCONFIG por defecto (save-defconfig)",
   "espIdf.clearSavedIdfSetups.title": "Limpiar configuraciones de IDF guardadas",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Unit Test: Construir y programar la app unit test app para pruebas",
   "espIdf.unitTest.installPyTest.title": "Unit Test: Instalar requerimientos ESP-IDF PyTest",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -60,6 +60,7 @@
   "espIdf.welcome.title": "Добро пожаловать",
   "espIdf.projectConfigurationEditor.title": "Открыть конфигурацию проекта",
   "espIdf.projectConf.title": "Выберите конфигурацию проекта",
+  "espIdf.saveDefSdkconfig.title": "ESP-IDF: Сохраните файл SDKCONFIG по умолчанию (save-defconfig)",
   "espIdf.clearSavedIdfSetups.title": "Очистить сохраненные настройки IDF",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Модульный тест: сборка и запуск приложения модульного тестирования для тестирования.",
   "espIdf.unitTest.installPyTest.title": "Модульный тест: установите требования ESP-IDF PyTest",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -60,6 +60,7 @@
   "espIdf.welcome.title": "欢迎",
   "espIdf.projectConfigurationEditor.title": "打开项目配置",
   "espIdf.projectConf.title": "选择项目配置",
+  "espIdf.saveDefSdkconfig.title": "ESP-IDF: 保存默认SDKCONFIG文件（save-defconfig）",
   "espIdf.clearSavedIdfSetups.title": "清除保存的IDF设置",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "单元测试：构建并闪存用于测试的单元测试应用程序",
   "espIdf.unitTest.installPyTest.title": "单元测试：安装ESP-IDF PyTest要求",

--- a/package.json
+++ b/package.json
@@ -280,6 +280,10 @@
           "group": "navigation"
         },
         {
+          "command": "espIdf.saveDefSdkconfig",
+          "group": "navigation"
+        },
+        {
           "when": "resourceExtname == .bin",
           "group": "navigation",
           "command": "espIdf.flashBinaryToPartition"
@@ -1331,6 +1335,11 @@
       {
         "command": "espIdf.unitTest.buildFlashUnitTestApp",
         "title": "%espIdf.unitTest.buildFlashUnitTestApp.title%",
+        "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.saveDefSdkconfig",
+        "title": "%espIdf.saveDefSdkconfig.title%",
         "category": "ESP-IDF"
       }
     ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -63,6 +63,7 @@
   "espIdf.welcome.title": "Welcome",
   "espIdf.projectConfigurationEditor.title": "Open Project Configuration",
   "espIdf.projectConf.title": "Select project configuration",
+  "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/src/espIdf/menuconfig/saveDefConfig.ts
+++ b/src/espIdf/menuconfig/saveDefConfig.ts
@@ -1,0 +1,105 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Wednesday, 13th December 2023 2:25:30 pm
+ * Copyright 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CancellationToken,
+  ProcessExecution,
+  ProcessExecutionOptions,
+  TaskPanelKind,
+  TaskPresentationOptions,
+  TaskRevealKind,
+  TaskScope,
+  Uri,
+  workspace,
+} from "vscode";
+import { TaskManager } from "../../taskManager";
+import { readParameter } from "../../idfConfiguration";
+import { Logger } from "../../logger/logger";
+import { join } from "path";
+import { appendIdfAndToolsToPath } from "../../utils";
+import { pathExists } from "fs-extra";
+
+export async function saveDefSdkconfig(
+  workspaceFolder: Uri,
+  cancelToken?: CancellationToken
+) {
+  if (cancelToken) {
+    cancelToken.onCancellationRequested(() => {
+      TaskManager.cancelTasks();
+      TaskManager.disposeListeners();
+    });
+  }
+  const idfPath = readParameter("idf.espIdfPath", workspaceFolder);
+  const isSilentMode = readParameter(
+    "idf.notificationSilentMode",
+    workspaceFolder
+  ) as boolean;
+  const showTaskOutput = isSilentMode
+    ? TaskRevealKind.Always
+    : TaskRevealKind.Silent;
+  const saveDefConfigPresentationOptions = {
+    reveal: showTaskOutput,
+    showReuseMessage: false,
+    clear: false,
+    panel: TaskPanelKind.Shared,
+  } as TaskPresentationOptions;
+  const curWorkspaceFolder = workspace.workspaceFolders.find(
+    (w) => w.uri === workspaceFolder
+  );
+  const saveDefSdkconfig = await getSaveDefConfigExecution(
+    idfPath,
+    workspaceFolder
+  );
+  TaskManager.addTask(
+    {
+      type: "esp-idf",
+      command: "IDF Save Default SDKCONFIG",
+      taskId: "idf-defconfig-task",
+    },
+    curWorkspaceFolder || TaskScope.Workspace,
+    "Save Default SDKCONFIG",
+    saveDefSdkconfig,
+    ["espIdf"],
+    saveDefConfigPresentationOptions
+  );
+  await TaskManager.runTasks();
+  if (cancelToken && !cancelToken.isCancellationRequested) {
+    Logger.infoNotify("def-config has been generated");
+  }
+  TaskManager.disposeListeners();
+}
+
+export async function getSaveDefConfigExecution(
+  idfPath: string,
+  wsFolder: Uri
+) {
+  const saveDefConfArgs = [join(idfPath, "tools", "idf.py"), "save-defconfig"];
+  const modifiedEnv = appendIdfAndToolsToPath(wsFolder);
+  const options: ProcessExecutionOptions = {
+    cwd: wsFolder.fsPath,
+    env: modifiedEnv,
+  };
+  const pythonBinPath = readParameter("idf.pythonBinPath", wsFolder) as string;
+  const pythonBinExists = await pathExists(pythonBinPath);
+  if (!pythonBinExists) {
+    throw new Error(
+      `idf.pythonBinPath doesn't exist. Configure the extension first.`
+    );
+  }
+  return new ProcessExecution(pythonBinPath, saveDefConfArgs, options);
+}

--- a/src/espIdf/menuconfig/saveDefConfig.ts
+++ b/src/espIdf/menuconfig/saveDefConfig.ts
@@ -68,7 +68,7 @@ export async function saveDefSdkconfig(
   TaskManager.addTask(
     {
       type: "esp-idf",
-      command: "IDF Save Default SDKCONFIG",
+      command: "ESP-IDF: Save Default SDKCONFIG",
       taskId: "idf-defconfig-task",
     },
     curWorkspaceFolder || TaskScope.Workspace,

--- a/src/espIdf/menuconfig/saveDefConfig.ts
+++ b/src/espIdf/menuconfig/saveDefConfig.ts
@@ -28,7 +28,7 @@ import {
   workspace,
 } from "vscode";
 import { TaskManager } from "../../taskManager";
-import { readParameter } from "../../idfConfiguration";
+import { NotificationMode, readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { join } from "path";
 import { appendIdfAndToolsToPath } from "../../utils";
@@ -45,13 +45,15 @@ export async function saveDefSdkconfig(
     });
   }
   const idfPath = readParameter("idf.espIdfPath", workspaceFolder);
-  const isSilentMode = readParameter(
-    "idf.notificationSilentMode",
+  const notificationMode = readParameter(
+    "idf.notificationMode",
     workspaceFolder
-  ) as boolean;
-  const showTaskOutput = isSilentMode
-    ? TaskRevealKind.Always
-    : TaskRevealKind.Silent;
+  ) as string;
+  const showTaskOutput =
+    notificationMode === NotificationMode.All ||
+    notificationMode === NotificationMode.Output
+      ? TaskRevealKind.Always
+      : TaskRevealKind.Silent;
   const saveDefConfigPresentationOptions = {
     reveal: showTaskOutput,
     showReuseMessage: false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,6 +142,7 @@ import {
   installPyTestPackages,
 } from "./espIdf/unitTest/configure";
 import { getFileList, getTestComponents } from "./espIdf/unitTest/utils";
+import { saveDefSdkconfig } from "./espIdf/menuconfig/saveDefConfig";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -1782,6 +1783,28 @@ export async function activate(context: vscode.ExtensionContext) {
       } catch (error) {
         Logger.errorNotify(error.message, error);
       }
+    });
+  });
+
+  registerIDFCommand("espIdf.saveDefSdkconfig", async () => {
+    PreCheck.perform([openFolderCheck], () => {
+      vscode.window.withProgress(
+        {
+          cancellable: true,
+          location: vscode.ProgressLocation.Notification,
+          title: "ESP-IDF: Save Default Configuration (save-defconfig)",
+        },
+        async (
+          progress: vscode.Progress<{ message: string; increment: number }>,
+          cancelToken: vscode.CancellationToken
+        ) => {
+          try {
+            await saveDefSdkconfig(workspaceRoot, cancelToken);
+          } catch (error) {
+            Logger.errorNotify(error.message, error);
+          }
+        }
+      );
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1787,7 +1787,8 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.saveDefSdkconfig", async () => {
-    PreCheck.perform([openFolderCheck], () => {
+    const idfVersionCheck = await minIdfVersionCheck("5.0", workspaceRoot);
+    PreCheck.perform([idfVersionCheck, openFolderCheck], () => {
       vscode.window.withProgress(
         {
           cancellable: true,


### PR DESCRIPTION
## Description

Add `ESP-IDF: Save Default SDKCONFIG file (save-defconfig)` command to create a `sdkconfig.defaults` file from current project using `idf.py save-defconfig` command in the back.

PTAL @boris-gu

Fixes #1090

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)"
2. Execute action.
3. Observe results. The `IDF Save Default SDKCONFIG` task should show the `idf.py save-defconfig` output. The `sdkconfig.defaults` should be generated.

## How has this been tested?

Manual testing of running command with blink example from ESP-IDF v5.0.4

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): MacOS

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
