### PR TITLE
Enhance/openocd troubleshooting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,8 @@ export namespace ESP {
     }
     export const GithubRepository =
       "https://github.com/espressif/vscode-esp-idf-extension";
-    export const OpenOcdTroubleshootingFaq = "https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ";
+    export const OpenOcdTroubleshootingFaq =
+      "https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ";
     export const ARDUINO_ESP32_URL =
       "https://github.com/espressif/arduino-esp32.git";
     export namespace Docs {

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,7 @@ export namespace ESP {
     }
     export const GithubRepository =
       "https://github.com/espressif/vscode-esp-idf-extension";
+    export const OpenOcdTroubleshootingFaq = "https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ";
     export const ARDUINO_ESP32_URL =
       "https://github.com/espressif/arduino-esp32.git";
     export namespace Docs {

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -29,6 +29,7 @@ import {
   spawn as sspawn,
 } from "../../utils";
 import { TCLClient, TCLConnection } from "./tcl/tclClient";
+import { ESP } from "../../config";
 
 export interface IOpenOCDConfig {
   host: string;
@@ -225,6 +226,7 @@ export class OpenOCDManager extends EventEmitter {
         const err = new Error(errorMsg);
         Logger.errorNotify(errorMsg + `\n❌ ${errStr}`, err);
         OutputChannel.appendLine(`❌ ${errStr}`, "OpenOCD");
+        OutputChannel.appendLine(`For assistance with OpenOCD errors, please refer to our Troubleshooting FAQ: ${ESP.URL.OpenOcdTroubleshootingFaq}`, "OpenOCD");
         this.emit("error", err, this.chan);
       }
       OutputChannel.appendLine(errStr, "OpenOCD");

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -243,7 +243,7 @@ export class OpenOCDManager extends EventEmitter {
       this.stop();
     });
     this.server.on("close", (code: number, signal: string) => {
-      if(this.encounteredErrors) {
+      if (this.encounteredErrors) {
         OutputChannel.appendLine(
           `For assistance with OpenOCD errors, please refer to our Troubleshooting FAQ: ${ESP.URL.OpenOcdTroubleshootingFaq}`,
           "OpenOCD"

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -226,7 +226,10 @@ export class OpenOCDManager extends EventEmitter {
         const err = new Error(errorMsg);
         Logger.errorNotify(errorMsg + `\n❌ ${errStr}`, err);
         OutputChannel.appendLine(`❌ ${errStr}`, "OpenOCD");
-        OutputChannel.appendLine(`For assistance with OpenOCD errors, please refer to our Troubleshooting FAQ: ${ESP.URL.OpenOcdTroubleshootingFaq}`, "OpenOCD");
+        OutputChannel.appendLine(
+          `For assistance with OpenOCD errors, please refer to our Troubleshooting FAQ: ${ESP.URL.OpenOcdTroubleshootingFaq}`,
+          "OpenOCD"
+        );
         this.emit("error", err, this.chan);
       }
       OutputChannel.appendLine(errStr, "OpenOCD");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ export class PreCheck {
         /v(\d+.?\d+.?\d)-esp32-(\d+)/
       );
       if (!minVersionParsed || !currentVersionParsed) {
-        throw new Error("Error parsing versions");
+        throw new Error("Error parsing OpenOCD versions");
       }
       const validationResult =
         currentVersionParsed[1] >= minVersionParsed[1]


### PR DESCRIPTION
## Description

Added [Troubleshooting link ](https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ)for OpenOCD errors.

Task: https://jira.espressif.com:8443/browse/VSC-1237

## Type of change

- Enhancement

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open Project
2. Take actions that would trigger an OpenOCD error.

- Expected behaviour:

After error message in the "ESP-IDF" output channel, there should be a new line added with the following text:

`For assistance with OpenOCD errors, please refer to our Troubleshooting FAQ: https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ.`

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested on Windows 11. Tried to run OpenOCD without setting up the project.

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
