### PR TITLE
added ESP-HomeKit-SDK support in the "Show Examples Projects" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esp-idf-extension",
   "displayName": "ESP-IDF",
   "description": "Develop and debug applications for Espressif ESP32, ESP32-S2 chips with ESP-IDF",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "license": "Apache-2.0",
   "publisher": "espressif",
   "icon": "media/espressif_icon.png",
@@ -399,6 +399,12 @@
             "type": "string",
             "default": "${env:ESP_MATTER_PATH}",
             "description": "%param.espMatterPath%",
+            "scope": "resource"
+          },
+          "idf.espHomeKitSDKPath": {
+            "type": "string",
+            "default": "${env:HOMEKIT_PATH}",
+            "description": "%param.espHomeKitSDKPath%",
             "scope": "resource"
           },
           "idf.toolsPath": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,6 +76,7 @@
   "param.espAdfPath": "Path to locate ESP-ADF framework (ADF_PATH)",
   "param.espMdfPath": "Path to locate ESP-MDF framework (MDF_PATH)",
   "param.espMatterPath": "Path to locate ESP-Matter framework (ESP_MATTER_PATH)",
+  "param.espHomeKitSDKPath": "Path to locate ESP-Homkit SDK framework (HOMEKIT_PATH)",
   "param.espRainmakerPath": "Path to locate ESP-Rainmaker framework (RMAKER_PATH)",
   "param.toolsPath": "Path to locate ESP-IDF Tools (IDF_TOOLS_PATH)",
   "param.exportPaths": "Paths to be appended to PATH",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,7 +438,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   context.subscriptions.push(sdkDeleteWatchDisposable);
 
-  vscode.window.onDidCloseTerminal(async (terminal: vscode.Terminal) => {});
+  vscode.window.onDidCloseTerminal(async (terminal: vscode.Terminal) => { });
 
   registerIDFCommand("espIdf.createFiles", async () => {
     PreCheck.perform([openFolderCheck], async () => {
@@ -1310,7 +1310,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.debug.registerDebugAdapterTrackerFactory("espidf", {
     createDebugAdapterTracker(session: vscode.DebugSession) {
       return {
-        onWillReceiveMessage: (m) => {},
+        onWillReceiveMessage: (m) => { },
       };
     },
   });
@@ -1429,8 +1429,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-              ? error
-              : "Error installing Python requirements";
+                ? error
+                : "Error installing Python requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1500,8 +1500,8 @@ export async function activate(context: vscode.ExtensionContext) {
             const msg = error.message
               ? error.message
               : typeof error === "string"
-              ? error
-              : "Error installing ESP-Matter Python Requirements";
+                ? error
+                : "Error installing ESP-Matter Python Requirements";
             Logger.errorNotify(msg, error);
           }
         }
@@ -1689,10 +1689,10 @@ export async function activate(context: vscode.ExtensionContext) {
               setupArgs = setupArgs
                 ? setupArgs
                 : await getSetupInitialValues(
-                    context.extensionPath,
-                    progress,
-                    workspaceRoot
-                  );
+                  context.extensionPath,
+                  progress,
+                  workspaceRoot
+                );
               SetupPanel.createOrShow(context.extensionPath, setupArgs);
             } catch (error) {
               Logger.errorNotify(error.message, error);
@@ -2050,8 +2050,8 @@ export async function activate(context: vscode.ExtensionContext) {
         typeof appTraceTreeDataProvider.appTraceButton.label === "string"
           ? appTraceTreeDataProvider.appTraceButton.label.match(/start/gi)
           : appTraceTreeDataProvider.appTraceButton.label.label.match(
-              /start/gi
-            );
+            /start/gi
+          );
       if (appTraceLabel) {
         await appTraceManager.start(workspaceRoot);
       } else {
@@ -2069,8 +2069,8 @@ export async function activate(context: vscode.ExtensionContext) {
           typeof appTraceTreeDataProvider.heapTraceButton.label === "string"
             ? appTraceTreeDataProvider.heapTraceButton.label.match(/start/gi)
             : appTraceTreeDataProvider.heapTraceButton.label.label.match(
-                /start/gi
-              );
+              /start/gi
+            );
         if (heapTraceLabel) {
           await gdbHeapTraceManager.start(workspaceRoot);
         } else {
@@ -3002,6 +3002,7 @@ async function getFrameworksPickItems() {
   const rainmakerPathDir = idfConf.readParameter(
     "idf.espRainmakerPath"
   ) as string;
+  const espHomeKitSDKDir = idfConf.readParameter("idf.espHomeKitSDKPath") as string;
 
   const pickItems = [];
   try {
@@ -3046,6 +3047,14 @@ async function getFrameworksPickItems() {
         label: `Use current ESP-Rainmaker (${rainmakerPathDir})`,
         target: rainmakerPathDir,
       });
+    }
+    const doesEspHomeKitSDKPathExists = await utils.dirExistPromise(espHomeKitSDKDir)
+    if (doesEspHomeKitSDKPathExists) {
+      pickItems.push({
+        description: "ESP-HomeKit-SDK",
+        label: `Use current ESP-HomeKit-SDK (${espHomeKitSDKDir})`,
+        target: espHomeKitSDKDir,
+      })
     }
   } catch (error) {
     const errMsg = error.message ? error.message : "Error getting frameworks";


### PR DESCRIPTION
## Description

added ESP-HomeKit-SDK support in the "Show Examples Projects" command

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

1. Click on "Command"
2. Execute "ESP_IDF: Show Examples Projects.
3. If the ESP HomeKit SDK is installed and the HOMEKIT_PATH is set, there should be an option to select the ESP HomeKit SDK examples.

- Expected behaviour: User able to select ESP HomeKit SDK examples inthe "ESP_IDF: Show Examples Projects" command

- Expected output: able to select "Select current ESP Homekit SDK" as an option in the "ESP_IDF: Show Examples Projects" command and the selected example is copied to a destination directory.

## How has this been tested?
- Built the VSIX install package and installed successfully
- Create various HomeKit SDK example projects and flash them to the ESP32 module.

**Test Configuration**:
* ESP-IDF Version: main branch (5.3)
* OS (macOS):

## Dependent components impacted by this PR:
- ESP-IDF: Show Examples Projects command

## Checklist
- [X] PR Self Reviewed
- [X] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
