### PR TITLE
fix openOCD notification error messages

### DIFF
--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -115,7 +115,9 @@ export class OpenOCDManager extends EventEmitter {
           break;
       }
     } catch (error) {
-      Logger.errorNotify(error.message, error);
+      const msg = error.message ? error.message : JSON.stringify(error);
+      Logger.error(msg, error);
+      OutputChannel.appendLine(msg, "OpenOCD");
     }
     return true;
   }
@@ -226,7 +228,7 @@ export class OpenOCDManager extends EventEmitter {
           " "
         )}`;
         const err = new Error(errorMsg);
-        Logger.errorNotify(errorMsg + `\n❌ ${errStr}`, err);
+        Logger.error(errorMsg + `\n❌ ${errStr}`, err);
         OutputChannel.appendLine(`❌ ${errStr}`, "OpenOCD");
         this.emit("error", err, this.chan);
       }
@@ -251,10 +253,11 @@ export class OpenOCDManager extends EventEmitter {
       }
       this.encounteredErrors = false;
       if (!signal && code && code !== 0) {
-        Logger.errorNotify(
+        Logger.error(
           `OpenOCD Exit with non-zero error code ${code}`,
           new Error("Spawn exit with non-zero" + code)
         );
+        OutputChannel.appendLine(`OpenOCD Exit with non-zero error code ${code}`, "OpenOCD");
       }
       this.stop();
     });


### PR DESCRIPTION
## Description

Remove openOCD to report errors as notifications.

Fixes #1135
Fixes #1148

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "OpenOCD Server" to start openOCD server.
2. Disconnect device without closing openOCD.
3. Observe results.

- Expected behaviour:

Errors should be added in log file and Output channel ESP-IDF but not shown as notification.

- Expected output:

## How has this been tested?

Manual testing based on steps before.

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
