### PR TITLE
add idf py reconfigure task

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Partition Table Editor                                  |                                        |                                           |
 | Pick a workspace folder                                 |                                        |                                           |
 | Remove Editor coverage                                  |                                        |                                           |
+| Run idf.py reconfigure task                             |                                        |                                           |
+| Run ESP-IDF-SBOM vulnerability check                    |                                        |                                           |
 | Save Default SDKCONFIG file (save-defconfig)            |                                        |                                           |
 | SDK Configuration editor                                | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>G</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>G</kbd> |
 | Search in documentation...                              | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>Q</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>Q</kbd> |
@@ -159,8 +161,6 @@ Click <kbd>F1</kbd> to show Visual studio code actions, then type **ESP-IDF** to
 | Size analysis of the binaries                           | <kbd>⌘</kbd> <kbd>I</kbd> <kbd>S</kbd> | <kbd>Ctrl</kbd> <kbd>E</kbd> <kbd>S</kbd> |
 | Unit Test: Build and flash unit test app for testing    |                                        |                                           |
 | Unit Test: Install ESP-IDF PyTest requirements          |                                        |                                           |
-| Remove Editor coverage                                  |                                        |                                           |
-| Run ESP-IDF-SBOM vulnerability check                    |                                        |                                           |
 
 # About commands
 

--- a/package.json
+++ b/package.json
@@ -1384,6 +1384,10 @@
         "command": "espIdf.selectCurrentIdfVersion",
         "title": "%espIdf.selectCurrentIdfVersion.title%",
         "category": "ESP-IDF"
+      },
+      {
+        "command": "espIdf.idfReconfigureTask",
+        "title": "%espIdf.idfReconfigureTask.title%"
       }
     ],
     "breakpoints": [

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -50,6 +50,7 @@
 	"espIdf.getEspMdf.title": "Instalar ESP-MDF",
 	"espIdf.getEspRainmaker.title": "Instalar ESP-Rainmaker",
 	"espIdf.heaptrace.title": "Rastreo de montón",
+  "espIdf.idfReconfigureTask.title": "ESP-IDF: Ejecute la tarea de reconfiguración de idf.py",
 	"espIdf.importProject.title": "Importar proyecto ESP-IDF",
 	"espIdf.installEspMatterPyReqs.title": "Instalar paquetes Python de ESP-Matter",
 	"espIdf.installPyReqs.title": "Instalar paquetes Python de la extensión ESP-IDF",

--- a/package.nls.json
+++ b/package.nls.json
@@ -50,6 +50,7 @@
   "espIdf.getEspMdf.title": "Install ESP-MDF",
   "espIdf.getEspRainmaker.title": "Install ESP-Rainmaker",
   "espIdf.heaptrace.title": "Heap Trace",
+  "espIdf.idfReconfigureTask.title": "ESP-IDF: Run idf.py reconfigure task",
   "espIdf.importProject.title": "Import ESP-IDF Project",
   "espIdf.installEspMatterPyReqs.title": "Install ESP-Matter Python Packages",
   "espIdf.installPyReqs.title": "Install ESP-IDF Extension Python Packages",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -50,6 +50,7 @@
 	"espIdf.getEspMdf.title": "Instale ESP-MDF",
 	"espIdf.getEspRainmaker.title": "Instale ESP-Rainmaker",
 	"espIdf.heaptrace.title": "Rastreamento de pilha",
+  "espIdf.idfReconfigureTask.title": "ESP-IDF: Execute a tarefa de reconfiguração idf.py",
 	"espIdf.importProject.title": "Importar projeto ESP-IDF",
 	"espIdf.installEspMatterPyReqs.title": "Instale pacotes ESP-Matter Python",
 	"espIdf.installPyReqs.title": "Instale pacotes Python de extensão ESP-IDF",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -50,6 +50,7 @@
 	"espIdf.getEspMdf.title": "Установить ЭСП-МДФ",
 	"espIdf.getEspRainmaker.title": "Установите ESP-Rainmaker",
 	"espIdf.heaptrace.title": "Трассировка кучи",
+  "espIdf.idfReconfigureTask.title": "ESP-IDF: запустить задачу перенастройки idf.py",
 	"espIdf.importProject.title": "Импортировать проект ESP-IDF",
 	"espIdf.installEspMatterPyReqs.title": "Установите пакеты Python ESP-Matter",
 	"espIdf.installPyReqs.title": "Установите пакеты Python расширения ESP-IDF",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -50,6 +50,7 @@
 	"espIdf.getEspMdf.title": "安装 ESP-MDF",
 	"espIdf.getEspRainmaker.title": "安装 ESP-Rainmaker",
 	"espIdf.heaptrace.title": "堆跟踪",
+  "espIdf.idfReconfigureTask.title": "ESP-IDF: 运行IDF.py重新配置任务",
 	"espIdf.importProject.title": "导入 ESP-IDF 项目",
 	"espIdf.installEspMatterPyReqs.title": "安装 ESP-Matter Python 包",
 	"espIdf.installPyReqs.title": "安装 ESP-IDF 扩展 Python 包",

--- a/src/espIdf/reconfigure/task.ts
+++ b/src/espIdf/reconfigure/task.ts
@@ -1,0 +1,129 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Wednesday, 22nd May 2024 4:45:50 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ProcessExecution,
+  ProcessExecutionOptions,
+  TaskPanelKind,
+  TaskPresentationOptions,
+  TaskRevealKind,
+  TaskScope,
+  Uri,
+  workspace,
+} from "vscode";
+import { NotificationMode, readParameter } from "../../idfConfiguration";
+import { appendIdfAndToolsToPath } from "../../utils";
+import { join } from "path";
+import { TaskManager } from "../../taskManager";
+
+export class IdfReconfigureTask {
+  private buildDirPath: string;
+  private curWorkspace: Uri;
+  private idfPathDir: string;
+  private pythonBinPath: string;
+
+  constructor(workspace: Uri) {
+    this.curWorkspace = workspace;
+    this.idfPathDir = readParameter("idf.espIdfPath", workspace) as string;
+    this.pythonBinPath = readParameter(
+      "idf.pythonBinPath",
+      workspace
+    ) as string;
+    this.buildDirPath = readParameter("idf.buildPath", workspace) as string;
+  }
+
+  public async reconfigure() {
+    const modifiedEnv = appendIdfAndToolsToPath(this.curWorkspace);
+    const options: ProcessExecutionOptions = {
+      cwd: this.curWorkspace.fsPath,
+      env: modifiedEnv,
+    };
+    const currentWorkspaceFolder = workspace.workspaceFolders.find(
+      (w) => w.uri === this.curWorkspace
+    );
+
+    const notificationMode = readParameter(
+      "idf.notificationMode",
+      currentWorkspaceFolder
+    ) as string;
+    const showTaskOutput =
+      notificationMode === NotificationMode.All ||
+      notificationMode === NotificationMode.Output
+        ? TaskRevealKind.Always
+        : TaskRevealKind.Silent;
+
+    const idfPy = join(this.idfPathDir, "tools", "idf.py");
+    const reconfigureArgs = [idfPy];
+
+    let buildPathArgsIndex = reconfigureArgs.indexOf("-B");
+    if (buildPathArgsIndex !== -1) {
+      reconfigureArgs.splice(buildPathArgsIndex, 2);
+    }
+    reconfigureArgs.push("-B", this.buildDirPath);
+
+    const sdkconfigDefaults =
+      (readParameter("idf.sdkconfigDefaults") as string[]) || [];
+    if (
+      reconfigureArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&
+      sdkconfigDefaults &&
+      sdkconfigDefaults.length
+    ) {
+      reconfigureArgs.push(
+        `-DSDKCONFIG_DEFAULTS='${sdkconfigDefaults.join(";")}'`
+      );
+    }
+
+    const enableCCache = readParameter(
+      "idf.enableCCache",
+      this.curWorkspace
+    ) as boolean;
+    if (enableCCache && reconfigureArgs && reconfigureArgs.length) {
+      const indexOfCCache = reconfigureArgs.indexOf("-DCCACHE_ENABLE=1");
+      if (indexOfCCache === -1) {
+        reconfigureArgs.push("-DCCACHE_ENABLE=1");
+      }
+    }
+
+    reconfigureArgs.push("reconfigure");
+
+    const reconfigureExecution = new ProcessExecution(
+      this.pythonBinPath,
+      reconfigureArgs,
+      options
+    );
+    const presentationOptions = {
+      reveal: showTaskOutput,
+      showReuseMessage: false,
+      clear: false,
+      panel: TaskPanelKind.Shared,
+    } as TaskPresentationOptions;
+
+    TaskManager.addTask(
+      {
+        type: "esp-idf",
+        command: "ESP-IDF Reconfigure",
+        taskId: "idf-reconfigure-task",
+      },
+      currentWorkspaceFolder || TaskScope.Workspace,
+      "ESP-IDF Reconfigure",
+      reconfigureExecution,
+      ["espIdf"],
+      presentationOptions
+    );
+  }
+}


### PR DESCRIPTION
## Description

Add `ESP-IDF: Run idf.py reconfigure task` command to run `idf.py reconfigure` from extension.

Fixes #1197

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Run idf.py reconfigure task"
2. Execute command and See  make configure step being executed.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing running the command.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): MacOS Windows

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
