### PR TITLE
Fix Github tag url to receive 100 tags (VSC-1357)

### DIFF
--- a/src/setup/espIdfVersionList.ts
+++ b/src/setup/espIdfVersionList.ts
@@ -70,7 +70,7 @@ export async function downloadEspIdfVersionList(
 
 export async function getEspIdfTags() {
   try {
-    const urlToUse = "https://api.github.com/repos/espressif/esp-idf/tags";
+    const urlToUse = "https://api.github.com/repos/espressif/esp-idf/tags?per_page=100";
     const idfTagsResponse = await axios.get<{ name: string }[]>(urlToUse);
     const tagsStrList = idfTagsResponse.data.map((idfTag) => idfTag.name);
     return createEspIdfLinkList(tagsStrList);


### PR DESCRIPTION
## Description

Adds more tags to the github request.

Fixes #1193

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
