### PR TITLE
Enhance/whitespaces2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Install ESP-IDF and ESP-IDF Tools by following the [install tutorial](./docs/tut
 
   > **NOTE:** Please take a look at [Working with multiple projects](./docs/MULTI_PROJECTS.md) for more information. Default is User settings.
 
-- On the first time using the extension, press <kbd>F1</kbd> to show the Visual Studio Code Command Palette and type **ESP-IDF: Configure ESP-IDF Extension** to open the extension configuration wizard. This will install ESP-IDF, ESP-IDF tools, create a virtual python environment with ESP-IDF and this extension python packages and configure the extension settings with these values. **NOTE: Make sure that there is no spaces in any configured path since [ESP-IDF build system doesn't support spaces yet.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html#start-a-project)**.
+- On the first time using the extension, press <kbd>F1</kbd> to show the Visual Studio Code Command Palette and type **ESP-IDF: Configure ESP-IDF extension** to open the extension configuration wizard. This will install ESP-IDF, ESP-IDF tools, create a virtual python environment with ESP-IDF and this extension python packages and configure the extension settings with these values. 
+  > **NOTE:** For versions of ESP-IDF < 5.0, spaces are not supported inside configured paths.
 
   > **NOTE:** Please take a look at [Install tutorial](./docs/tutorial/install.md) documentation or the [Setup documentation](./docs/SETUP.md) for details about extension setup and configuration.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -55,7 +55,7 @@ so make sure that if using an existing python virtual environment that installin
 
 > **NOTE:** Currently the python package `pygdbmi` used by the debug adapter still depends on some Python 2.7 libraries (libpython2.7.so.1.0) so make sure that the Python executable in `idf.pythonBinPath` you use contains these libraries. This will be dropped in later versions of ESP-IDF.
 
-> **NOTE:** Make sure that `IDF_PATH` and `IDF_TOOLS_PATH` doesn't have any spaces to avoid any build issues since [ESP-IDF Build System does NOT support spaces yet.](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup.html#start-a-project).
+> **NOTE**: If you want to use an ESP-IDF version < 5.0, make sure that IDF_PATH and IDF_TOOLS_PATH don't have any spaces since they were no suported in previous versions.
 
 After choosing any of the previous options, a status page is displayed showing ESP-IDF, tools and python environment setup progress status. When the setup is finished, a message is shown that "All settings have been configured. You can close this window."
 
@@ -113,8 +113,6 @@ where:
 - `idf.openOcdConfigs` are the config files used for OpenOCD for your device (relative paths to `OPENOCD_SCRIPTS` directory of OpenOCD-ESP32 tool).
 
 **DO NOT USE ~, $HOME OR %USERPROFILE% ENVIRONMENT VARIABLES ARE NOT RESOLVED IN THIS CONFIGURATION SETTINGS. You must use ${env:HOME} instead of \$HOME (Linux/MacOS) or %HOME% (Windows).**
-
-> **NOTE:** Make sure that your configurations settings doesn't have any spaces to avoid any build issues.
 
 Make sure to install the extension and extension debug adapter Python requirements by running the following commands in your terminal:
 

--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -26,7 +26,7 @@
     - Pick an ESP-IDF version to download (or find ESP-IDF in your system) and the python executable to create the virtual environment.
     - Choose the location for ESP-IDF Tools and python virtual environment (also known as `IDF_TOOLS_PATH`) which is `$HOME\.espressif` on MacOS/Linux and `%USERPROFILE%\.espressif` on Windows by default.
       > **NOTE:** Windows users don't need to select a python executable since it is part of the setup.
-
+      > **NOTE:** Make sure that `IDF_TOOLS_PATH` doesn't have any spaces to avoid any build issues.
 <p>
   <img src="../../media/tutorials/setup/select-esp-idf.png" alt="Select ESP-IDF" width="950">
 </p>

--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -27,8 +27,6 @@
     - Choose the location for ESP-IDF Tools and python virtual environment (also known as `IDF_TOOLS_PATH`) which is `$HOME\.espressif` on MacOS/Linux and `%USERPROFILE%\.espressif` on Windows by default.
       > **NOTE:** Windows users don't need to select a python executable since it is part of the setup.
 
-> **NOTE:** Make sure that `IDF_PATH` and `IDF_TOOLS_PATH` doesn't have any spaces to avoid any build issues.
-
 <p>
   <img src="../../media/tutorials/setup/select-esp-idf.png" alt="Select ESP-IDF" width="950">
 </p>
@@ -60,7 +58,7 @@
   <img src="../../media/tutorials/setup/install-complete.png" alt="Install complete">
 </p>
 
-> **NOTE**: The advance mode allows the user to choose to use existing ESP-IDF tools by manually entering each ESP-IDF tool absolute path. Make sure each ESP-IDF tool path doesn't have any spaces.
+> **NOTE**: > The advance mode allows the user to choose to use existing ESP-IDF tools by manually entering each ESP-IDF tool absolute path. Again, if chose an ESP-IDF version < 5.0, make sure each ESP-IDF tool path doesn't have any spaces, since they were no suported in previous versions..
 
 15. Now that the extension setup is finally done, check the [Basic use](./basic_use.md) to learn how to use the SDK Configuration editor, build, flash and monitor your Espressif device.
 

--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -93,17 +93,9 @@ export class PlatformInformation {
 
   private static GetWindowsArchitecture(): Promise<string> {
     const command = "wmic";
-    const args = [
-      "os",
-      "get",
-      "osarchitecture"
-    ];
+    const args = ["os", "get", "osarchitecture"];
     return utils
-      .execChildProcess(
-        command,
-        args,
-        utils.extensionContext.extensionPath
-      )
+      .execChildProcess(command, args, utils.extensionContext.extensionPath)
       .then((architecture) => {
         if (architecture) {
           const archArray: string[] = architecture.split(os.EOL);

--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -80,8 +80,10 @@ export class PlatformInformation {
   }
 
   public static GetUnixArchitecture(): Promise<string> {
+    const command = "uname";
+    const args = ["-m"];
     return utils
-      .execChildProcess("uname -m", utils.extensionContext.extensionPath)
+      .execChildProcess(command, args, utils.extensionContext.extensionPath)
       .then((architecture) => {
         if (architecture) {
           return architecture.trim();
@@ -90,9 +92,16 @@ export class PlatformInformation {
   }
 
   private static GetWindowsArchitecture(): Promise<string> {
+    const command = "wmic";
+    const args = [
+      "os",
+      "get",
+      "osarchitecture"
+    ];
     return utils
       .execChildProcess(
-        "wmic os get osarchitecture",
+        command,
+        args,
         utils.extensionContext.extensionPath
       )
       .then((architecture) => {

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -163,8 +163,7 @@ export class BuildTask {
           compilerArgs.push("-DCCACHE_ENABLE=1");
         }
       }
-      const cmakeCommand = "cmake";
-      const compileExecution = new vscode.ProcessExecution(cmakeCommand, compilerArgs, this.processOptions);
+      const compileExecution = new vscode.ProcessExecution(canAccessCMake, compilerArgs, this.processOptions);
       const compilePresentationOptions = {
         reveal: showTaskOutput,
         showReuseMessage: false,

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -28,23 +28,35 @@ import { selectedDFUAdapterId } from "../flash/dfu";
 export class BuildTask {
   public static isBuilding: boolean;
   private buildDirPath: string;
-  private curWorkspace: vscode.Uri;
+  private currentWorkspace: vscode.Uri;
   private idfPathDir: string;
   private adapterTargetName: string;
+  private processOptions: vscode.ProcessExecutionOptions;
+  private modifiedEnv: { [key: string]: string };
+  private pythonBinPath: string;
 
-  constructor(workspace: vscode.Uri) {
-    this.curWorkspace = workspace;
+  constructor(workspaceUri: vscode.Uri) {
+    this.currentWorkspace = workspaceUri;
     this.idfPathDir = idfConf.readParameter(
       "idf.espIdfPath",
-      workspace
+      workspaceUri
     ) as string;
     this.adapterTargetName = idfConf.readParameter(
       "idf.adapterTargetName",
-      workspace
+      workspaceUri
     ) as string;
     this.buildDirPath = idfConf.readParameter(
       "idf.buildPath",
-      workspace
+      workspaceUri
+    ) as string;
+    this.modifiedEnv = appendIdfAndToolsToPath(workspaceUri);
+    this.processOptions = {
+      cwd: this.buildDirPath,
+      env: this.modifiedEnv,
+    };
+    this.pythonBinPath = idfConf.readParameter(
+      "idf.pythonBinPath",
+      workspaceUri
     ) as string;
   }
 
@@ -55,43 +67,11 @@ export class BuildTask {
   private async saveBeforeBuild() {
     const shallSaveBeforeBuild = idfConf.readParameter(
       "idf.saveBeforeBuild",
-      this.curWorkspace
+      this.currentWorkspace
     );
     if (shallSaveBeforeBuild) {
       await vscode.workspace.saveAll();
     }
-  }
-
-  public getShellExecution(
-    args: string[],
-    options?: vscode.ShellExecutionOptions
-  ) {
-    return new vscode.ShellExecution(`cmake ${args.join(" ")}`, options);
-  }
-
-  public getNinjaShellExecution(
-    args: string[],
-    options?: vscode.ShellExecutionOptions
-  ) {
-    return new vscode.ShellExecution(`ninja ${args.join(" ")}`, options);
-  }
-
-  public dfuShellExecution(options?: vscode.ShellExecutionOptions) {
-    const pythonBinPath = idfConf.readParameter(
-      "idf.pythonBinPath",
-      this.curWorkspace
-    ) as string;
-    return new vscode.ShellExecution(
-      `${pythonBinPath} ${join(
-        this.idfPathDir,
-        "tools",
-        "mkdfu.py"
-      )} write -o ${join(this.buildDirPath, "dfu.bin")} --json ${join(
-        this.buildDirPath,
-        "flasher_args.json"
-      )} --pid ${selectedDFUAdapterId(this.adapterTargetName)}`,
-      options
-    );
   }
 
   public async build() {
@@ -107,17 +87,16 @@ export class BuildTask {
       throw new Error("ALREADY_BUILDING");
     }
     this.building(true);
-    const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
     await ensureDir(this.buildDirPath);
     const canAccessCMake = await isBinInPath(
       "cmake",
-      this.curWorkspace.fsPath,
-      modifiedEnv
+      this.currentWorkspace.fsPath,
+      this.modifiedEnv
     );
     const canAccessNinja = await isBinInPath(
       "ninja",
-      this.curWorkspace.fsPath,
-      modifiedEnv
+      this.currentWorkspace.fsPath,
+      this.modifiedEnv
     );
 
     const cmakeCachePath = join(this.buildDirPath, "CMakeCache.txt");
@@ -127,33 +106,13 @@ export class BuildTask {
       throw new Error("CMake or Ninja executables not found");
     }
 
-    const options: vscode.ShellExecutionOptions = {
-      cwd: this.buildDirPath,
-      env: modifiedEnv,
-    };
-    const shellExecutablePath = idfConf.readParameter(
-      "idf.customTerminalExecutable",
-      this.curWorkspace
-    ) as string;
-    const shellExecutableArgs = idfConf.readParameter(
-      "idf.customTerminalExecutableArgs",
-      this.curWorkspace
-    ) as string[];
-    if (shellExecutablePath) {
-      options.executable = shellExecutablePath;
-    }
-
-    if (shellExecutableArgs && shellExecutableArgs.length) {
-      options.shellArgs = shellExecutableArgs;
-    }
-
-    const curWorkspaceFolder = vscode.workspace.workspaceFolders.find(
-      (w) => w.uri === this.curWorkspace
+    const currentWorkspaceFolder = vscode.workspace.workspaceFolders.find(
+      (w) => w.uri === this.currentWorkspace
     );
 
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode",
-      this.curWorkspace
+      this.currentWorkspace
     ) as string;
     const showTaskOutput =
       notificationMode === idfConf.NotificationMode.All ||
@@ -164,7 +123,7 @@ export class BuildTask {
     if (!cmakeCacheExists) {
       let compilerArgs = (idfConf.readParameter(
         "idf.cmakeCompilerArgs",
-        this.curWorkspace
+        this.currentWorkspace
       ) as Array<string>) || [
         "-G",
         "Ninja",
@@ -178,7 +137,7 @@ export class BuildTask {
       compilerArgs.push("-B", this.buildDirPath);
 
       if (compilerArgs.indexOf("-S") === -1) {
-        compilerArgs.push("-S", this.curWorkspace.fsPath);
+        compilerArgs.push("-S", this.currentWorkspace.fsPath);
       }
 
       const sdkconfigDefaults =
@@ -196,7 +155,7 @@ export class BuildTask {
 
       const enableCCache = idfConf.readParameter(
         "idf.enableCCache",
-        this.curWorkspace
+        this.currentWorkspace
       ) as boolean;
       if (enableCCache && compilerArgs && compilerArgs.length) {
         const indexOfCCache = compilerArgs.indexOf("-DCCACHE_ENABLE=1");
@@ -204,7 +163,8 @@ export class BuildTask {
           compilerArgs.push("-DCCACHE_ENABLE=1");
         }
       }
-      const compileExecution = this.getShellExecution(compilerArgs, options);
+      const cmakeCommand = "cmake";
+      const compileExecution = new vscode.ProcessExecution(cmakeCommand, compilerArgs, this.processOptions);
       const compilePresentationOptions = {
         reveal: showTaskOutput,
         showReuseMessage: false,
@@ -217,7 +177,7 @@ export class BuildTask {
           command: "ESP-IDF Compile",
           taskId: "idf-compile-task",
         },
-        curWorkspaceFolder || vscode.TaskScope.Workspace,
+        currentWorkspaceFolder || vscode.TaskScope.Workspace,
         "ESP-IDF Compile",
         compileExecution,
         ["espIdf"],
@@ -227,10 +187,11 @@ export class BuildTask {
     }
 
     const buildArgs =
-      (idfConf.readParameter("idf.ninjaArgs", this.curWorkspace) as Array<
+      (idfConf.readParameter("idf.ninjaArgs", this.currentWorkspace) as Array<
         string
       >) || [];
-    const buildExecution = this.getNinjaShellExecution(buildArgs, options);
+    const ninjaCommand = "ninja";
+    const buildExecution = new vscode.ProcessExecution(ninjaCommand, buildArgs, this.processOptions);
     const buildPresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,
@@ -239,7 +200,7 @@ export class BuildTask {
     } as vscode.TaskPresentationOptions;
     TaskManager.addTask(
       { type: "esp-idf", command: "ESP-IDF Build", taskId: "idf-build-task" },
-      curWorkspaceFolder || vscode.TaskScope.Workspace,
+      currentWorkspaceFolder || vscode.TaskScope.Workspace,
       "ESP-IDF Build",
       buildExecution,
       ["espIdf"],
@@ -249,36 +210,16 @@ export class BuildTask {
 
   public async buildDfu() {
     this.building(true);
-    const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
+    const modifiedEnv = appendIdfAndToolsToPath(this.currentWorkspace);
     await ensureDir(this.buildDirPath);
 
-    const options: vscode.ShellExecutionOptions = {
-      cwd: this.curWorkspace.fsPath,
-      env: modifiedEnv,
-    };
-
-    const shellExecutablePath = idfConf.readParameter(
-      "idf.customTerminalExecutable",
-      this.curWorkspace
-    ) as string;
-    const shellExecutableArgs = idfConf.readParameter(
-      "idf.customTerminalExecutableArgs",
-      this.curWorkspace
-    ) as string[];
-    if (shellExecutablePath) {
-      options.executable = shellExecutablePath;
-    }
-    if (shellExecutableArgs && shellExecutableArgs.length) {
-      options.shellArgs = shellExecutableArgs;
-    }
-
-    const curWorkspaceFolder = vscode.workspace.workspaceFolders.find(
-      (w) => w.uri === this.curWorkspace
+    const currentWorkspaceFolder = vscode.workspace.workspaceFolders.find(
+      (w) => w.uri === this.currentWorkspace
     );
 
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode",
-      this.curWorkspace
+      this.currentWorkspace
     ) as string;
     const showTaskOutput =
       notificationMode === idfConf.NotificationMode.All ||
@@ -286,7 +227,17 @@ export class BuildTask {
         ? vscode.TaskRevealKind.Always
         : vscode.TaskRevealKind.Silent;
 
-    const writeExecution = this.dfuShellExecution(options);
+    const args = [
+      join(this.idfPathDir, "tools", "mkdfu.py"),
+      "write",
+      "-o",
+      join(this.buildDirPath, "dfu.bin"),
+      "--json",
+      join(this.buildDirPath, "flasher_args.json"),
+      "--pid",
+      selectedDFUAdapterId(this.adapterTargetName)
+    ];
+    const writeExecution = new vscode.ProcessExecution(this.pythonBinPath, args, this.processOptions);
     const buildPresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,
@@ -299,7 +250,7 @@ export class BuildTask {
         command: "ESP-IDF Write DFU.bin",
         taskId: "idf-write-dfu-task",
       },
-      curWorkspaceFolder || vscode.TaskScope.Workspace,
+      currentWorkspaceFolder || vscode.TaskScope.Workspace,
       "ESP-IDF Write DFU.bin",
       writeExecution,
       ["espIdf"],

--- a/src/common/abstractCloning.ts
+++ b/src/common/abstractCloning.ts
@@ -246,12 +246,14 @@ export class AbstractCloning {
       "esp-components",
     ];
     await execChildProcess(
-      `${this.gitBinPath} submodule init`,
+      this.gitBinPath,
+      ["submodule", "init"],
       repoPath,
       OutputChannel.init()
     );
     const gitModules = await execChildProcess(
-      `${this.gitBinPath} config -f .gitmodules --list`,
+      this.gitBinPath,
+      ["config", "-f", ".gitmodules", "--list"],
       repoPath,
       OutputChannel.init()
     );
@@ -297,7 +299,8 @@ export class AbstractCloning {
         }
 
         await execChildProcess(
-          `${this.gitBinPath} config submodule.${subPath}.url ${subUrl}`,
+          this.gitBinPath,
+          ["config", `submodule.${subPath}.url`, subUrl],
           repoPath,
           OutputChannel.init()
         );

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -88,20 +88,25 @@ export async function createSBOM(workspaceUri: Uri) {
       clear: false,
       panel: TaskPanelKind.Shared,
     } as TaskPresentationOptions;
-    const command = "esp-idf-sbnom";
+    const command = "esp-idf-sbom";
     const argsCreating = [
       "create",
       projectDescriptionJson,
       "--output-file",
-      sbomFilePath
-    ];
-    const sbomCreateExecution = new ProcessExecution(command, argsCreating, options);
-    
-    const argsChecking = [
-      "check",
       sbomFilePath,
     ];
-    const sbomCheckExecution = new ProcessExecution(command, argsChecking, options);
+    const sbomCreateExecution = new ProcessExecution(
+      command,
+      argsCreating,
+      options
+    );
+
+    const argsChecking = ["check", sbomFilePath];
+    const sbomCheckExecution = new ProcessExecution(
+      command,
+      argsChecking,
+      options
+    );
     TaskManager.addTask(
       {
         type: "esp-idf",

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -23,8 +23,8 @@ import {
   TaskPanelKind,
   TaskPresentationOptions,
   TaskScope,
-  ShellExecutionOptions,
-  ShellExecution,
+  ProcessExecutionOptions,
+  ProcessExecution,
 } from "vscode";
 import {
   appendIdfAndToolsToPath,
@@ -66,24 +66,10 @@ export async function createSBOM(workspaceUri: Uri) {
         );
       }
     }
-    const options: ShellExecutionOptions = {
+    const options: ProcessExecutionOptions = {
       cwd: workspaceUri.fsPath,
       env: modifiedEnv,
     };
-    const shellExecutablePath = readParameter(
-      "idf.customTerminalExecutable",
-      workspaceUri
-    ) as string;
-    const shellExecutableArgs = readParameter(
-      "idf.customTerminalExecutableArgs",
-      workspaceUri
-    ) as string[];
-    if (shellExecutablePath) {
-      options.executable = shellExecutablePath;
-    }
-    if (shellExecutableArgs && shellExecutableArgs.length) {
-      options.shellArgs = shellExecutableArgs;
-    }
     const notificationMode = readParameter(
       "idf.notificationMode",
       workspaceUri
@@ -102,14 +88,20 @@ export async function createSBOM(workspaceUri: Uri) {
       clear: false,
       panel: TaskPanelKind.Shared,
     } as TaskPresentationOptions;
-    const sbomCreateExecution = new ShellExecution(
-      `esp-idf-sbom create ${projectDescriptionJson} --output-file ${sbomFilePath}`,
-      options
-    );
-    const sbomCheckExecution = new ShellExecution(
-      `esp-idf-sbom check ${sbomFilePath}`,
-      options
-    );
+    const command = "esp-idf-sbnom";
+    const argsCreating = [
+      "create",
+      projectDescriptionJson,
+      "--output-file",
+      sbomFilePath
+    ];
+    const sbomCreateExecution = new ProcessExecution(command, argsCreating, options);
+    
+    const argsChecking = [
+      "check",
+      sbomFilePath,
+    ];
+    const sbomCheckExecution = new ProcessExecution(command, argsChecking, options);
     TaskManager.addTask(
       {
         type: "esp-idf",

--- a/src/espBom/index.ts
+++ b/src/espBom/index.ts
@@ -140,7 +140,8 @@ export async function installEspSBOM(workspace: Uri) {
   const modifiedEnv = appendIdfAndToolsToPath(workspace);
   try {
     const showResult = await execChildProcess(
-      `"${pythonBinPath}" -m pip show esp-idf-sbom`,
+      pythonBinPath,
+      ["-m", "pip", "show", "esp-idf-sbom"],
       workspace.fsPath,
       OutputChannel.init(),
       { env: modifiedEnv }
@@ -148,7 +149,8 @@ export async function installEspSBOM(workspace: Uri) {
     OutputChannel.appendLine(showResult);
   } catch (error) {
     const installResult = await execChildProcess(
-      `"${pythonBinPath}" -m pip install esp-idf-sbom`,
+      pythonBinPath,
+      ["-m", "pip", "install", "esp-idf-sbom"],
       workspace.fsPath,
       OutputChannel.init(),
       { env: modifiedEnv }

--- a/src/espIdf/nvs/partitionTable/panel.ts
+++ b/src/espIdf/nvs/partitionTable/panel.ts
@@ -182,7 +182,8 @@ export class NVSPartitionTable {
       }
       OutputChannel.appendLine(`${pythonBinPath} ${partToolArgs.join(" ")}`);
       const result = await execChildProcess(
-        `${pythonBinPath} ${partToolArgs.join(" ")}`,
+        pythonBinPath,
+        partToolArgs,
         dirPath
       );
       OutputChannel.appendLine(result);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -680,8 +680,15 @@ export async function activate(context: vscode.ExtensionContext) {
           cancelToken: vscode.CancellationToken
         ) => {
           try {
+            const args = [
+              flashScriptPath,
+              "-p",
+              port,
+              "erase_flash"
+            ];
             const result = await utils.execChildProcess(
-              `${pythonBinPath} ${flashScriptPath} -p ${port} erase_flash`,
+              pythonBinPath,
+              args,
               process.cwd(),
               OutputChannel.init(),
               null,
@@ -3462,8 +3469,14 @@ export async function activate(context: vscode.ExtensionContext) {
             "idf.buildPath",
             workspaceRoot
           ) as string;
+          const args = [
+            ninjaSummaryScript,
+            "-C",
+            buildDir
+          ];
           const summaryResult = await utils.execChildProcess(
-            `${pythonBinPath} ${ninjaSummaryScript} -C ${buildDir}`,
+            pythonBinPath,
+            args,
             workspaceRoot.fsPath,
             OutputChannel.init()
           );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -680,12 +680,7 @@ export async function activate(context: vscode.ExtensionContext) {
           cancelToken: vscode.CancellationToken
         ) => {
           try {
-            const args = [
-              flashScriptPath,
-              "-p",
-              port,
-              "erase_flash"
-            ];
+            const args = [flashScriptPath, "-p", port, "erase_flash"];
             const result = await utils.execChildProcess(
               pythonBinPath,
               args,
@@ -3469,11 +3464,7 @@ export async function activate(context: vscode.ExtensionContext) {
             "idf.buildPath",
             workspaceRoot
           ) as string;
-          const args = [
-            ninjaSummaryScript,
-            "-C",
-            buildDir
-          ];
+          const args = [ninjaSummaryScript, "-C", buildDir];
           const summaryResult = await utils.execChildProcess(
             pythonBinPath,
             args,

--- a/src/flash/dfu.ts
+++ b/src/flash/dfu.ts
@@ -64,14 +64,14 @@ export async function listAvailableDfuDevices(text) {
  * @param {string} chip - String to identify the chip (IDF_TARGET)
  * @returns {number} PID Number for DFU
  */
- export function selectedDFUAdapterId(chip: string): number {
+ export function selectedDFUAdapterId(chip: string): string {
   switch (chip) {
     case "esp32s2":
-      return 2;
+      return "2";
     case "esp32s3":
-      return 9;
+      return "9";
     default:
-      return -1;
+      return "-1";
   }
 }
 

--- a/src/flash/dfu.ts
+++ b/src/flash/dfu.ts
@@ -34,7 +34,8 @@ function deviceLabel(selectedDevice: string) {
 export async function getDfuList(workspaceUri: vscode.Uri) {
   const modifiedEnv = appendIdfAndToolsToPath(workspaceUri);
   return await execChildProcess(
-    "dfu-util --list",
+    "dfu-util",
+    ["--list"],
     process.cwd(),
     OutputChannel.init(),
     {

--- a/src/flash/dfu.ts
+++ b/src/flash/dfu.ts
@@ -31,8 +31,8 @@ function deviceLabel(selectedDevice: string) {
   return "ESP32-S3";
 }
 
-export async function getDfuList(workspace: vscode.Uri) {
-  const modifiedEnv = appendIdfAndToolsToPath(workspace);
+export async function getDfuList(workspaceUri: vscode.Uri) {
+  const modifiedEnv = appendIdfAndToolsToPath(workspaceUri);
   return await execChildProcess(
     "dfu-util --list",
     process.cwd(),

--- a/src/flash/jtag.ts
+++ b/src/flash/jtag.ts
@@ -22,12 +22,15 @@ export class JTAGFlash {
   constructor(private readonly client: TCLClient) {}
 
   async flash(command: string, ...args: string[]) {
-    const fullCommand = `${command} ${args.map(arg => `"${arg}"`).join(' ')}`;
+    const fullCommand = `${command} ${args.map((arg) => `"${arg}"`).join(" ")}`;
 
     return new Promise((resolve, reject) => {
       this.client
         .on("response", (data) => {
-          const response = data.toString().replace(TCLClient.DELIMITER, "").trim();
+          const response = data
+            .toString()
+            .replace(TCLClient.DELIMITER, "")
+            .trim();
           if (response !== "0") {
             return reject(
               `Failed to flash the device (JTag), please try again [got response: '${response}', expecting: '0']`

--- a/src/flash/jtag.ts
+++ b/src/flash/jtag.ts
@@ -20,11 +20,14 @@ import { TCLClient } from "../espIdf/openOcd/tcl/tclClient";
 
 export class JTAGFlash {
   constructor(private readonly client: TCLClient) {}
-  async flash(command: string) {
+
+  async flash(command: string, ...args: string[]) {
+    const fullCommand = `${command} ${args.map(arg => `"${arg}"`).join(' ')}`;
+
     return new Promise((resolve, reject) => {
       this.client
         .on("response", (data) => {
-          const response = data.toString().replace("\x1a", "").trim();
+          const response = data.toString().replace(TCLClient.DELIMITER, "").trim();
           if (response !== "0") {
             return reject(
               `Failed to flash the device (JTag), please try again [got response: '${response}', expecting: '0']`
@@ -39,7 +42,7 @@ export class JTAGFlash {
             "Failed to flash (via JTag), due to some unknown error in tcl, please try to relaunch open-ocd"
           );
         })
-        .sendCommand(command);
+        .sendCommand(fullCommand);
     });
   }
 }

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -32,7 +32,8 @@ export async function jtagFlashCommand(workspace: Uri) {
   let continueFlag = true;
   const isOpenOCDLaunched = await OpenOCDManager.init().promptUserToLaunchOpenOCDServer();
   if (!isOpenOCDLaunched) {
-    const errStr = "Can't perform JTag flash, because OpenOCD server is not running!";
+    const errStr =
+      "Can't perform JTag flash, because OpenOCD server is not running!";
     OutputChannel.appendLineAndShow(errStr, "Flash");
     return Logger.warnNotify(errStr);
   }
@@ -56,7 +57,13 @@ export async function jtagFlashCommand(workspace: Uri) {
   try {
     customTask.addCustomTask(CustomTaskType.PreFlash);
     await customTask.runTasks(CustomTaskType.PreFlash);
-    await jtag.flash("program_esp_bins", buildPath, "flasher_args.json", "verify", "reset");
+    await jtag.flash(
+      "program_esp_bins",
+      buildPath,
+      "flasher_args.json",
+      "verify",
+      "reset"
+    );
     customTask.addCustomTask(CustomTaskType.PostFlash);
     await customTask.runTasks(CustomTaskType.PostFlash);
     const msg = "⚡️ Flashed Successfully (JTag)";

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -56,9 +56,7 @@ export async function jtagFlashCommand(workspace: Uri) {
   try {
     customTask.addCustomTask(CustomTaskType.PreFlash);
     await customTask.runTasks(CustomTaskType.PreFlash);
-    await jtag.flash(
-      `program_esp_bins ${buildPath} flasher_args.json verify reset`
-    );
+    await jtag.flash("program_esp_bins", buildPath, "flasher_args.json", "verify", "reset");
     customTask.addCustomTask(CustomTaskType.PostFlash);
     await customTask.runTasks(CustomTaskType.PostFlash);
     const msg = "⚡️ Flashed Successfully (JTag)";

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -221,13 +221,18 @@ export class IdfToolsManager {
     ) {
       modifiedEnv[pathNameInEnv] = modifiedPath;
     }
-    const versionCmd = pkg.version_cmd.join(" ");
-    if (versionCmd === "") {
+    if (pkg.version_cmd.length === 0) {
       return "No command version";
     }
+    const command = pkg.version_cmd[0];
+    const args = pkg.version_cmd.slice(1);
     try {
+      const args = [
+
+      ]
       const binVersionResponse = await utils.execChildProcess(
-        versionCmd,
+        command,
+        args,
         process.cwd(),
         logToChannel ? this.toolsManagerChannel : undefined,
         {

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -227,9 +227,6 @@ export class IdfToolsManager {
     const command = pkg.version_cmd[0];
     const args = pkg.version_cmd.slice(1);
     try {
-      const args = [
-
-      ]
       const binVersionResponse = await utils.execChildProcess(
         command,
         args,

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -39,8 +39,14 @@ export async function installEspIdfToolFromIdf(
       return reject(new Error("Process cancelled by user"));
     }
     try {
+      const args = [
+        idfToolsPyPath,
+        "install",
+        toolName
+      ];
       const processResult = await utils.execChildProcess(
-        `"${pythonBinPath}" ${idfToolsPyPath} install ${toolName}`,
+        pythonBinPath,
+        args,
         idfToolsPath,
         channel,
         { cwd: idfToolsPath, env: modifiedEnv },
@@ -101,7 +107,8 @@ export async function installPythonEnvFromIdfTools(
   const pyEnvPath = await getPythonEnvPath(espDir, idfToolsDir, pythonBinPath);
 
   await execProcessWithLog(
-    `"${pythonBinPath}" "${idfToolsPyPath}" install-python-env`,
+    pythonBinPath,
+    [idfToolsPyPath,"install-python-env"],
     idfToolsDir,
     pyTracker,
     channel,
@@ -145,19 +152,19 @@ export async function installExtensionPyReqs(
     `espidf.constraints.v${espIdfVersion}.txt`
   );
   const constrainsFileExists = await pathExists(constrainsFile);
-  let constraintArg = "";
+  let constraintArg = [];
   if (constrainsFileExists) {
-    constraintArg = `--constraint "${constrainsFile}" `;
+    constraintArg = ["--constraint", constrainsFile];
   } else {
     const extensionConstraintsFile = join(
       utils.extensionContext.extensionPath,
-      `espidf.constraints.txt`
+      "espidf.constraints.txt"
     );
     const extensionConstraintsFileExists = await pathExists(
       extensionConstraintsFile
     );
     if (extensionConstraintsFileExists) {
-      constraintArg = `--constraint "${extensionConstraintsFile}" `;
+      constraintArg = ["--constraint", extensionConstraintsFile];
     }
   }
   const installDAPyPkgsMsg = `Installing ESP-IDF Debug Adapter python packages in ${virtualEnvPython} ...\n`;
@@ -168,8 +175,19 @@ export async function installExtensionPyReqs(
   if (channel) {
     channel.appendLine(installDAPyPkgsMsg + "\n");
   }
+  const args = [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    ...constraintArg,
+    "--no-warn-script-location",
+    "-r",
+    debugAdapterRequirements
+  ];
   await execProcessWithLog(
-    `"${virtualEnvPython}" -m pip install --upgrade ${constraintArg}--no-warn-script-location -r "${debugAdapterRequirements}"`,
+    virtualEnvPython,
+    args,
     idfToolsDir,
     pyTracker,
     channel,
@@ -215,8 +233,18 @@ export async function installEspMatterPyReqs(
   if (channel) {
     channel.appendLine(installMatterPyPkgsMsg + "\n");
   }
+  const args = [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "--no-warn-script-location",
+    "-r",
+    matterRequirements
+  ];
   await execProcessWithLog(
-    `"${virtualEnvPython}" -m pip install --upgrade --no-warn-script-location -r "${matterRequirements}"`,
+    virtualEnvPython,
+    args,
     idfToolsDir,
     pyTracker,
     channel,
@@ -227,6 +255,7 @@ export async function installEspMatterPyReqs(
 }
 export async function execProcessWithLog(
   cmd: string,
+  args: string[],
   workDir: string,
   pyTracker?: PyReqLog,
   channel?: OutputChannel,
@@ -235,6 +264,7 @@ export async function execProcessWithLog(
 ) {
   const processResult = await utils.execChildProcess(
     cmd,
+    args,
     workDir,
     channel,
     opts,
@@ -254,9 +284,15 @@ export async function getPythonEnvPath(
   idfToolsDir: string,
   pythonBin: string
 ) {
+  const pythonCode = `import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))`;
+  const args = [
+    "-c",
+    pythonCode
+  ];
   const pythonVersion = (
     await utils.execChildProcess(
-      `"${pythonBin}" -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))"`,
+      pythonBin,
+      args,
       espIdfDir
     )
   ).replace(/(\n|\r|\r\n)/gm, "");
@@ -275,7 +311,8 @@ export async function getPythonEnvPath(
 export async function checkPythonExists(pythonBin: string, workingDir: string) {
   try {
     const versionResult = await utils.execChildProcess(
-      `"${pythonBin}" --version`,
+      pythonBin,
+      ["--version"],
       workingDir
     );
     if (versionResult) {
@@ -302,8 +339,14 @@ export async function checkPythonExists(pythonBin: string, workingDir: string) {
 
 export async function checkPipExists(pyBinPath: string, workingDir: string) {
   try {
+    const args = [
+      "-m",
+      "pip",
+      "--version"
+    ];
     const pipResult = await utils.execChildProcess(
-      `"${pyBinPath}" -m pip --version`,
+      pyBinPath,
+      args,
       workingDir
     );
     if (pipResult) {
@@ -349,32 +392,35 @@ export async function getPythonBinList(workingDir: string) {
 
 export async function getUnixPythonList(workingDir: string) {
   try {
-    const pyVersionsStr = await utils.execChildProcess(
-      "which -a python; which -a python3",
-      workingDir
-    );
-    if (pyVersionsStr) {
-      const resultList = pyVersionsStr.trim().split("\n");
-      const uniquePathsSet = new Set(resultList);
-      const uniquePathsArray = Array.from(uniquePathsSet);
-      return uniquePathsArray;
-    }
+    const pythonVersionsRaw = await utils.execChildProcess("which", ["-a", "python"], workingDir);
+    const pythonVersions = pythonVersionsRaw.trim() ? pythonVersionsRaw.trim().split("\n") : [];
+    
+    const python3VersionsRaw = await utils.execChildProcess("which", ["-a", "python3"], workingDir);
+    const python3Versions = python3VersionsRaw.trim() ? python3VersionsRaw.trim().split("\n") : [];
+
+    const combinedVersionsArray = [...pythonVersions, ...python3Versions];
+    const uniquePathsSet = new Set(combinedVersionsArray.filter(path => path.length > 0));
+    const uniquePathsArray = Array.from(uniquePathsSet);
+
+    return uniquePathsArray;
   } catch (error) {
     Logger.errorNotify("Error looking for python in system", error);
     return ["Not found"];
   }
 }
 
+
 export async function checkIfNotVirtualEnv(
   pythonBinPath: string,
   workDir: string
 ) {
   try {
-    const isVirtualEnvBuffer = await utils.execChildProcess(
-      `"${pythonBinPath}" -c "import sys; print('{}'.format(sys.prefix == sys.base_prefix))"`,
+    const isVirtualEnv = await utils.execChildProcess(
+      pythonBinPath,
+      ["-c", "import sys; print(sys.prefix == sys.base_prefix)"],
       workDir
     );
-    return isVirtualEnvBuffer.toString().indexOf("True") !== -1 ? true : false;
+    return isVirtualEnv.trim() === "True";
   } catch (error) {
     Logger.errorNotify("Error checking Python is virtualenv", error);
     return false;

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -349,7 +349,8 @@ export async function checkPipExists(pyBinPath: string, workingDir: string) {
 export async function checkVenvExists(pyBinPath: string, workingDir: string) {
   try {
     const pipResult = await utils.execChildProcess(
-      `"${pyBinPath}" -c "import venv"`,
+      pyBinPath,
+      ["-c", "import venv"],
       workingDir
     );
     return true;

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -374,23 +374,34 @@ export async function getPythonBinList(workingDir: string) {
 
 export async function getUnixPythonList(workingDir: string) {
   try {
-    const pythonVersionsRaw = await utils.execChildProcess(
-      "which",
-      ["-a", "python"],
-      workingDir
-    );
-    const pythonVersions = pythonVersionsRaw.trim()
-      ? pythonVersionsRaw.trim().split("\n")
-      : [];
+    let pythonVersions: string[] = [];
+    let python3Versions: string[] = [];
 
-    const python3VersionsRaw = await utils.execChildProcess(
-      "which",
-      ["-a", "python3"],
-      workingDir
-    );
-    const python3Versions = python3VersionsRaw.trim()
-      ? python3VersionsRaw.trim().split("\n")
-      : [];
+    try {
+      const pythonVersionsRaw = await utils.execChildProcess(
+        "which",
+        ["-a", "python"],
+        workingDir
+      );
+      pythonVersions = pythonVersionsRaw.trim()
+        ? pythonVersionsRaw.trim().split("\n")
+        : [];
+    } catch (pythonError) {
+      Logger.warn("Error finding python versions", pythonError);
+    }
+
+    try {
+      const python3VersionsRaw = await utils.execChildProcess(
+        "which",
+        ["-a", "python3"],
+        workingDir
+      );
+      python3Versions = python3VersionsRaw.trim()
+        ? python3VersionsRaw.trim().split("\n")
+        : [];
+    } catch (python3Error) {
+      Logger.warn("Error finding python3 versions", python3Error);
+    }
 
     const combinedVersionsArray = [...pythonVersions, ...python3Versions];
     const uniquePathsSet = new Set(

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -39,11 +39,7 @@ export async function installEspIdfToolFromIdf(
       return reject(new Error("Process cancelled by user"));
     }
     try {
-      const args = [
-        idfToolsPyPath,
-        "install",
-        toolName
-      ];
+      const args = [idfToolsPyPath, "install", toolName];
       const processResult = await utils.execChildProcess(
         pythonBinPath,
         args,
@@ -108,7 +104,7 @@ export async function installPythonEnvFromIdfTools(
 
   await execProcessWithLog(
     pythonBinPath,
-    [idfToolsPyPath,"install-python-env"],
+    [idfToolsPyPath, "install-python-env"],
     idfToolsDir,
     pyTracker,
     channel,
@@ -183,7 +179,7 @@ export async function installExtensionPyReqs(
     ...constraintArg,
     "--no-warn-script-location",
     "-r",
-    debugAdapterRequirements
+    debugAdapterRequirements,
   ];
   await execProcessWithLog(
     virtualEnvPython,
@@ -240,7 +236,7 @@ export async function installEspMatterPyReqs(
     "--upgrade",
     "--no-warn-script-location",
     "-r",
-    matterRequirements
+    matterRequirements,
   ];
   await execProcessWithLog(
     virtualEnvPython,
@@ -285,16 +281,9 @@ export async function getPythonEnvPath(
   pythonBin: string
 ) {
   const pythonCode = `import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))`;
-  const args = [
-    "-c",
-    pythonCode
-  ];
+  const args = ["-c", pythonCode];
   const pythonVersion = (
-    await utils.execChildProcess(
-      pythonBin,
-      args,
-      espIdfDir
-    )
+    await utils.execChildProcess(pythonBin, args, espIdfDir)
   ).replace(/(\n|\r|\r\n)/gm, "");
   const fullEspIdfVersion = await utils.getEspIdfFromCMake(espIdfDir);
   const majorMinorMatches = fullEspIdfVersion.match(/([0-9]+\.[0-9]+).*/);
@@ -339,16 +328,8 @@ export async function checkPythonExists(pythonBin: string, workingDir: string) {
 
 export async function checkPipExists(pyBinPath: string, workingDir: string) {
   try {
-    const args = [
-      "-m",
-      "pip",
-      "--version"
-    ];
-    const pipResult = await utils.execChildProcess(
-      pyBinPath,
-      args,
-      workingDir
-    );
+    const args = ["-m", "pip", "--version"];
+    const pipResult = await utils.execChildProcess(pyBinPath, args, workingDir);
     if (pipResult) {
       const match = pipResult.match(/pip\s\d+(.\d+)?(.\d+)?/g);
       if (match && match.length > 0) {
@@ -392,14 +373,28 @@ export async function getPythonBinList(workingDir: string) {
 
 export async function getUnixPythonList(workingDir: string) {
   try {
-    const pythonVersionsRaw = await utils.execChildProcess("which", ["-a", "python"], workingDir);
-    const pythonVersions = pythonVersionsRaw.trim() ? pythonVersionsRaw.trim().split("\n") : [];
-    
-    const python3VersionsRaw = await utils.execChildProcess("which", ["-a", "python3"], workingDir);
-    const python3Versions = python3VersionsRaw.trim() ? python3VersionsRaw.trim().split("\n") : [];
+    const pythonVersionsRaw = await utils.execChildProcess(
+      "which",
+      ["-a", "python"],
+      workingDir
+    );
+    const pythonVersions = pythonVersionsRaw.trim()
+      ? pythonVersionsRaw.trim().split("\n")
+      : [];
+
+    const python3VersionsRaw = await utils.execChildProcess(
+      "which",
+      ["-a", "python3"],
+      workingDir
+    );
+    const python3Versions = python3VersionsRaw.trim()
+      ? python3VersionsRaw.trim().split("\n")
+      : [];
 
     const combinedVersionsArray = [...pythonVersions, ...python3Versions];
-    const uniquePathsSet = new Set(combinedVersionsArray.filter(path => path.length > 0));
+    const uniquePathsSet = new Set(
+      combinedVersionsArray.filter((path) => path.length > 0)
+    );
     const uniquePathsArray = Array.from(uniquePathsSet);
 
     return uniquePathsArray;
@@ -408,7 +403,6 @@ export async function getUnixPythonList(workingDir: string) {
     return ["Not found"];
   }
 }
-
 
 export async function checkIfNotVirtualEnv(
   pythonBinPath: string,

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -436,16 +436,6 @@ export class SetupPanel {
             idfGitPath = embedPaths.idfGitPath;
             idfPythonPath = embedPaths.idfPythonPath;
           }
-          const pathToCheck =
-            selectedIdfVersion.filename === "manual"
-              ? espIdfPath
-              : idfContainerPath;
-          this.checkSpacesInPaths(
-            pathToCheck,
-            toolsPath,
-            idfGitPath,
-            idfPythonPath
-          );
           await expressInstall(
             selectedIdfVersion,
             idfPythonPath,
@@ -575,12 +565,6 @@ export class SetupPanel {
             idfGitPath = embedPaths.idfGitPath;
             idfPythonPath = embedPaths.idfPythonPath;
           }
-          this.checkSpacesInPaths(
-            idfPath,
-            toolsPath,
-            idfGitPath,
-            idfPythonPath
-          );
           await downloadIdfTools(
             idfPath,
             toolsPath,
@@ -692,36 +676,6 @@ export class SetupPanel {
       workspaceFolderUri
     );
     return { idfPythonPath, idfGitPath };
-  }
-
-  private checkSpacesInPaths(
-    idfPath: string,
-    idfToolsPath: string,
-    gitPath: string,
-    pythonBinPath: string
-  ) {
-    const doesIdfPathHasSpaces = checkSpacesInPath(idfPath);
-    const doesIdfToolsPathHasSpaces = checkSpacesInPath(idfToolsPath);
-    const doesGitPathHasSpaces = checkSpacesInPath(gitPath);
-    const doesPythonBinPath = checkSpacesInPath(pythonBinPath);
-    let pathHasSpaces = "";
-    if (doesIdfPathHasSpaces) {
-      pathHasSpaces = `${idfPath} has spaces. Use another location. (IDF_PATH_WITH_SPACES)`;
-    }
-    if (doesIdfToolsPathHasSpaces) {
-      pathHasSpaces = `${idfToolsPath} has spaces. Use another location. (IDF_TOOLS_PATH_WITH_SPACES)`;
-    }
-    if (doesGitPathHasSpaces) {
-      pathHasSpaces = `${gitPath} has spaces. Use another location. (GIT_PATH_WITH_SPACES)`;
-    }
-    if (doesPythonBinPath) {
-      pathHasSpaces = `${pythonBinPath} has spaces. Use another location. (PYTHON_BIN_PATH_WITH_SPACES)`;
-    }
-    if (pathHasSpaces) {
-      OutputChannel.appendLine(pathHasSpaces);
-      Logger.infoNotify(pathHasSpaces);
-      throw new Error(pathHasSpaces);
-    }
   }
 
   private async getOpenOcdRulesPath() {

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -436,6 +436,13 @@ export class SetupPanel {
             idfGitPath = embedPaths.idfGitPath;
             idfPythonPath = embedPaths.idfPythonPath;
           }
+          const pathToCheck =
+            selectedIdfVersion.filename === "manual"
+              ? espIdfPath
+              : idfContainerPath;
+          this.checkSpacesInPaths(
+            toolsPath,
+          );
           await expressInstall(
             selectedIdfVersion,
             idfPythonPath,
@@ -565,6 +572,9 @@ export class SetupPanel {
             idfGitPath = embedPaths.idfGitPath;
             idfPythonPath = embedPaths.idfPythonPath;
           }
+          this.checkSpacesInPaths(
+            toolsPath,
+          );
           await downloadIdfTools(
             idfPath,
             toolsPath,
@@ -683,6 +693,21 @@ export class SetupPanel {
       await getOpenOcdRules(Uri.file(this.context.extensionPath));
     } catch (error) {
       this.setupErrHandler(error);
+    }
+  }
+
+  private checkSpacesInPaths(
+    idfToolsPath: string,
+  ) {
+    const doesIdfToolsPathHasSpaces = checkSpacesInPath(idfToolsPath);
+    let pathHasSpaces = "";
+    if (doesIdfToolsPathHasSpaces) {
+      pathHasSpaces = `${idfToolsPath} has spaces. Use another location. (IDF_TOOLS_PATH_WITH_SPACES)`;
+    }
+    if (pathHasSpaces) {
+      OutputChannel.appendLine(pathHasSpaces);
+      Logger.infoNotify(pathHasSpaces);
+      throw new Error(pathHasSpaces);
     }
   }
 

--- a/src/support/checkEspIdfRequirements.ts
+++ b/src/support/checkEspIdfRequirements.ts
@@ -64,7 +64,8 @@ export async function checkRequirements(
   );
   modifiedEnv.IDF_PATH = reportedResult.configurationSettings.espIdfPath;
   const requirementsResult = await execChildProcess(
-    `${reportedResult.configurationSettings.pythonBinPath} ${checkPythonDepsScript} -r "${requirementsPath}"`,
+    reportedResult.configurationSettings.pythonBinPath,
+    [checkPythonDepsScript, "-r", requirementsPath],
     context.extensionPath,
     { env: modifiedEnv, cwd: context.extensionPath }
   );

--- a/src/support/configurationAccess.ts
+++ b/src/support/configurationAccess.ts
@@ -71,13 +71,15 @@ export async function getConfigurationAccess(
   }
   if (process.platform !== "win32") {
     const cmakePathInEnv = await execChildProcess(
-      `which cmake`,
+      "which",
+      ["cmake"],
       context.extensionPath
     );
     reportedResult.configurationAccess.cmakeInEnv =
       cmakePathInEnv && cmakePathInEnv.indexOf("not found") === -1;
     const ninjaPathInEnv = await execChildProcess(
-      `which ninja`,
+      "which",
+      ["ninja"],
       context.extensionPath
     );
     reportedResult.configurationAccess.ninjaInEnv =

--- a/src/support/execChildProcess.ts
+++ b/src/support/execChildProcess.ts
@@ -15,10 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { exec, ExecOptions } from "child_process";
+import { execFile, ExecOptions } from "child_process";
 
 export function execChildProcess(
-  cmd: string,
+  command: string,
+  args: string[] = [],
   pathWhereToExecute: string,
   opts?: ExecOptions
 ) {
@@ -29,7 +30,7 @@ export function execChildProcess(
     };
   }
   return new Promise<string>((resolve, reject) => {
-    exec(cmd, opts, (error: Error, stdout: string, stderr: string) => {
+    execFile(command, args, opts, (error: Error, stdout: string, stderr: string) => {
       if (error) {
         return reject(error);
       }

--- a/src/support/gitVersion.ts
+++ b/src/support/gitVersion.ts
@@ -26,7 +26,8 @@ export async function getGitVersion(
   context: vscode.ExtensionContext,
 ) {
   const rawGitVersion = await execChildProcess(
-    `"${reportedResult.configurationSettings.gitPath}" --version`,
+    reportedResult.configurationSettings.gitPath,
+    ["--version"],
     context.extensionPath
   );
   reportedResult.gitVersion.output = rawGitVersion;

--- a/src/support/pipVersion.ts
+++ b/src/support/pipVersion.ts
@@ -26,7 +26,8 @@ export async function getPipVersion(
 ) {
   try {
     const rawPipVersion = await execChildProcess(
-      `"${reportedResult.configurationSettings.pythonBinPath}" -m pip --version`,
+      reportedResult.configurationSettings.pythonBinPath,
+      ["-m", "pip", "--version"],
       context.extensionPath
     );
     reportedResult.pipVersion.output = rawPipVersion;

--- a/src/support/pythonPackages.ts
+++ b/src/support/pythonPackages.ts
@@ -24,7 +24,8 @@ export async function getPythonPackages(
   context: vscode.ExtensionContext
 ) {
   const rawPythonPackagesList = await execChildProcess(
-    `${reportedResult.configurationSettings.pythonBinPath} -m pip list --format json`,
+    reportedResult.configurationSettings.pythonBinPath,
+    ["-m", "pip", "list", "--format", "json"],
     context.extensionPath
   );
   reportedResult.pythonPackages.output = rawPythonPackagesList;

--- a/src/support/pythonVersion.ts
+++ b/src/support/pythonVersion.ts
@@ -26,7 +26,8 @@ export async function getPythonVersion(
 ) {
   try {
     const rawPythonVersion = await execChildProcess(
-      `"${reportedResult.configurationSettings.pythonBinPath}" --version`,
+      reportedResult.configurationSettings.pythonBinPath,
+      ["--version"],
       context.extensionPath
     );
     reportedResult.pythonVersion.output = rawPythonVersion;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -825,14 +825,23 @@ export async function fixFileModeGitRepository(
     const modifiedEnv = appendIdfAndToolsToPath(workingDirUri);
     const fixFileModeResult = await execChildProcess(
       gitPath,
-    ["config", "--local", "core.fileMode", "false"],
+      ["config", "--local", "core.fileMode", "false"],
       workingDir,
       OutputChannel.init(),
       { env: modifiedEnv, cwd: workingDir }
     );
     const fixSubmodulesFileModeResult = await execChildProcess(
       gitPath,
-      ["submodule", "foreach", "--recursive", "git", "config", "--local", "core.fileMode", "false"],
+      [
+        "submodule",
+        "foreach",
+        "--recursive",
+        "git",
+        "config",
+        "--local",
+        "core.fileMode",
+        "false",
+      ],
       workingDir,
       OutputChannel.init(),
       { env: modifiedEnv, cwd: workingDir }
@@ -1233,4 +1242,30 @@ export function markdownToWebviewHtml(
   }
   cleanHtml = cleanHtml.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
   return cleanHtml;
+}
+
+export function getUserShell() {
+  if (idfConf.readParameter("idf.customTerminalExecutable")) {
+    return "custom";
+  }
+  const config = vscode.workspace.getConfiguration("terminal.integrated");
+  const shellWindows = config.get("defaultProfile.windows") as string;
+  const shellMac = config.get("defaultProfile.osx") as string;
+  const shellLinux = config.get("defaultProfile.linux") as string;
+
+  // list of shells to check
+  const shells = ["PowerShell", "Command Prompt", "bash", "zsh"];
+
+  // if user's shell is in the list, return it
+  for (let i = 0; i < shells.length; i++) {
+    if (shellWindows && shellWindows.includes(shells[i])) {
+      return shells[i];
+    } else if (shellMac && shellMac.includes(shells[i])) {
+      return shells[i];
+    } else if (shellLinux && shellLinux.includes(shells[i])) {
+      return shells[i];
+    }
+  }
+  // if no match, return null
+  return null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ import {
 } from "fs-extra";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import { marked } from "marked";
-import { EOL } from "os";
+import { EOL, platform } from "os";
 import * as path from "path";
 import * as url from "url";
 import * as vscode from "vscode";
@@ -1248,7 +1248,9 @@ export function getUserShell() {
   if (idfConf.readParameter("idf.customTerminalExecutable")) {
     return "custom";
   }
+
   const config = vscode.workspace.getConfiguration("terminal.integrated");
+
   const shellWindows = config.get("defaultProfile.windows") as string;
   const shellMac = config.get("defaultProfile.osx") as string;
   const shellLinux = config.get("defaultProfile.linux") as string;
@@ -1266,6 +1268,17 @@ export function getUserShell() {
       return shells[i];
     }
   }
+
+  // if no match or no defaultProfile, pick one based on user's OS
+  const userOS = platform();
+  if (userOS === "win32") {
+    return "PowerShell";
+  } else if (userOS === "darwin") {
+    return "zsh";
+  } else if (userOS === "linux") {
+    return "bash";
+  }
+
   // if no match, return null
   return null;
 }

--- a/src/views/setup/App.vue
+++ b/src/views/setup/App.vue
@@ -21,7 +21,7 @@ const isLinuxPlatform = computed(() => {
 
 const openOCDRulesPathText = computed(() => {
   return openOCDRulesPath.value !== ""
-    ? `sudo cp -n "${openOCDRulesPath.value}" /etc/udev/rules.d`
+    ? `sudo cp -n ${openOCDRulesPath.value} /etc/udev/rules.d`
     : "";
 });
 </script>
@@ -66,7 +66,7 @@ const openOCDRulesPathText = computed(() => {
           </p>
           <p>Run this command in a terminal with sudo privileges:</p>
         </div>
-        <div class="notification keep-spaces" v-if="openOCDRulesPathText">
+        <div class="notification" v-if="openOCDRulesPathText">
           {{ openOCDRulesPathText }}
         </div>
       </div>
@@ -117,9 +117,5 @@ const openOCDRulesPathText = computed(() => {
 
 .span-path {
   color: var(--vscode-button-hoverBackground);
-}
-
-.keep-spaces {
-  white-space: pre-wrap;
 }
 </style>

--- a/src/views/setup/App.vue
+++ b/src/views/setup/App.vue
@@ -21,7 +21,7 @@ const isLinuxPlatform = computed(() => {
 
 const openOCDRulesPathText = computed(() => {
   return openOCDRulesPath.value !== ""
-    ? `sudo cp -n ${openOCDRulesPath.value} /etc/udev/rules.d`
+    ? `sudo cp -n "${openOCDRulesPath.value}" /etc/udev/rules.d`
     : "";
 });
 </script>
@@ -66,7 +66,7 @@ const openOCDRulesPathText = computed(() => {
           </p>
           <p>Run this command in a terminal with sudo privileges:</p>
         </div>
-        <div class="notification" v-if="openOCDRulesPathText">
+        <div class="notification keep-spaces" v-if="openOCDRulesPathText">
           {{ openOCDRulesPathText }}
         </div>
       </div>
@@ -117,5 +117,9 @@ const openOCDRulesPathText = computed(() => {
 
 .span-path {
   color: var(--vscode-button-hoverBackground);
+}
+
+.keep-spaces {
+  white-space: pre-wrap;
 }
 </style>

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -11,11 +11,11 @@ const setupMode = computed(() => {
 });
 
 const isVersionLowerThan5 = (version: string): boolean => {
-    if (!version) return false;
-    const versionParts = version.split(".");
-    const majorVersion = Number(versionParts[0]);
-    return majorVersion < 5;
-  }
+  if (!version) return false;
+  const versionParts = version.split(".");
+  const majorVersion = Number(versionParts[0]);
+  return majorVersion < 5;
+};
 
 function goTo(route: string, setupMode: SetupMode) {
   router.push(route);
@@ -61,7 +61,8 @@ function goTo(route: string, setupMode: SetupMode) {
         <p>IDF Tools path: {{ prevSetup.toolsPath }}</p>
         <p>Git path: {{ prevSetup.gitPath }}</p>
         <p v-if="isVersionLowerThan5(prevSetup.version)" class="warning-text">
-          Whitespaces in project, ESP-IDF and ESP Tools paths are not supported in versions lower than 5.0
+          Whitespaces in project, ESP-IDF and ESP Tools paths are not supported
+          in versions lower than 5.0
         </p>
       </div>
     </div>
@@ -73,6 +74,5 @@ function goTo(route: string, setupMode: SetupMode) {
 .warning-text {
   color: var(--vscode-editorWarning-foreground);
   font-size: small;
-  
 }
 </style>

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -10,6 +10,13 @@ const setupMode = computed(() => {
   return SetupMode;
 });
 
+const isVersionLowerThan5 = (version: string): boolean => {
+    if (!version) return false;
+    const versionParts = version.split(".");
+    const majorVersion = Number(versionParts[0]);
+    return majorVersion < 5;
+  }
+
 function goTo(route: string, setupMode: SetupMode) {
   router.push(route);
   store.setupMode = setupMode;
@@ -53,8 +60,19 @@ function goTo(route: string, setupMode: SetupMode) {
         <p>Python path: {{ prevSetup.python }}</p>
         <p>IDF Tools path: {{ prevSetup.toolsPath }}</p>
         <p>Git path: {{ prevSetup.gitPath }}</p>
+        <p v-if="isVersionLowerThan5(prevSetup.version)" class="warning-text">
+          Whitespaces in project, ESP-IDF and ESP Tools paths are not supported in versions lower than 5.0
+        </p>
       </div>
     </div>
   </div>
 </template>
 ./types
+
+<style scoped>
+.warning-text {
+  color: var(--vscode-editorWarning-foreground);
+  font-size: small;
+  
+}
+</style>

--- a/src/views/setup/ExistingSetup.vue
+++ b/src/views/setup/ExistingSetup.vue
@@ -10,13 +10,6 @@ const setupMode = computed(() => {
   return SetupMode;
 });
 
-const isVersionLowerThan5 = (version: string): boolean => {
-  if (!version) return false;
-  const versionParts = version.split(".");
-  const majorVersion = Number(versionParts[0]);
-  return majorVersion < 5;
-};
-
 function goTo(route: string, setupMode: SetupMode) {
   router.push(route);
   store.setupMode = setupMode;
@@ -60,19 +53,8 @@ function goTo(route: string, setupMode: SetupMode) {
         <p>Python path: {{ prevSetup.python }}</p>
         <p>IDF Tools path: {{ prevSetup.toolsPath }}</p>
         <p>Git path: {{ prevSetup.gitPath }}</p>
-        <p v-if="isVersionLowerThan5(prevSetup.version)" class="warning-text">
-          Whitespaces in project, ESP-IDF and ESP Tools paths are not supported
-          in versions lower than 5.0
-        </p>
       </div>
     </div>
   </div>
 </template>
 ./types
-
-<style scoped>
-.warning-text {
-  color: var(--vscode-editorWarning-foreground);
-  font-size: small;
-}
-</style>

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -11,20 +11,13 @@ import { IconClose } from "@iconify-prerendered/vue-codicon";
 const store = useSetupStore();
 
 const {
+  espIdfErrorStatus,
   gitVersion,
   pathSep,
   pyExecErrorStatus,
   toolsFolder,
   setupMode,
-  selectedEspIdfVersion,
-  espIdf,
-  espIdfContainer,
 } = storeToRefs(store);
-
-const errMsgIdf =
-  "The ESP IDF folder path cannot contain spaces for ESP-IDF version lower than 5.0";
-const errMsgTools =
-  "The ESP Tools folder path cannot contain spaces for ESP-IDF version lower than 5.0";
 
 const isNotWinPlatform = computed(() => {
   return pathSep.value.indexOf("/") !== -1;
@@ -34,43 +27,9 @@ const actionButtonText = computed(() => {
   return setupMode.value === SetupMode.advanced ? "Configure Tools" : "Install";
 });
 
-const isVersionLowerThan5 = computed(() => {
-  const version = selectedEspIdfVersion.value.version;
-  if (version) {
-    const match = version.match(/v(\d+(\.\d+)?(\.\d+)?)/);
-    if (match) {
-      const versionNumber = parseFloat(match[1]);
-      return versionNumber < 5;
-    }
-  }
-  return false;
-});
-
-const whiteSpaceNotSupportedIdf = computed(() => {
-  if (isVersionLowerThan5.value) {
-    if (selectedEspIdfVersion.value.filename === "manual") {
-      return espIdf.value.includes(" ");
-    }
-    if (selectedEspIdfVersion.value.filename !== "manual") {
-      return espIdfContainer.value.includes(" ");
-    }
-  }
-});
-
-const whiteSpaceNotSupportedTools = computed(() => {
-  if (isVersionLowerThan5.value) {
-    return toolsFolder.value.includes(" ");
-  }
-});
-
-const buttonTooltip = computed(() => {
-  if (whiteSpaceNotSupportedIdf.value) {
-    return errMsgIdf;
-  } else if (whiteSpaceNotSupportedTools.value) {
-    return errMsgTools;
-  }
-  return ""; // No tooltip when the button is not disabled
-});
+function setEspIdfErrorStatus() {
+  store.espIdfErrorStatus = "";
+}
 
 function setPyExecErrorStatus() {
   store.pyExecErrorStatus = "";
@@ -94,9 +53,12 @@ function setToolsFolder(newToolsPath: string) {
 
       <div
         class="notification is-danger error-message"
-        v-if="whiteSpaceNotSupportedIdf"
+        v-if="espIdfErrorStatus"
       >
-        <span>{{ errMsgIdf }}</span>
+        <p>{{ espIdfErrorStatus }}</p>
+        <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
+          <IconClose />
+        </div>
       </div>
 
       <folderOpen
@@ -105,13 +67,6 @@ function setToolsFolder(newToolsPath: string) {
         :propMutate="setToolsFolder"
         :openMethod="store.openEspIdfToolsFolder"
       />
-
-      <div
-        class="notification is-danger error-message"
-        v-if="whiteSpaceNotSupportedTools"
-      >
-        <span>{{ errMsgTools }}</span>
-      </div>
 
       <selectPyVersion v-if="isNotWinPlatform"></selectPyVersion>
 
@@ -131,8 +86,6 @@ function setToolsFolder(newToolsPath: string) {
             @click="store.installEspIdf"
             class="button"
             data-config-id="start-install-btn"
-            :disabled="whiteSpaceNotSupportedIdf || whiteSpaceNotSupportedTools"
-            :title="buttonTooltip"
           >
             {{ actionButtonText }}
           </button>
@@ -150,7 +103,7 @@ function setToolsFolder(newToolsPath: string) {
 .error-message {
   padding: 0.5em;
   margin: 0.5em;
-  display: inline-block;
+  display: flex;
   justify-content: space-between;
   align-items: center;
 }

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -153,6 +153,10 @@ function setToolsFolder(newToolsPath: string) {
 </template>
 
 <style scoped>
+#install {
+  margin: 1% 5%;
+}
+
 .error-message {
   padding: 0.5em;
   margin: 0.5em;

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -69,7 +69,10 @@ const isInstallDisabled = computed(() => {
     hasToolsWhitespace.value ||
     (selectedEspIdfVersion.value.filename !== "manual" &&
       isVersionLessThanFive.value &&
-      hasWhitespaceInEspIdfContainer.value)
+      hasWhitespaceInEspIdfContainer.value) ||
+    !espIdf.value ||
+    !espIdfContainer.value ||
+    !toolsFolder.value
   );
 });
 
@@ -132,6 +135,10 @@ function setToolsFolder(newToolsPath: string) {
 
       <div v-if="hasToolsWhitespace" class="notification is-danger">
         White spaces are not allowed in the ESP-IDF Tools path.
+      </div>
+
+      <div v-if="!toolsFolder" class="notification is-danger">
+        ESP-IDF Tools path should not be empty.
       </div>
 
       <selectPyVersion v-if="isNotWinPlatform" />

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -18,11 +18,13 @@ const {
   setupMode,
   selectedEspIdfVersion,
   espIdf,
-  espIdfContainer
+  espIdfContainer,
 } = storeToRefs(store);
 
-const errMsgIdf = "The ESP IDF folder path cannot contain spaces for ESP-IDF version lower than 5.0";
-const errMsgTools = "The ESP Tools folder path cannot contain spaces for ESP-IDF version lower than 5.0";
+const errMsgIdf =
+  "The ESP IDF folder path cannot contain spaces for ESP-IDF version lower than 5.0";
+const errMsgTools =
+  "The ESP Tools folder path cannot contain spaces for ESP-IDF version lower than 5.0";
 
 const isNotWinPlatform = computed(() => {
   return pathSep.value.indexOf("/") !== -1;
@@ -45,21 +47,21 @@ const isVersionLowerThan5 = computed(() => {
 });
 
 const whiteSpaceNotSupportedIdf = computed(() => {
-  if(isVersionLowerThan5.value) {
-    if (selectedEspIdfVersion.value.filename === 'manual') {
-      return espIdf.value.includes(' ');
+  if (isVersionLowerThan5.value) {
+    if (selectedEspIdfVersion.value.filename === "manual") {
+      return espIdf.value.includes(" ");
     }
-    if (selectedEspIdfVersion.value.filename !== 'manual') {
-      return espIdfContainer.value.includes(' ');
+    if (selectedEspIdfVersion.value.filename !== "manual") {
+      return espIdfContainer.value.includes(" ");
     }
   }
-})
+});
 
 const whiteSpaceNotSupportedTools = computed(() => {
-  if(isVersionLowerThan5.value) {
-    return toolsFolder.value.includes(' ');
+  if (isVersionLowerThan5.value) {
+    return toolsFolder.value.includes(" ");
   }
-})
+});
 
 const buttonTooltip = computed(() => {
   if (whiteSpaceNotSupportedIdf.value) {
@@ -94,7 +96,7 @@ function setToolsFolder(newToolsPath: string) {
         class="notification is-danger error-message"
         v-if="whiteSpaceNotSupportedIdf"
       >
-        <span>{{errMsgIdf}}</span>
+        <span>{{ errMsgIdf }}</span>
       </div>
 
       <folderOpen
@@ -108,7 +110,7 @@ function setToolsFolder(newToolsPath: string) {
         class="notification is-danger error-message"
         v-if="whiteSpaceNotSupportedTools"
       >
-        <span>{{errMsgTools}}</span>
+        <span>{{ errMsgTools }}</span>
       </div>
 
       <selectPyVersion v-if="isNotWinPlatform"></selectPyVersion>

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -2,7 +2,7 @@
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "./store";
 import { SetupMode } from "./types";
-import { computed } from "vue";
+import { computed, watchEffect } from "vue";
 import folderOpen from "./components/folderOpen.vue";
 import selectEspIdf from "./components/selectEspIdf.vue";
 import selectPyVersion from "./components/selectPyVersion.vue";
@@ -17,6 +17,9 @@ const {
   pyExecErrorStatus,
   toolsFolder,
   setupMode,
+  selectedEspIdfVersion,
+  espIdf,
+  espIdfContainer,
 } = storeToRefs(store);
 
 const isNotWinPlatform = computed(() => {
@@ -25,6 +28,61 @@ const isNotWinPlatform = computed(() => {
 
 const actionButtonText = computed(() => {
   return setupMode.value === SetupMode.advanced ? "Configure Tools" : "Install";
+});
+
+const hasToolsWhitespace = computed(() => {
+  return /\s/.test(toolsFolder.value);
+});
+
+const isVersionLessThanFive = computed(() => {
+  if (!selectedEspIdfVersion.value || !selectedEspIdfVersion.value.version) {
+    return false;
+  }
+
+  const versionString = selectedEspIdfVersion.value.version.match(
+    /(\d+\.\d+\.\d+|\d+\.\d+)/
+  );
+  if (!versionString) {
+    return false;
+  }
+
+  const version = versionString[0].split(".").map((num) => parseInt(num));
+  if (version[0] < 5) {
+    return true;
+  } else if (version[0] === 5 && version[1] === 0 && version[2] === 0) {
+    return true;
+  }
+
+  return false;
+});
+
+const hasWhitespaceInEspIdf = computed(() => {
+  return /\s/.test(espIdf.value);
+});
+
+const hasWhitespaceInEspIdfContainer = computed(() => {
+  return /\s/.test(espIdfContainer.value);
+});
+
+const isInstallDisabled = computed(() => {
+  return (
+    hasToolsWhitespace.value ||
+    (selectedEspIdfVersion.value.filename !== "manual" &&
+      isVersionLessThanFive.value &&
+      hasWhitespaceInEspIdfContainer.value)
+  );
+});
+
+watchEffect(() => {
+  if (!hasWhitespaceInEspIdf.value) {
+    store.whiteSpaceErrorIDF = "";
+  }
+  if (!hasWhitespaceInEspIdfContainer.value) {
+    store.whiteSpaceErrorIDFContainer = "";
+  }
+  if (!hasToolsWhitespace.value) {
+    store.whiteSpaceErrorTools = "";
+  }
 });
 
 function setEspIdfErrorStatus() {
@@ -42,6 +100,20 @@ function setToolsFolder(newToolsPath: string) {
 
 <template>
   <div id="install">
+    <div class="notification is-danger error-message" v-if="espIdfErrorStatus">
+      <p>{{ espIdfErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
+    <div class="notification is-danger error-message" v-if="pyExecErrorStatus">
+      <p>{{ pyExecErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
     <div class="notification">
       <div class="field" v-if="isNotWinPlatform && gitVersion">
         <label data-config-id="git-version"
@@ -49,17 +121,7 @@ function setToolsFolder(newToolsPath: string) {
         >
       </div>
 
-      <selectEspIdf></selectEspIdf>
-
-      <div
-        class="notification is-danger error-message"
-        v-if="espIdfErrorStatus"
-      >
-        <p>{{ espIdfErrorStatus }}</p>
-        <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
-          <IconClose />
-        </div>
-      </div>
+      <selectEspIdf />
 
       <folderOpen
         propLabel="Enter ESP-IDF Tools directory (IDF_TOOLS_PATH):"
@@ -68,17 +130,11 @@ function setToolsFolder(newToolsPath: string) {
         :openMethod="store.openEspIdfToolsFolder"
       />
 
-      <selectPyVersion v-if="isNotWinPlatform"></selectPyVersion>
-
-      <div
-        class="notification is-danger error-message"
-        v-if="pyExecErrorStatus"
-      >
-        <p>{{ pyExecErrorStatus }}</p>
-        <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
-          <IconClose />
-        </div>
+      <div v-if="hasToolsWhitespace" class="notification is-danger">
+        White spaces are not allowed in the ESP-IDF Tools path.
       </div>
+
+      <selectPyVersion v-if="isNotWinPlatform" />
 
       <div class="field install-btn">
         <div class="control">
@@ -86,6 +142,7 @@ function setToolsFolder(newToolsPath: string) {
             @click="store.installEspIdf"
             class="button"
             data-config-id="start-install-btn"
+            :disabled="isInstallDisabled"
           >
             {{ actionButtonText }}
           </button>
@@ -96,10 +153,6 @@ function setToolsFolder(newToolsPath: string) {
 </template>
 
 <style scoped>
-#install {
-  margin: 1% 5%;
-}
-
 .error-message {
   padding: 0.5em;
   margin: 0.5em;

--- a/src/views/setup/components/folderOpen.vue
+++ b/src/views/setup/components/folderOpen.vue
@@ -34,7 +34,7 @@ function onKeyEnter() {
 </script>
 
 <template>
-  <div>
+  <div class="field">
     <label class="label">{{ propLabel }}</label>
     <div class="field has-addons align-center">
       <div class="control expanded">

--- a/src/views/setup/components/folderOpen.vue
+++ b/src/views/setup/components/folderOpen.vue
@@ -34,7 +34,7 @@ function onKeyEnter() {
 </script>
 
 <template>
-  <div class="field">
+  <div>
     <label class="label">{{ propLabel }}</label>
     <div class="field has-addons align-center">
       <div class="control expanded">

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -3,7 +3,7 @@ import { storeToRefs } from "pinia";
 import { useSetupStore } from "../store";
 import { IdfMirror } from "../types";
 import folderOpen from "./folderOpen.vue";
-import { computed } from "vue";
+import { computed, watchEffect } from "vue";
 
 const store = useSetupStore();
 
@@ -22,7 +22,7 @@ const {
 } = storeToRefs(store);
 
 const idfVersionList = computed(() => {
-  if (showIdfTagList) {
+  if (showIdfTagList.value) {
     const idfVersionWithTagsList = [...espIdfVersionList.value];
     for (const idfTag of espIdfTags.value) {
       const existingVersion = espIdfVersionList.value.find(
@@ -53,6 +53,52 @@ const resultingIdfPath = computed(() => {
   return `${selectedEspIdfVersion.value.version.replace("release/", "")}${
     store.pathSep
   }esp-idf`;
+});
+
+const isVersionLessThanFive = computed(() => {
+  if (!selectedEspIdfVersion.value || !selectedEspIdfVersion.value.version) {
+    return false;
+  }
+
+  const versionString = selectedEspIdfVersion.value.version.match(
+    /(\d+\.\d+\.\d+|\d+\.\d+)/
+  );
+  if (!versionString) {
+    return false;
+  }
+
+  const version = versionString[0].split(".").map((num) => parseInt(num));
+  if (version[0] < 5) {
+    return true;
+  } else if (version[0] === 5 && version[1] === 0 && version[2] === 0) {
+    return true;
+  }
+
+  return false;
+});
+
+const hasWhitespaceInEspIdf = computed(() => {
+  return /\s/.test(espIdf.value);
+});
+
+const hasWhitespaceInEspIdfContainer = computed(() => {
+  return /\s/.test(espIdfContainer.value);
+});
+
+const showManualVersionWarning = computed(() => {
+  return (
+    selectedEspIdfVersion.value.filename === "manual" &&
+    hasWhitespaceInEspIdf.value
+  );
+});
+
+watchEffect(() => {
+  if (!hasWhitespaceInEspIdf.value) {
+    store.whiteSpaceErrorIDF = "";
+  }
+  if (!hasWhitespaceInEspIdfContainer.value) {
+    store.whiteSpaceErrorIDFContainer = "";
+  }
 });
 </script>
 
@@ -120,6 +166,22 @@ const resultingIdfPath = computed(() => {
         selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
       "
     />
+    <div v-if="showManualVersionWarning" class="notification is-warning">
+      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
+      are not supported for earlier versions.
+    </div>
+    <div
+      v-if="
+        selectedEspIdfVersion &&
+        selectedEspIdfVersion.filename !== 'manual' &&
+        isVersionLessThanFive &&
+        hasWhitespaceInEspIdfContainer
+      "
+      class="notification is-danger"
+    >
+      White spaces are only supported for ESP-IDF path for versions >
+      5.0
+    </div>
   </div>
 </template>
 

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -85,6 +85,14 @@ const hasWhitespaceInEspIdfContainer = computed(() => {
   return /\s/.test(espIdfContainer.value);
 });
 
+const isPathEmpty = computed(() => {
+  if (selectedEspIdfVersion.value.filename === "manual") {
+    return !espIdf.value;
+  } else {
+    return !espIdfContainer.value;
+  }
+});
+
 const showManualVersionWarning = computed(() => {
   return (
     selectedEspIdfVersion.value.filename === "manual" &&
@@ -179,8 +187,10 @@ watchEffect(() => {
       "
       class="notification is-danger"
     >
-      White spaces are only supported for ESP-IDF path for versions >
-      5.0
+      White spaces are only supported for ESP-IDF path for versions > 5.0.
+    </div>
+    <div v-if="isPathEmpty" class="notification is-danger">
+      ESP-IDF path should not be empty.
     </div>
   </div>
 </template>

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -72,6 +72,9 @@ export const useSetupStore = defineStore("setup", () => {
   let pathSep: Ref<string> = ref("/");
   let platform: Ref<string> = ref("");
   let pyExecErrorStatus: Ref<string> = ref("");
+  let whiteSpaceErrorIDF: Ref<string> = ref("");
+  let whiteSpaceErrorTools: Ref<string> = ref("");
+  let whiteSpaceErrorIDFContainer: Ref<string> = ref("");
   let pyReqsLog: Ref<string> = ref("");
   let pyVersionsList: Ref<string[]> = ref([]);
   let saveScope: Ref<number> = ref(1);
@@ -430,5 +433,8 @@ export const useSetupStore = defineStore("setup", () => {
     openShowExamplesPanel,
     requestInitValues,
     toggleContent,
+    whiteSpaceErrorIDF,
+    whiteSpaceErrorTools,
+    whiteSpaceErrorIDFContainer,
   };
 });


### PR DESCRIPTION
## Description

Enable usage of white spaces in project's path, esp idf's path and tools's path.
https://jira.espressif.com:8443/browse/VSC-808

Fixes #[1162](https://github.com/espressif/vscode-esp-idf-extension/issues/1162)
Fixes #[939](https://github.com/espressif/vscode-esp-idf-extension/issues/939)

## Type of change

Please delete options that are not relevant.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Configure extension with whitespaces in esp idf's path, in the tools' path and project's path.
2. Test all features (building, flashing, monitoring etc)

All features should work, however, there is an issue currently with esp-idf while building a project with whitespaces:
```
 Run Build Command(s):C:/ESPRES~2/tools/ninja/111~1.1/ninja.exe cmTC_c5154 && [1/2] Building C object CMakeFiles/cmTC_c5154.dir/testCCompiler.c.obj
    FAILED: CMakeFiles/cmTC_c5154.dir/testCCompiler.c.obj 
    C:\ESPRES~2\tools\XTENSA~2\ESP-13~1.0_2\XTENSA~1\bin\XT8994~1.EXE   -mlongcalls -Wno-frame-address -o CMakeFiles/cmTC_c5154.dir/testCCompiler.c.obj -c "C:/Users/Radu/Desktop/esp projects/esp     spaces/blink/build/CMakeFiles/CMakeTmp/testCCompiler.c"
    thread 'main' panicked at 'assertion failed: `(left == right)`
      left: `"XT8994~1.EXE"`,
     right: `"xtensa"`: Called tool must have pattern "xtensa-esp*-elf-*"', main.rs:46:18
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    ninja: build stopped: subcommand failed.
```

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested as described above on Windows 11 with different shells, including: Command Prompt, Powershell and Bash

**Test Configuration**:
* ESP-IDF Version: 5.2.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
