### PR TITLE
:pencil2: Add clarity to placeholder flash method

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3812,7 +3812,7 @@ async function selectFlashMethod() {
     {
       ignoreFocusOut: true,
       placeHolder:
-        "Select flash method, you can modify the choice later from settings 'idf.flashType'",
+        "Select flash method, you can modify the choice later from 'settings.json' (idf.flashType)",
     }
   )) as ESP.FlashType;
   if (!newFlashType) {


### PR DESCRIPTION
## Description

Added a bit more clarity to the placeholder text that is shown when choosing Flashing Method:

**Old text**:  "Select flash method, you can modify the choice later from settings 'idf.flashType'"

**New text**: "Select flash method, you can modify the choice later from 'settings.json' (idf.flashType)"

Task: https://jira.espressif.com:8443/browse/VSC-1235

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

1. Open Project
2. Change Flash Method

In the menu that appears, the new text should be present.

**Test Configuration**:
* ESP-IDF Version: Latest
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
