### PR TITLE
Chip-id in port selection (VSC-1359)

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -111,6 +111,10 @@ export class SerialPort {
           "esptool",
           "esptool.py"
         );
+        const stat = await vscode.workspace.fs.stat(vscode.Uri.file(esptoolPath));
+        if (stat.type !== vscode.FileType.File) { // esptool.py does not exists
+          throw new Error(`esptool.py does not exists in ${esptoolPath}`);
+        }
         async function processPorts(serialPort: SerialPortDetails) {
           try {
             const chipIdBuffer = await spawn(
@@ -120,9 +124,9 @@ export class SerialPort {
               2000 // success is quick, failing takes too much time
             );
             const regexp = /Chip is(.*?)[\r]?\n/;
-            const chipIdString2 = chipIdBuffer.toString().match(regexp);
+            const chipIdString = chipIdBuffer.toString().match(regexp);
 
-            serialPort.chipType = chipIdString2[1].trim();
+            serialPort.chipType = chipIdString && chipIdString.length > 1 ? chipIdString[1].trim() : undefined;
           } catch (error) {
             serialPort.chipType = undefined;
           }

--- a/src/espIdf/serial/serialPortDetails.ts
+++ b/src/espIdf/serial/serialPortDetails.ts
@@ -21,16 +21,19 @@ export class SerialPortDetails {
   public manufacturer: string;
   public vendorId: string;
   public productId: string;
+  public chipType: string;
 
   constructor(
     comName: string,
     manufacturer?: string,
     vendorId?: string,
-    product?: string
+    product?: string,
+    chipType?: string
   ) {
     this.comName = comName;
     this.manufacturer = manufacturer;
     this.vendorId = vendorId;
     this.productId = product;
+    this.chipType = chipType;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export function spawn(
       if (timeoutHandler) {
         clearTimeout(timeoutHandler);
       }
-      reject(error)
+      reject(error);
     });
 
     child.on("exit", (code) => {


### PR DESCRIPTION
[## Description

Switcxhed serial port listing to node serialport and providing additional information about connected board chip ( if the board is ESP).


## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output
Click on "Select port to use"
Wait for ~2 seconds
Observe results.

- Expected behaviour:
<img width="392" alt="image" src="https://github.com/espressif/vscode-esp-idf-extension/assets/4068385/5e72c7c4-90f0-4007-90a0-622b21357933">

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
