### PR TITLE
add missing idf targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ Check all the tutorials [here](./docs/tutorial/toc.md).
 
 # Table of content
 
-- [ESP-IDF Visual Studio Code Extension](#esp-idf-visual-studio-code-extension)
-- [Tutorials](#tutorials)
-- [Table of content](#table-of-content)
-- [How to use](#how-to-use)
-- [Available commands](#available-commands)
-- [About commands](#about-commands)
-- [Commands for tasks.json and launch.json](#commands-for-tasksjson-and-launchjson)
-- [Available Tasks in tasks.json](#available-tasks-in-tasksjson)
-- [Troubleshooting](#troubleshooting)
-- [Code of Conduct](#code-of-conduct)
-- [License](#license)
+- [ESP-IDF Visual Studio Code Extension](./README.md#esp-idf-visual-studio-code-extension)
+- [Tutorials](./README.md#tutorials)
+- [Table of content](./README.md#table-of-content)
+- [How to use](./README.md#how-to-use)
+- [Available commands](./README.md#available-commands)
+- [About commands](./README.md#about-commands)
+- [Commands for tasks.json and launch.json](./README.md#commands-for-tasksjson-and-launchjson)
+- [Available Tasks in tasks.json](./README.md#available-tasks-in-tasksjson)
+- [Troubleshooting](./README.md#troubleshooting)
+- [Code of Conduct](./README.md#code-of-conduct)
+- [License](./README.md#license)
 
 Check all the [documentation](./docs/ONBOARDING.md).
 
@@ -91,7 +91,7 @@ Installation of ESP-IDF and ESP-IDF Tools is being done from this extension itse
   > **NOTE:** When using the **ESP-IDF: Select Flash Method and Flash** command, your choice will be saved in the `idf.flashType` configuration setting in the current workspace folder's settings.json.
 - You can later start a monitor by pressing <kbd>F1</kbd> and typing **ESP-IDF: Monitor your Device** which will log the device activity in a Visual Studio Code terminal.
 - To make sure you can debug your device, select the your board by pressing <kbd>F1</kbd> and typing **ESP-IDF: Select OpenOCD Board Configuration** or manually define the openOCD configuration files with `idf.openOcdConfigs` configuration in your settings.json.
-- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly). Check the [Troubleshooting](#Troubleshooting) section if you have any issues.
+- If you want to start a debug session, just press F5 (make sure you had at least build and flash once before so the debugger works correctly). Check the [Troubleshooting](./README.md#Troubleshooting) section if you have any issues.
 
 # Available commands
 
@@ -106,11 +106,13 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Add vscode configuration folder                         |                                        |                                           |
 | Build, Flash and start a monitor on your device         | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>D</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>D</kbd> |
 | Build your project                                      | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>B</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>B</kbd> |
+| Clear eFuse Summary                                     |                                        |                                           |
+| Clear ESP-IDF Search Results                            |                                        |                                           |
 | Clear Saved ESP-IDF Setups                              |                                        |                                           |
 | Configure ESP-IDF extension                             |                                        |                                           |
 | Configure Paths                                         |                                        |                                           |
 | Configure Project SDKConfig for Coverage                |                                        |                                           |
-| Create project from extension template                  | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
+| Create project from Extension Template                  | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>C</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>C</kbd> |
 | Create New ESP-IDF Component                            |                                        |                                           |
 | Device configuration                                    |                                        |                                           |
 | Dispose Current SDK Configuration Editor Server Process |                                        |                                           |
@@ -123,6 +125,7 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Flash (UART) your project                               |                                        |                                           |
 | Flash (with JTag)                                       |                                        |                                           |
 | Full Clean Project                                      | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>X</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>X</kbd> |
+| Get eFuse Summary                                       |                                        |                                           |
 | Get HTML Coverage Report for project                    |                                        |                                           |
 | Import ESP-IDF Project                                  |                                        |                                           |
 | Install ESP-ADF                                         |                                        |                                           |

--- a/i18n/en/package.i18n.json
+++ b/i18n/en/package.i18n.json
@@ -2,7 +2,7 @@
   "espIdf.createFiles.title": "Create Project from Extension Template",
   "espIdf.addArduinoAsComponentToCurFolder.title": "Add Arduino ESP32 as ESP-IDF Component",
   "espIdf.createIdfTerminal.title": "Open ESP-IDF Terminal",
-  "espIdf.createVsCodeFolder.title": "Add .vscode Configuration Folder",
+  "espIdf.createVsCodeFolder.title": "Add vscode Configuration Folder",
   "espIdf.setPath.title": "Configure Paths",
   "espIdf.setTarget.title": "Set Espressif Device Target",
   "espIdf.selectConfTarget.title": "Select where to Save Configuration Settings",

--- a/package.json
+++ b/package.json
@@ -493,17 +493,24 @@
             "default": "esp32",
             "enum": [
               "esp32",
-              "esp32s2",
-              "esp32s3",
+              "esp32c2",
               "esp32c3",
               "esp32c6",
+              "esp32h2",
+              "esp32p4",
+              "esp32s2",
+              "esp32s3",
               "custom"
             ],
             "enumDescriptions": [
               "esp32",
-              "esp32 s2",
-              "esp32 s3",
-              "esp32 c3",
+              "esp32 C2",
+              "esp32 C3",
+              "esp32 C6",
+              "esp32 H2",
+              "esp32 P4",
+              "esp32 S2",
+              "esp32 S3",
               "custom"
             ],
             "description": "%param.adapterTargetName%",
@@ -1266,7 +1273,7 @@
       },
       {
         "command": "espIdf.qemuCommand",
-        "title": "QEMU Manager",
+        "title": "%espIdf.launchQemu.title%",
         "category": "ESP-IDF"
       },
       {

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
   "espIdf.createFiles.title": "Create Project from Extension Template",
   "espIdf.addArduinoAsComponentToCurFolder.title": "Add Arduino ESP32 as ESP-IDF Component",
   "espIdf.createIdfTerminal.title": "Open ESP-IDF Terminal",
-  "espIdf.createVsCodeFolder.title": "Add .vscode Configuration Folder",
+  "espIdf.createVsCodeFolder.title": "Add vscode Configuration Folder",
   "espIdf.setPath.title": "Configure Paths",
   "espIdf.selectConfTarget.title": "Select where to Save Configuration Settings",
   "espIdf.selectNotificationMode.title": "Select Output and Notification Mode",

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -20,6 +20,7 @@ import * as idfConf from "../../idfConfiguration";
 import { readJSON } from "fs-extra";
 import { Logger } from "../../logger/logger";
 import { Uri } from "vscode";
+import { defaultBoards } from "./defaultBoards";
 
 export interface IdfBoard {
   name: string;
@@ -27,57 +28,6 @@ export interface IdfBoard {
   target: string;
   configFiles: string[];
 }
-
-export const defaultBoards = [
-  {
-    name: "ESP32 module",
-    description: "ESP32 used with ESP-PROG board",
-    target: "esp32",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-S2 module",
-    description: "ESP32-S2 used with ESP-PROG board",
-    target: "esp32s2",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s2.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-S3 chip (via ESP-PROG)",
-    description: "ESP32-S3 used with ESP-PROG board",
-    target: "esp32s3",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s3.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-S3 chip (via builtin USB-JTAG)",
-    description: "ESP32-S3 debugging via builtin USB-JTAG",
-    target: "esp32s3",
-    configFiles: ["board/esp32s3-builtin.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-C3 chip (via ESP-PROG)",
-    description: "ESP32-C3 used with ESP-PROG board",
-    target: "esp32c3",
-    configFiles: ["board/esp32c3-ftdi.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-C3 chip (via builtin USB-JTAG)",
-    description: "ESP32-C3 debugging via builtin USB-JTAG",
-    target: "esp32c3",
-    configFiles: ["board/esp32c3-builtin.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-C6 chip (via ESP-PROG)",
-    description: "ESP32-C6 used with ESP-PROG board",
-    target: "esp32c6",
-    configFiles: ["board/esp32c6-ftdi.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-C6 chip (via builtin USB-JTAG)",
-    description: "ESP32-C6 debugging via builtin USB-JTAG",
-    target: "esp32c6",
-    configFiles: ["board/esp32c6-builtin.cfg"],
-  } as IdfBoard,
-];
 
 export function getOpenOcdScripts(workspace: Uri): string {
   const customExtraVars = idfConf.readParameter(

--- a/src/espIdf/openOcd/defaultBoards.ts
+++ b/src/espIdf/openOcd/defaultBoards.ts
@@ -1,0 +1,106 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Wednesday, 10th January 2024 7:38:05 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IdfBoard } from "./boardConfiguration";
+
+export const defaultBoards = [
+  {
+    name: "ESP32 module",
+    description: "ESP32 used with ESP-PROG board",
+    target: "esp32",
+    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via ESP-PROG)",
+    description: "ESP32-C3 used with ESP-PROG board",
+    target: "esp32c3",
+    configFiles: ["board/esp32c3-ftdi.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via ESP-PROG-2)",
+    description: "ESP32-C3 debugging via ESP-PROG-2 board",
+    target: "esp32c3",
+    configFiles: ["board/esp32c3-bridge.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via builtin USB-JTAG)",
+    description: "ESP32-C3 debugging via builtin USB-JTAG",
+    target: "esp32c3",
+    configFiles: ["board/esp32c3-builtin.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via ESP-PROG)",
+    description: "ESP32-C6 used with ESP-PROG board",
+    target: "esp32c6",
+    configFiles: ["board/esp32c6-ftdi.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via ESP-PROG-2)",
+    description: "ESP32-C6 debugging via ESP-PROG-2 board",
+    target: "esp32c6",
+    configFiles: ["board/esp32c6-bridge.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via builtin USB-JTAG)",
+    description: "ESP32-C6 debugging via builtin USB-JTAG",
+    target: "esp32c6",
+    configFiles: ["board/esp32c6-builtin.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via builtin USB-JTAG)",
+    description: "ESP32-H2 debugging via builtin USB-JTAG",
+    target: "esp32h2",
+    configFiles: ["board/esp32h2-builtin.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via ESP-PROG)",
+    description: "ESP32-H2 debugging via ESP-PROG board",
+    target: "esp32h2",
+    configFiles: [ "board/esp32h2-ftdi.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via ESP-PROG-2)",
+    description: "ESP32-H2 debugging via ESP-PROG-2 board",
+    target: "esp32h2",
+    configFiles: ["board/esp32h2-bridge.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-S2 module",
+    description: "ESP32-S2 used with ESP-PROG board",
+    target: "esp32s2",
+    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s2.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-S2 chip (via ESP-PROG-2)",
+    description: "ESP32-S2 debugging via ESP-PROG-2 board",
+    target: "esp32s2",
+    configFiles: ["board/esp32s2-bridge.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-S3 chip (via ESP-PROG)",
+    description: "ESP32-S3 used with ESP-PROG board",
+    target: "esp32s3",
+    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s3.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-S3 chip (via builtin USB-JTAG)",
+    description: "ESP32-S3 debugging via builtin USB-JTAG",
+    target: "esp32s3",
+    configFiles: ["board/esp32s3-builtin.cfg"],
+  } as IdfBoard,
+]; 

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -19,11 +19,11 @@ import { SerialPort } from "../espIdf/serial/serialPort";
 import { dirExistPromise } from "../utils";
 import { Logger } from "../logger/logger";
 import {
-  defaultBoards,
   getBoards,
   getOpenOcdScripts,
   IdfBoard,
 } from "../espIdf/openOcd/boardConfiguration";
+import { defaultBoards } from "../espIdf/openOcd/defaultBoards";
 
 export interface INewProjectArgs {
   espIdfPath: string;

--- a/src/test/oocdBoards.test.ts
+++ b/src/test/oocdBoards.test.ts
@@ -19,7 +19,8 @@
 import * as assert from "assert";
 import { readJSON } from "fs-extra";
 import { join } from "path";
-import { defaultBoards, getBoards } from "../espIdf/openOcd/boardConfiguration";
+import { getBoards } from "../espIdf/openOcd/boardConfiguration";
+import { defaultBoards } from "../espIdf/openOcd/defaultBoards";
 
 suite("OpenOCD Board tests", () => {
   let boardJsonObj: any;


### PR DESCRIPTION
## Description

Add ESP32 C2 ESP32 H2 Targets

Fixes #XXX

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Set Espressif device target"
2. Execute action. Check that selected target for ESP32H2 or ESP32C2 are set in settings.json and no errors found. 
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual test of `ESP-IDF: Set Espressif device target` command.

**Test Configuration**:
* ESP-IDF Version: 5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
