### PR TITLE
use workspace folder uri in serial port

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -60,7 +60,7 @@ export class SerialPort {
         { placeHolder: msg }
       );
       if (chosen && chosen.label) {
-        await this.updatePortListStatus(chosen.label);
+        await this.updatePortListStatus(chosen.label, workspaceFolder);
       }
     } catch (error) {
       Logger.errorNotify(
@@ -74,11 +74,12 @@ export class SerialPort {
     return await this.list(workspaceFolder);
   }
 
-  private async updatePortListStatus(l: string) {
+  private async updatePortListStatus(l: string, wsFolder: vscode.Uri) {
     const settingsSavedLocation = await idfConf.writeParameter(
       "idf.port",
       l,
-      vscode.ConfigurationTarget.WorkspaceFolder
+      vscode.ConfigurationTarget.WorkspaceFolder,
+      wsFolder
     );
     const portHasBeenSelectedMsg = this.locDic.localize(
       "serial.portHasBeenSelectedMessage",


### PR DESCRIPTION
## Description

Fix the need to select workspace folder on serial port selection

Fixes #1166 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Select port to use"
2. Execute action.
3. Observe results. No dropdown to select workspace should be shown.

- Expected behaviour:

- Expected output:


**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
