### PR TITLE
fix workspace for jtag pre post tasks

### DIFF
--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -49,7 +49,7 @@ export async function jtagFlashCommand(workspace: Uri) {
     "idf.buildPath",
     workspace
   ) as string;
-  const customTask = new CustomTask(Uri.file(buildPath));
+  const customTask = new CustomTask(workspace);
   if (forceUNIXPathSeparator === true) {
     buildPath = buildPath.replace(/\\/g, "/");
   }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes #1146 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

This can be reproduced with the following settings.json entries in an example esp-idf project.
```json
"idf.flashType": "JTAG",
"idf.preFlashTask": " echo workspaceFolder = ${workspaceFolder}"
```
Then click on the "ESP-IDF: Flash Device" button.

- Expected behaviour: Workspace folder doesn't contain build path.

- Expected output:

## How has this been tested?

Manual testing using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
