### PR TITLE
feat: avoid adding `saveDefSdkconfig` menu item to every files in explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,8 +282,9 @@
           "group": "navigation"
         },
         {
+          "when": "resourceFilename == CMakeLists.txt || resourceFilename =~ /^sdkconfig.*$/",
           "command": "espIdf.saveDefSdkconfig",
-          "group": "navigation"
+          "group": "2_workspace"
         },
         {
           "when": "resourceExtname == .bin",


### PR DESCRIPTION
## Description

Avoid adding `saveDefSdkconfig` menu item to every files in explorer

## Type of change
New feature (non-breaking change which adds functionality)

## Expected behaviour
`espIdf.saveDefSdkconfig` should be only added to ESP-IDF-related project files.
And it should not be ordered at first, for it is not used often.