### PR TITLE
Fix compiler args for white spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -551,8 +551,7 @@
           "idf.cmakeCompilerArgs": {
             "type": "array",
             "default": [
-              "-G",
-              "Ninja",
+              "-G=Ninja",
               "-DPYTHON_DEPS_CHECKED=1",
               "-DESP_PLATFORM=1"
             ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esp-idf-extension",
   "displayName": "ESP-IDF",
   "description": "Develop and debug applications for Espressif ESP32, ESP32-S2 chips with ESP-IDF",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "publisher": "espressif",
   "icon": "media/espressif_icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esp-idf-extension",
   "displayName": "ESP-IDF",
   "description": "Develop and debug applications for Espressif ESP32, ESP32-S2 chips with ESP-IDF",
-  "version": "1.7.2",
+  "version": "1.7.1",
   "license": "Apache-2.0",
   "publisher": "espressif",
   "icon": "media/espressif_icon.png",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -125,8 +125,7 @@ export class BuildTask {
         "idf.cmakeCompilerArgs",
         this.currentWorkspace
       ) as Array<string>) || [
-        "-G",
-        "Ninja",
+        "-G=Ninja",
         "-DPYTHON_DEPS_CHECKED=1",
         "-DESP_PLATFORM=1",
       ];
@@ -134,10 +133,10 @@ export class BuildTask {
       if (buildPathArgsIndex !== -1) {
         compilerArgs.splice(buildPathArgsIndex, 2);
       }
-      compilerArgs.push("-B", this.buildDirPath);
+      compilerArgs.push(`-B=${this.buildDirPath}`);
 
       if (compilerArgs.indexOf("-S") === -1) {
-        compilerArgs.push("-S", this.currentWorkspace.fsPath);
+        compilerArgs.push(`-S=${this.currentWorkspace.fsPath}`);
       }
 
       const sdkconfigDefaults =


### PR DESCRIPTION
## Description

This fixes the bug in which if you open with docker container a project with white spaces in it and try to build the project, it will fail.

Please include a summary of the change and which issue is fixed.

JIRA: [VSC-1381](https://jira.espressif.com:8443/browse/VSC-1381)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Create project with whitespaces in name "project-n am e" -> re-open in devcontainer -> try to build -> failed.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
