### PR TITLE
Feature/esp SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Size analysis of the binaries                           | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>S</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>S</kbd> |
 | Unit Test: Build and flash unit test app for testing    |                                        |                                           |
 | Unit Test: Install ESP-IDF PyTest requirements          |                                        |                                           |
+| Remove Editor coverage                                  |                                        |                                           |
+| Run ESP-IDF-SBOM vulnerability check                    |                                        |                                           |
 
 # About commands
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -154,6 +154,7 @@ These settings allow to support additional frameworks together with ESP-IDF:
 | `idf.espMatterPath`       | Path to locate ESP-Matter framework (ESP_MATTER_PATH)           |
 | `idf.espRainmakerPath`    | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH) |
 | `idf.espRainmakerPathWin` | Path to locate ESP-Rainmaker framework in Windows (RMAKER_PATH) |
+| `idf.sbomFilePath`        | Path to create ESP-IDF SBOM report                              |
 
 The **ESP-IDF: Install ESP-ADF** command will clone ESP-ADF and set `idf.espAdfPath` (`idf.espAdfPathWin` in Windows).
 The **ESP-IDF: Install ESP-MDF** command will clone ESP-MDF and set `idf.espMdfPath` (`idf.espMdfPathWin` in Windows).

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -64,6 +64,7 @@
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Unit Test: Build and flash unit test app for testing",
   "espIdf.unitTest.installPyTest.title": "Unit Test: Install ESP-IDF PyTest  requirements",
   "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
+  "espIdf.createSbom.title": "Run ESP-IDF-SBOM vulnerability check",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -134,6 +134,7 @@
   "param.monitorCustomTimestampFormat": "Custom timestamp format in IDF Monitor",
   "param.customTerminalExecutable.title": "Custom executable for extensions tasks",
   "param.customTerminalExecutableArgs.title": "List of arguments for the custom executable for extension tasks",
+  "param.sbomFilePath.title": "esp-idf sbom file path",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -120,6 +120,7 @@
   "param.customTerminalExecutable.title": "Ejecutable personalizado para las tareas de la extensión ESP-IDF",
   "param.customTerminalExecutableArgs.title": "Lista de argumentos para el ejecutble personalizado de tareas de la extensión ESP-IDF",
   "param.sdkconfigFilePath.title": "Ruta absoluta de archivo sdkconfig",
+  "param.sbomFilePath.title": "Ruta absoluta de archivo esp-idf sbom",
   "view.components.name": "Componentes de proyecto",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Refresh Trace Archive List",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -53,6 +53,7 @@
   "espIdf.monitorQemu.title": "Monitorear dispositivo QEMU",
   "espIdf.qemuDebug.title": "Lanzar sesión de depurador para QEMU",
   "espIdf.createDevContainer.title": "Agregar configuracion del contenedor docker",
+  "espIdf.createSbom.title": "Lanzar verificación de vulnerabilidad ESP-IDF-SBOM",
   "esp.component-manager.ui.show.title": "Mostrar registro de componentes",
   "esp.component-manager.cli.addDependencyError": "Error al agregar dependencias al componente",
   "espIdf.partition.table.refresh.title": "Actualizar tabla de particiones",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -64,6 +64,7 @@
   "espIdf.clearSavedIdfSetups.title": "Очистить сохраненные настройки IDF",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "Модульный тест: сборка и запуск приложения модульного тестирования для тестирования.",
   "espIdf.unitTest.installPyTest.title": "Модульный тест: установите требования ESP-IDF PyTest",
+  "espIdf.createSbom.title": "Запустите проверку уязвимостей ESP-IDF-SBOM.",
   "esp.component-manager.ui.show.title": "Показать реестр компонентов",
   "esp.component-manager.cli.addDependencyError": "Ошибка при добавлении зависимости к компоненту",
   "debug.initConfig.name": "Отладка запуск",

--- a/i18n/ru/package.i18n.json
+++ b/i18n/ru/package.i18n.json
@@ -118,6 +118,7 @@
   "param.enableStatusBar.title": "Включить элементы строки состояния расширения ESP-IDF",
   "param.enableSizeTaskAfterBuildTask.title": "Включить задачу размера IDF после задачи сборки",
   "param.sdkconfigFilePath.title": "абсолютный путь к файлу sdkconfig",
+  "param.sbomFilePath.title": "путь к файлу esp-idf sbom",
   "view.components.name": "Компоненты проекта",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "Обновить список архива трассировки",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -64,6 +64,7 @@
   "espIdf.clearSavedIdfSetups.title": "清除保存的IDF设置",
   "espIdf.unitTest.buildFlashUnitTestApp.title": "单元测试：构建并闪存用于测试的单元测试应用程序",
   "espIdf.unitTest.installPyTest.title": "单元测试：安装ESP-IDF PyTest要求",
+  "espIdf.createSbom.title": "运行ESP-IDF-SBOM漏洞检查",
   "esp.component-manager.ui.show.title": "显示组件注册表",
   "esp.component-manager.cli.addDependencyError": "向组件添加依赖项时遇到错误",
   "debug.initConfig.name": "ESP-IDF调试 启动",

--- a/i18n/zh-CN/package.i18n.json
+++ b/i18n/zh-CN/package.i18n.json
@@ -118,6 +118,7 @@
   "param.enableStatusBar.title": "启用ESP-IDF扩展状态栏项目",
   "param.enableSizeTaskAfterBuildTask.title": "在生成任务后启用IDF大小任务",
   "param.sdkconfigFilePath.title": "sdkconfig文件绝对路径",
+  "param.sbomFilePath.title": "esp-idf sbom文件路径",
   "view.components.name": "项目组件",
   "configuration.title": "ESP-IDF",
   "espIdf.apptrace.archive.refresh.title": "刷新跟踪归档列表",

--- a/package.json
+++ b/package.json
@@ -1346,7 +1346,12 @@
       },
       {
         "command": "espIdf.saveDefSdkconfig",
-        "title": "%espIdf.saveDefSdkconfig.title%",
+        "title": "%espIdf.saveDefSdkconfig.title%",,
+        "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.createSbom",
+        "title": "Install ESP-SBOM",
         "category": "ESP-IDF"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1351,7 +1351,7 @@
       },
       {
         "command": "espIdf.createSbom",
-        "title": "Install ESP-SBOM",
+        "title": "%espIdf.createSbom.title%",
         "category": "ESP-IDF"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1352,7 +1352,7 @@
       },
       {
         "command": "espIdf.saveDefSdkconfig",
-        "title": "%espIdf.saveDefSdkconfig.title%",,
+        "title": "%espIdf.saveDefSdkconfig.title%",
         "category": "ESP-IDF"
       },
       {

--- a/package.json
+++ b/package.json
@@ -929,6 +929,12 @@
             "description": "%param.sdkconfigFilePath.title%",
             "scope": "resource",
             "default": ""
+          },
+          "idf.sbomFilePath": {
+            "type": "string",
+            "scope": "resource",
+            "default": "espidf.spdx",
+            "description": "%param.sbomFilePath.title%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -64,6 +64,7 @@
   "espIdf.projectConfigurationEditor.title": "Open Project Configuration",
   "espIdf.projectConf.title": "Select project configuration",
   "espIdf.saveDefSdkconfig.title": "ESP-IDF: Save Default SDKCONFIG file (save-defconfig)",
+  "espIdf.createSbom.title": "Run ESP-IDF-SBOM vulnerability check",
   "esp.component-manager.ui.show.title": "Show Component Registry",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",

--- a/package.nls.json
+++ b/package.nls.json
@@ -134,6 +134,7 @@
   "param.enableCCache.title": "Enable CCache in build task",
   "param.enableSizeTaskAfterBuildTask.title": "Enable IDF Size task after build task",
   "param.sdkconfigFilePath.title": "sdkconfig file absolute path",
+  "param.sbomFilePath.title": "esp-idf sbom file path",
   "esp.rainmaker.backend.sync.title": "Sync with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.connect.title": "Connect with ESP-Rainmaker Cloud Server",
   "esp.rainmaker.backend.logout.title": "Unlink Rainmaker Account",

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -232,6 +232,7 @@
     "param.deleteComponentsOnFullClean",
     "param.enableStatusBar.title",
     "param.enableSizeTaskAfterBuildTask.title",
-    "param.sdkconfigFilePath.title"
+    "param.sdkconfigFilePath.title",
+    "param.sbomFilePath.title"
   ]
 }

--- a/schema.i18n.json
+++ b/schema.i18n.json
@@ -141,6 +141,7 @@
     "espIdf.clearSavedIdfSetups.title",
     "espIdf.unitTest.buildFlashUnitTestApp.title",
     "espIdf.unitTest.installPyTest.title",
+    "espIdf.createSbom.title",
     "debug.initConfig.name",
     "debug.initConfig.description",
     "param.adapterTargetName",

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -1,0 +1,47 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Tuesday, 9th January 2024 3:40:14 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Uri } from "vscode";
+import { appendIdfAndToolsToPath, execChildProcess } from "../utils";
+import { readParameter } from "../idfConfiguration";
+import { OutputChannel } from "../logger/outputChannel";
+
+export async function createSBOM(workspace: Uri) {}
+
+export async function checkVulnerabilities(workspace: Uri) {}
+
+export async function installEspSBOM(workspace: Uri) {
+  const pythonBinPath = readParameter("idf.pythonBinPath", workspace) as string;
+  const modifiedEnv = appendIdfAndToolsToPath(workspace);
+  try {
+    const result = await execChildProcess(
+      `"${pythonBinPath}" -m pip show esp-idf-sbom`,
+      workspace.fsPath,
+      OutputChannel.init(),
+      { env: modifiedEnv }
+    );
+    return result.indexOf("WARNING: Package(s) not found: esp-idf-sbom") === -1;
+  } catch (error) {
+    const installResult = await execChildProcess(
+      `"${pythonBinPath}" -m pip install esp-idf-sbom`,
+      workspace.fsPath,
+      OutputChannel.init(),
+      { env: modifiedEnv }
+    );
+  }
+}

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -52,6 +52,12 @@ export async function createSBOM(workspaceUri: Uri) {
       "idf.sbomFilePath",
       workspaceUri
     ) as string;
+    const sbomFileExists = await pathExists(sbomFilePath);
+    if (sbomFileExists) {
+      return Logger.infoNotify(
+        `${sbomFilePath} exists. Please update idf.sbomFilePath to a non existing file path for ESP-IDF SBOM tasks.`
+      );
+    }
     const options: ShellExecutionOptions = {
       cwd: workspaceUri.fsPath,
       env: modifiedEnv,
@@ -97,7 +103,11 @@ export async function createSBOM(workspaceUri: Uri) {
       options
     );
     TaskManager.addTask(
-      { type: "esp-idf", command: "ESP-IDF SBOM Create", taskId: "idf-sbom-task" },
+      {
+        type: "esp-idf",
+        command: "ESP-IDF SBOM Create",
+        taskId: "idf-sbom-task",
+      },
       curWorkspaceFolder || TaskScope.Workspace,
       "ESP-IDF SBOM Creation",
       sbomCreateExecution,
@@ -105,7 +115,11 @@ export async function createSBOM(workspaceUri: Uri) {
       sbomPresentationOptions
     );
     TaskManager.addTask(
-      { type: "esp-idf", command: "ESP-IDF SBOM Check", taskId: "idf-sbom-check-task" },
+      {
+        type: "esp-idf",
+        command: "ESP-IDF SBOM Check",
+        taskId: "idf-sbom-check-task",
+      },
       curWorkspaceFolder || TaskScope.Workspace,
       "ESP-IDF SBOM Check",
       sbomCheckExecution,

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -46,9 +46,12 @@ export async function createSBOM(workspace: Uri) {
       shellArgs: [],
       shellPath: env.shell,
     });
-    espIdfSbomTerminal.sendText(`esp-idf-sbom create ${projectDescriptionJson} --output-file espidf.spdx`);
+    const sbomFilePath = readParameter("idf.sbomFilePath", workspace) as string;
+    espIdfSbomTerminal.sendText(
+      `esp-idf-sbom create ${projectDescriptionJson} --output-file ${sbomFilePath}`
+    );
     espIdfSbomTerminal.show();
-    espIdfSbomTerminal.sendText(`esp-idf-sbom check espidf.spdx`);
+    espIdfSbomTerminal.sendText(`esp-idf-sbom check ${sbomFilePath}`);
   } catch (error) {
     const msg = error.message
       ? error.message

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3066,8 +3066,29 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.createSbom", () => {
     PreCheck.perform([openFolderCheck], async () => {
-      await installEspSBOM(workspaceRoot);
-      await createSBOM(workspaceRoot);
+      const notificationMode = idfConf.readParameter(
+        "idf.notificationMode",
+        this.curWorkspace
+      ) as string;
+      const ProgressLocation =
+        notificationMode === idfConf.NotificationMode.All ||
+        notificationMode === idfConf.NotificationMode.Notifications
+          ? vscode.ProgressLocation.Notification
+          : vscode.ProgressLocation.Window;
+      vscode.window.withProgress(
+        {
+          title: "ESP-IDF: Create SBOM summary",
+          location: ProgressLocation,
+        },
+        async () => {
+          try {
+            await installEspSBOM(workspaceRoot);
+            await createSBOM(workspaceRoot);
+          } catch (err) {
+            return Logger.errorNotify(err.message, err);
+          }
+        }
+      );
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,6 +143,7 @@ import {
 } from "./espIdf/unitTest/configure";
 import { getFileList, getTestComponents } from "./espIdf/unitTest/utils";
 import { saveDefSdkconfig } from "./espIdf/menuconfig/saveDefConfig";
+import { installEspSBOM } from "./espBom";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -3061,6 +3062,12 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       }
     );
+  });
+
+  registerIDFCommand("espIdf.createSbom", () => {
+    PreCheck.perform([openFolderCheck], async () => {
+      await installEspSBOM(workspaceRoot);
+    });
   });
 
   registerIDFCommand("espIdf.selectFlashMethodAndFlash", () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ import {
 } from "./espIdf/unitTest/configure";
 import { getFileList, getTestComponents } from "./espIdf/unitTest/utils";
 import { saveDefSdkconfig } from "./espIdf/menuconfig/saveDefConfig";
-import { installEspSBOM } from "./espBom";
+import { createSBOM, installEspSBOM } from "./espBom";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -3067,6 +3067,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerIDFCommand("espIdf.createSbom", () => {
     PreCheck.perform([openFolderCheck], async () => {
       await installEspSBOM(workspaceRoot);
+      await createSBOM(workspaceRoot);
     });
   });
 


### PR DESCRIPTION
## Description

Add support for `esp-idf-sbom` in the extension by running the `ESP-IDF: Run ESP-IDF-SBOM vulnerability check` command. 
Fixes VSC-1154

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Run ESP-IDF-SBOM vulnerability check"
2. Execute command. If **esp-idf-sbom** is not installed in python virtual environment it will be installed, a espidf.spdx file will be created and used to generated a report in a new terminal ESP-IDF SBOM. 
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): Windows MacOS

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
