### PR TITLE
Chip identification

### DIFF
--- a/src/espIdf/serial/serialPortDetails.ts
+++ b/src/espIdf/serial/serialPortDetails.ts
@@ -21,16 +21,19 @@ export class SerialPortDetails {
   public manufacturer: string;
   public vendorId: string;
   public productId: string;
+  public chipType: string;
 
   constructor(
     comName: string,
     manufacturer?: string,
     vendorId?: string,
-    product?: string
+    product?: string,
+    chipType?: string
   ) {
     this.comName = comName;
     this.manufacturer = manufacturer;
     this.vendorId = vendorId;
     this.productId = product;
+    this.chipType = chipType;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export function spawn(
       if (timeoutHandler) {
         clearTimeout(timeoutHandler);
       }
-      reject(error)
+      reject(error);
     });
 
     child.on("exit", (code) => {


### PR DESCRIPTION
## Description

We now use esptool.py to identify the chip connected to the com ports so the user can see which port he wants to choose.



## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and the required output

1. Click on "Select port to use"
2. Wait for one second (if it takes longer there is a bug).
3. Observe results.

- Expected behaviour:
there should be visible description of the board connected to the port :

![image](https://github.com/espressif/vscode-esp-idf-extension/assets/4068385/651b1de2-3be1-4ede-aa21-ad23b8b8709a)

- Expected output:

## How has this been tested?

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version: 5.2.1
* OS (Windows,Linux and macOS): tested on both macos and Windows

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
