### PR TITLE
Fix chip id error in terminal (VSC-1378)

### DIFF
--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -89,7 +89,7 @@ export class SerialPort {
         const listOfSerialPorts = await SerialPortLib.SerialPort.list();
 
         if (!listOfSerialPorts || listOfSerialPorts.length === 0) {
-          reject(new Error('No serial ports found'));
+          reject(new Error("No serial ports found"));
           return;
         }
 
@@ -116,8 +116,11 @@ export class SerialPort {
           "esptool",
           "esptool.py"
         );
-        const stat = await vscode.workspace.fs.stat(vscode.Uri.file(esptoolPath));
-        if (stat.type !== vscode.FileType.File) { // esptool.py does not exists
+        const stat = await vscode.workspace.fs.stat(
+          vscode.Uri.file(esptoolPath)
+        );
+        if (stat.type !== vscode.FileType.File) {
+          // esptool.py does not exists
           throw new Error(`esptool.py does not exists in ${esptoolPath}`);
         }
         async function processPorts(serialPort: SerialPortDetails) {
@@ -126,12 +129,16 @@ export class SerialPort {
               pythonBinPath,
               [esptoolPath, "--port", serialPort.comName, "chip_id"],
               {},
-              2000 // success is quick, failing takes too much time
+              2000, // success is quick, failing takes too much time
+              true
             );
             const regexp = /Chip is(.*?)[\r]?\n/;
             const chipIdString = chipIdBuffer.toString().match(regexp);
 
-            serialPort.chipType = chipIdString && chipIdString.length > 1 ? chipIdString[1].trim() : undefined;
+            serialPort.chipType =
+              chipIdString && chipIdString.length > 1
+                ? chipIdString[1].trim()
+                : undefined;
           } catch (error) {
             serialPort.chipType = undefined;
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,12 +129,13 @@ export function spawn(
   command: string,
   args: string[] = [],
   options: any = {},
-  timeout: number = 0
+  timeout: number = 0,
+  silent: boolean = false // this switches the output to console off the output is only returned, not printed
 ): Promise<Buffer> {
   let buff = Buffer.alloc(0);
   const sendToOutputChannel = (data: Buffer) => {
     buff = Buffer.concat([buff, data]);
-    OutputChannel.appendLine(data.toString());
+    !silent && OutputChannel.appendLine(data.toString());
   };
   return new Promise((resolve, reject) => {
     options.cwd = options.cwd || path.resolve(path.join(__dirname, ".."));


### PR DESCRIPTION
removes the output of esptool.py to the console inside vscode when using it for device identification (VSC-1378)

## Description

removes the ouput of esptool.py to the console inside vscode when using it for device identification (VSC-1378)

Fixes #XXX

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

described in VSC-1378

- Expected behaviour:

- Expected output:

## How has this been tested?

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
