### PR TITLE
fix output channel interrupt

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -22,6 +22,7 @@ import { LocDictionary } from "../../localizationDictionary";
 import { Logger } from "../../logger/logger";
 import { spawn } from "../../utils";
 import { SerialPortDetails } from "./serialPortDetails";
+import { OutputChannel } from "../../logger/outputChannel";
 
 export class SerialPort {
   public static shared(): SerialPort {
@@ -63,10 +64,15 @@ export class SerialPort {
         await this.updatePortListStatus(chosen.label, workspaceFolder);
       }
     } catch (error) {
+      const msg = error.message
+        ? error.message
+        : "Something went wrong while getting the serial port list";
       Logger.errorNotify(
-        "Something went wrong while getting the serial port list",
+        msg,
         error
       );
+      OutputChannel.appendLine(msg, "Serial port");
+      OutputChannel.appendLineAndShow(JSON.stringify(error));
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3735,6 +3735,9 @@ const flash = (
           ) as ESP.FlashType;
         }
         await startFlashing(cancelToken, flashType, encryptPartition);
+        OutputChannel.appendLine(
+          "Flash has finished. You can monitor with ESP-IDF: Monitor your device command"
+        );
       }
     );
   });

--- a/src/logger/outputChannel.ts
+++ b/src/logger/outputChannel.ts
@@ -24,17 +24,21 @@ export class OutputChannel {
 
   public static appendLine(message: string, name?: string) {
     OutputChannel.checkInitialized();
-    if(name) {
+    if (name && this.lastTag !== name) {
+      if (this.lastTag) {
+        OutputChannel.instance.appendLine(`[/${this.lastTag}]`);
+      }
       OutputChannel.instance.appendLine(`[${name}]`);
+      this.lastTag = name;
     }
     OutputChannel.instance.appendLine(message);
   }
 
   public static append(message: string, name?: string) {
     OutputChannel.checkInitialized();
-    if(name) {
+    if (name) {
       OutputChannel.instance.appendLine(`[${name}]`);
-    } 
+    }
     OutputChannel.instance.append(message);
   }
 
@@ -57,6 +61,8 @@ export class OutputChannel {
   }
 
   private static instance: vscode.OutputChannel;
+
+  private static lastTag: string;
 
   private static checkInitialized() {
     if (!OutputChannel.instance) {


### PR DESCRIPTION
## Description

Add tag for Output channel just the first time and replace it when a new tag is received.
Add message after flashing to use the monitor command

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "SDK Configuration Editor". Tag should be printed only once at the beginning.
2. Start OpenOCD. The SDK Configuration Editor end tag should appear before OpenOCD tag.
3. Observe results.

## How has this been tested?

Manual testing based on steps above.

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
