### PR TITLE
Add validation for existing setup path

### DIFF
--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -342,8 +342,13 @@ export class SetupPanel {
                 exists: fileExists,
               });
             } else {
-              let versionEspIdf = message.currentVersion;
-              if (!versionEspIdf) {
+              let versionEspIdf;
+              if (
+                message.currentVersion &&
+                typeof message.currentVersion === "string"
+              ) {
+                versionEspIdf = message.currentVersion;
+              } else {
                 versionEspIdf = await getEspIdfFromCMake(message.path);
               }
               // compareVersion returns a negative value if versionEspIdf is less than "5.0"

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -46,7 +46,7 @@ import { createPyReqs } from "./pyReqsInstallStep";
 import { downloadIdfTools } from "./toolsDownloadStep";
 import { installIdfGit, installIdfPython } from "./embedGitPy";
 import { getOpenOcdRules } from "./addOpenOcdRules";
-import { checkSpacesInPath, getEspIdfFromCMake } from "../utils";
+import { checkSpacesInPath, getEspIdfFromCMake, canAccessFile } from "../utils";
 import { useIdfSetupSettings } from "./setupValidation/espIdfSetup";
 import { clearPreviousIdfSetups } from "./existingIdfSetups";
 import * as fs from "fs";
@@ -83,14 +83,6 @@ export class SetupPanel {
   private static readonly viewType = "setupPanel";
   private readonly panel: WebviewPanel;
   private disposables: Disposable[] = [];
-
-  private async checkFileExists(filePath: string): Promise<boolean> {
-    return new Promise((resolve) => {
-      fs.access(filePath, fs.constants.F_OK, (err) => {
-        resolve(!err);
-      });
-    });
-  }
 
   constructor(
     private context: ExtensionContext,
@@ -334,11 +326,11 @@ export class SetupPanel {
         case "exploreComponents":
           await commands.executeCommand("esp.component-manager.ui.show");
           break;
-        case "checkFileExists":
+        case "canAccessFile":
           if (message.path) {
-            const fileExists = await this.checkFileExists(message.path);
+            const fileExists = await canAccessFile(message.path);
             this.panel.webview.postMessage({
-              command: "checkFileExistsResponse",
+              command: "canAccessFileResponse",
               path: message.path,
               exists: fileExists,
             });

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -332,8 +332,9 @@ export class SetupPanel {
           await commands.executeCommand("esp.component-manager.ui.show");
           break;
         case "canAccessFile":
-          if (message.pathIdfPy) {
-            const fileExists = await canAccessFile(message.pathIdfPy);
+          if (message.path) {
+            const pathIdfPy = path.join(message.path, 'tools', 'idf.py');
+            const fileExists = await canAccessFile(pathIdfPy);
             if (!fileExists) {
               this.panel.webview.postMessage({
                 command: "canAccessFileResponse",

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -333,7 +333,7 @@ export class SetupPanel {
           break;
         case "canAccessFile":
           if (message.path) {
-            const pathIdfPy = path.join(message.path, 'tools', 'idf.py');
+            const pathIdfPy = path.join(message.path, "tools", "idf.py");
             const fileExists = await canAccessFile(pathIdfPy);
             if (!fileExists) {
               this.panel.webview.postMessage({

--- a/src/views/setup/Home.vue
+++ b/src/views/setup/Home.vue
@@ -46,20 +46,22 @@ function goTo(route: string, setupMode: SetupMode) {
     <div class="centerize notification" v-if="hasPrerequisites">
       <div class="control centerize home-title">
         <h1 class="title is-spaced">Welcome.</h1>
-        <p v-if="platform !== 'win32'">
-          Make sure that
-          <a
-            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html"
-            v-if="platform === 'darwin'"
-            >ESP-IDF Prerequisites for MacOS</a
-          >
-          <a
-            href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html"
-            v-if="platform === 'linux'"
-            >ESP-IDF Prerequisites for Linux</a
-          >
-        </p>
-        <p>are installed before choosing the setup mode.</p>
+        <div v-if="platform !== 'win32'" class="prerequisites-info">
+          <p>Make sure that</p>
+          <p>
+            <a
+              href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/macos-setup.html"
+              v-if="platform === 'darwin'"
+              >ESP-IDF Prerequisites for MacOS</a
+            >
+            <a
+              href="https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html"
+              v-if="platform === 'linux'"
+              >ESP-IDF Prerequisites for Linux</a
+            >
+          </p>
+          <p>are installed before choosing the setup mode.</p>
+        </div>
         <h2 class="subtitle">Choose a setup mode.</h2>
         <selectSaveScope />
       </div>
@@ -171,6 +173,19 @@ function goTo(route: string, setupMode: SetupMode) {
 
 div.notification.is-danger {
   background-color: var(--vscode-editorGutter-deletedBackground);
+}
+
+.prerequisites-info {
+  text-align: center;
+  margin: 1em 0;
+
+  p {
+    margin: 0.5em 0;
+  }
+
+  a {
+    font-weight: bold;
+  }
 }
 </style>
 ./types

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -1,3 +1,61 @@
+<template>
+  <div id="install">
+    <div class="notification is-danger error-message" v-if="espIdfErrorStatus">
+      <p>{{ espIdfErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
+    <div class="notification is-danger error-message" v-if="pyExecErrorStatus">
+      <p>{{ pyExecErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
+    <div class="notification">
+      <div class="field" v-if="isNotWinPlatform && gitVersion">
+        <label data-config-id="git-version"
+          >Git version: {{ gitVersion }}</label
+        >
+      </div>
+
+      <selectEspIdf />
+
+      <folderOpen
+        propLabel="Enter ESP-IDF Tools directory (IDF_TOOLS_PATH):"
+        :propModel="toolsFolder"
+        :propMutate="setToolsFolder"
+        :openMethod="store.openEspIdfToolsFolder"
+      />
+
+      <div v-if="hasToolsWhitespace" class="notification is-danger">
+        White spaces are not allowed in the ESP-IDF Tools path.
+      </div>
+
+      <div v-if="!toolsFolder" class="notification is-danger">
+        ESP-IDF Tools path should not be empty.
+      </div>
+
+      <selectPyVersion v-if="isNotWinPlatform" />
+
+      <div class="field install-btn">
+        <div class="control">
+          <button
+            @click="store.installEspIdf"
+            class="button"
+            data-config-id="start-install-btn"
+            :disabled="isInstallDisabled || store.isInstallButtonDisabled"
+          >
+            {{ actionButtonText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "./store";
@@ -20,6 +78,7 @@ const {
   selectedEspIdfVersion,
   espIdf,
   espIdfContainer,
+  isInstallButtonDisabled,
 } = storeToRefs(store);
 
 const isNotWinPlatform = computed(() => {
@@ -100,64 +159,6 @@ function setToolsFolder(newToolsPath: string) {
   store.toolsFolder = newToolsPath;
 }
 </script>
-
-<template>
-  <div id="install">
-    <div class="notification is-danger error-message" v-if="espIdfErrorStatus">
-      <p>{{ espIdfErrorStatus }}</p>
-      <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
-        <IconClose />
-      </div>
-    </div>
-
-    <div class="notification is-danger error-message" v-if="pyExecErrorStatus">
-      <p>{{ pyExecErrorStatus }}</p>
-      <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
-        <IconClose />
-      </div>
-    </div>
-
-    <div class="notification">
-      <div class="field" v-if="isNotWinPlatform && gitVersion">
-        <label data-config-id="git-version"
-          >Git version: {{ gitVersion }}</label
-        >
-      </div>
-
-      <selectEspIdf />
-
-      <folderOpen
-        propLabel="Enter ESP-IDF Tools directory (IDF_TOOLS_PATH):"
-        :propModel="toolsFolder"
-        :propMutate="setToolsFolder"
-        :openMethod="store.openEspIdfToolsFolder"
-      />
-
-      <div v-if="hasToolsWhitespace" class="notification is-danger">
-        White spaces are not allowed in the ESP-IDF Tools path.
-      </div>
-
-      <div v-if="!toolsFolder" class="notification is-danger">
-        ESP-IDF Tools path should not be empty.
-      </div>
-
-      <selectPyVersion v-if="isNotWinPlatform" />
-
-      <div class="field install-btn">
-        <div class="control">
-          <button
-            @click="store.installEspIdf"
-            class="button"
-            data-config-id="start-install-btn"
-            :disabled="isInstallDisabled"
-          >
-            {{ actionButtonText }}
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</template>
 
 <style scoped>
 #install {

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -2,13 +2,25 @@
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "./store";
 import { SetupMode } from "./types";
-import { computed, watchEffect } from "vue";
+import { computed, watchEffect, onMounted, onUnmounted } from "vue";
 import folderOpen from "./components/folderOpen.vue";
 import selectEspIdf from "./components/selectEspIdf.vue";
 import selectPyVersion from "./components/selectPyVersion.vue";
 import { IconClose } from "@iconify-prerendered/vue-codicon";
 
 const store = useSetupStore();
+
+onMounted(() => {
+  if (store.espIdf) {
+    store.validateEspIdfPath(store.espIdf);
+  } else if (store.espIdfContainer) {
+    store.validateEspIdfPath(store.espIdfContainer);
+  }
+});
+
+onUnmounted(() => {
+  store.clearIdfPathError();
+});
 
 const {
   espIdfErrorStatus,

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -1,61 +1,3 @@
-<template>
-  <div id="install">
-    <div class="notification is-danger error-message" v-if="espIdfErrorStatus">
-      <p>{{ espIdfErrorStatus }}</p>
-      <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
-        <IconClose />
-      </div>
-    </div>
-
-    <div class="notification is-danger error-message" v-if="pyExecErrorStatus">
-      <p>{{ pyExecErrorStatus }}</p>
-      <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
-        <IconClose />
-      </div>
-    </div>
-
-    <div class="notification">
-      <div class="field" v-if="isNotWinPlatform && gitVersion">
-        <label data-config-id="git-version"
-          >Git version: {{ gitVersion }}</label
-        >
-      </div>
-
-      <selectEspIdf />
-
-      <folderOpen
-        propLabel="Enter ESP-IDF Tools directory (IDF_TOOLS_PATH):"
-        :propModel="toolsFolder"
-        :propMutate="setToolsFolder"
-        :openMethod="store.openEspIdfToolsFolder"
-      />
-
-      <div v-if="hasToolsWhitespace" class="notification is-danger">
-        White spaces are not allowed in the ESP-IDF Tools path.
-      </div>
-
-      <div v-if="!toolsFolder" class="notification is-danger">
-        ESP-IDF Tools path should not be empty.
-      </div>
-
-      <selectPyVersion v-if="isNotWinPlatform" />
-
-      <div class="field install-btn">
-        <div class="control">
-          <button
-            @click="store.installEspIdf"
-            class="button"
-            data-config-id="start-install-btn"
-            :disabled="isInstallDisabled || store.isInstallButtonDisabled"
-          >
-            {{ actionButtonText }}
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</template>
-
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "./store";
@@ -159,6 +101,64 @@ function setToolsFolder(newToolsPath: string) {
   store.toolsFolder = newToolsPath;
 }
 </script>
+
+<template>
+  <div id="install">
+    <div class="notification is-danger error-message" v-if="espIdfErrorStatus">
+      <p>{{ espIdfErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setEspIdfErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
+    <div class="notification is-danger error-message" v-if="pyExecErrorStatus">
+      <p>{{ pyExecErrorStatus }}</p>
+      <div class="icon is-large is-size-4" @click="setPyExecErrorStatus">
+        <IconClose />
+      </div>
+    </div>
+
+    <div class="notification">
+      <div class="field" v-if="isNotWinPlatform && gitVersion">
+        <label data-config-id="git-version"
+          >Git version: {{ gitVersion }}</label
+        >
+      </div>
+
+      <selectEspIdf />
+
+      <folderOpen
+        propLabel="Enter ESP-IDF Tools directory (IDF_TOOLS_PATH):"
+        :propModel="toolsFolder"
+        :propMutate="setToolsFolder"
+        :openMethod="store.openEspIdfToolsFolder"
+      />
+
+      <div v-if="hasToolsWhitespace" class="notification is-danger">
+        White spaces are not allowed in the ESP-IDF Tools path.
+      </div>
+
+      <div v-if="!toolsFolder" class="notification is-danger">
+        ESP-IDF Tools path should not be empty.
+      </div>
+
+      <selectPyVersion v-if="isNotWinPlatform" />
+
+      <div class="field install-btn">
+        <div class="control">
+          <button
+            @click="store.installEspIdf"
+            class="button"
+            data-config-id="start-install-btn"
+            :disabled="isInstallDisabled || store.isInstallButtonDisabled"
+          >
+            {{ actionButtonText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
 
 <style scoped>
 #install {

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -19,7 +19,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  store.clearIdfPathError();
+  store.setIdfPathError("");
 });
 
 const {

--- a/src/views/setup/components/folderOpen.vue
+++ b/src/views/setup/components/folderOpen.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
 import { IconFolder, IconFolderOpened } from "@iconify-prerendered/vue-codicon";
 import { computed } from "vue";
+import { defineProps, defineEmits } from "vue";
 import { useSetupStore } from "../store";
+
 let folderIcon = "folder";
-const store = useSetupStore();
 const props = defineProps<{
   keyEnterMethod?: () => void;
   onChangeMethod?: () => void;
-  openMethod: () => void;
+  openMethod: () => Promise<string | undefined>;
   propLabel: string;
   propModel: string;
   propMutate: (val: string) => void;
   staticText?: string;
 }>();
+
+const store = useSetupStore();
+const emit = defineEmits(["blur"]);
 
 const dataModel = computed({
   get() {
@@ -31,6 +35,17 @@ function onKeyEnter() {
     props.keyEnterMethod();
   }
 }
+
+async function selectFolder() {
+  const folder = await props.openMethod();
+  if (folder !== undefined) {
+    props.propMutate(folder);
+    emit("blur", folder);
+    if (props.onChangeMethod) {
+      props.onChangeMethod();
+    }
+  }
+}
 </script>
 
 <template>
@@ -42,6 +57,7 @@ function onKeyEnter() {
           type="text"
           class="input"
           v-model="dataModel"
+          @blur="$emit('blur', dataModel)"
           @keyup.enter="onKeyEnter"
         />
       </div>
@@ -54,10 +70,10 @@ function onKeyEnter() {
           style="text-decoration: none;"
           @mouseover="folderIcon = 'folder-opened'"
           @mouseout="folderIcon = 'folder'"
-          v-on:click="openMethod"
+          @click="selectFolder"
         >
-          <IconFolderOpened v-if="(folderIcon === 'folder-opened')" />
-          <IconFolder v-if="(folderIcon === 'folder')" />
+          <IconFolderOpened v-if="folderIcon === 'folder-opened'" />
+          <IconFolder v-if="folderIcon === 'folder'" />
         </div>
       </div>
     </div>

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -1,3 +1,93 @@
+<template>
+  <div id="select-esp-idf-version">
+    <div class="field">
+      <label for="idf-mirror-select" class="label"
+        >Select download server:</label
+      >
+      <div class="control">
+        <div class="select">
+          <select v-model="selectedIdfMirror" @change="clearIDfErrorStatus">
+            <option :value="idfMirror.Espressif">Espressif</option>
+            <option :value="idfMirror.Github">Github</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="field">
+      <label class="checkbox is-small">
+        <input type="checkbox" v-model="showIdfTagList" />
+        Show all ESP-IDF tags
+      </label>
+    </div>
+    <div class="field">
+      <label for="idf-version-select" class="label"
+        >Select ESP-IDF version:</label
+      >
+      <div class="control">
+        <div class="select">
+          <select
+            v-model="selectedEspIdfVersion"
+            @change="clearIDfErrorStatus"
+            id="select-esp-idf"
+          >
+            <option
+              v-for="ver in idfVersionList"
+              :key="ver.name"
+              :value="ver"
+              >{{ ver.name }}</option
+            >
+          </select>
+        </div>
+      </div>
+    </div>
+    <folderOpen
+      propLabel="Enter ESP-IDF directory (IDF_PATH):"
+      :propModel.sync="espIdf"
+      :propMutate="setEspIdfPath"
+      :openMethod="store.openEspIdfFolder"
+      :onChangeMethod="clearIDfErrorStatus"
+      @blur="validatePathOnBlur"
+      v-if="
+        selectedEspIdfVersion && selectedEspIdfVersion.filename === 'manual'
+      "
+      data-config-id="manual-idf-directory"
+    />
+    <folderOpen
+      propLabel="Enter ESP-IDF container directory:"
+      :propModel.sync="espIdfContainer"
+      :propMutate="setEspIdfContainerPath"
+      :openMethod="store.openEspIdfContainerFolder"
+      :onChangeMethod="clearIDfErrorStatus"
+      :staticText="resultingIdfPath"
+      @blur="validatePathOnBlur"
+      v-if="
+        selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
+      "
+    />
+    <div v-if="showManualVersionWarning" class="notification is-warning">
+      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
+      are not supported for earlier versions.
+    </div>
+    <div
+      v-if="
+        selectedEspIdfVersion &&
+        selectedEspIdfVersion.filename !== 'manual' &&
+        isVersionLessThanFive &&
+        hasWhitespaceInEspIdfContainer
+      "
+      class="notification is-danger"
+    >
+      White spaces are only supported for ESP-IDF path for versions > 5.0.
+    </div>
+    <div v-if="isPathEmpty" class="notification is-danger">
+      ESP-IDF path should not be empty.
+    </div>
+    <div v-if="idfPathError" class="notification is-danger">
+      {{ idfPathError }}
+    </div>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "../store";
@@ -19,6 +109,9 @@ const {
   selectedEspIdfVersion,
   selectedIdfMirror,
   showIdfTagList,
+  whiteSpaceErrorIDFContainer,
+  idfPathError,
+  isInstallButtonDisabled,
 } = storeToRefs(store);
 
 const idfVersionList = computed(() => {
@@ -39,6 +132,7 @@ const idfVersionList = computed(() => {
 
 function clearIDfErrorStatus() {
   store.espIdfErrorStatus = "";
+  store.whiteSpaceErrorIDFContainer = "";
 }
 
 function setEspIdfPath(idfPath: string) {
@@ -47,6 +141,10 @@ function setEspIdfPath(idfPath: string) {
 
 function setEspIdfContainerPath(idfContainerPath: string) {
   store.espIdfContainer = idfContainerPath;
+}
+
+function validatePathOnBlur(path: string) {
+  store.validateEspIdfPath(path);
 }
 
 const resultingIdfPath = computed(() => {
@@ -109,91 +207,6 @@ watchEffect(() => {
   }
 });
 </script>
-
-<template>
-  <div id="select-esp-idf-version">
-    <div class="field">
-      <label for="idf-mirror-select" class="label"
-        >Select download server:</label
-      >
-      <div class="control">
-        <div class="select">
-          <select v-model="selectedIdfMirror" @change="clearIDfErrorStatus">
-            <option :value="idfMirror.Espressif">Espressif (Better speed for China)</option>
-            <option :value="idfMirror.Github">Github</option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="field">
-      <label class="checkbox is-small">
-        <input type="checkbox" v-model="showIdfTagList" />
-        Show all ESP-IDF tags
-      </label>
-    </div>
-    <div class="field">
-      <label for="idf-version-select" class="label"
-        >Select ESP-IDF version:</label
-      >
-      <div class="control">
-        <div class="select">
-          <select
-            v-model="selectedEspIdfVersion"
-            @change="clearIDfErrorStatus"
-            id="select-esp-idf"
-          >
-            <option
-              v-for="ver in idfVersionList"
-              :key="ver.name"
-              :value="ver"
-              >{{ ver.name }}</option
-            >
-          </select>
-        </div>
-      </div>
-    </div>
-    <folderOpen
-      propLabel="Enter ESP-IDF directory (IDF_PATH):"
-      :propModel.sync="espIdf"
-      :propMutate="setEspIdfPath"
-      :openMethod="store.openEspIdfFolder"
-      :onChangeMethod="clearIDfErrorStatus"
-      v-if="
-        selectedEspIdfVersion && selectedEspIdfVersion.filename === 'manual'
-      "
-      data-config-id="manual-idf-directory"
-    />
-    <folderOpen
-      propLabel="Enter ESP-IDF container directory:"
-      :propModel.sync="espIdfContainer"
-      :propMutate="setEspIdfContainerPath"
-      :openMethod="store.openEspIdfContainerFolder"
-      :onChangeMethod="clearIDfErrorStatus"
-      :staticText="resultingIdfPath"
-      v-if="
-        selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
-      "
-    />
-    <div v-if="showManualVersionWarning" class="notification is-warning">
-      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
-      are not supported for earlier versions.
-    </div>
-    <div
-      v-if="
-        selectedEspIdfVersion &&
-        selectedEspIdfVersion.filename !== 'manual' &&
-        isVersionLessThanFive &&
-        hasWhitespaceInEspIdfContainer
-      "
-      class="notification is-danger"
-    >
-      White spaces are only supported for ESP-IDF path for versions > 5.0.
-    </div>
-    <div v-if="isPathEmpty" class="notification is-danger">
-      ESP-IDF path should not be empty.
-    </div>
-  </div>
-</template>
 
 <style scoped>
 #select-esp-idf-version {

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -3,7 +3,7 @@ import { storeToRefs } from "pinia";
 import { useSetupStore } from "../store";
 import { IdfMirror } from "../types";
 import folderOpen from "./folderOpen.vue";
-import { computed, watchEffect } from "vue";
+import { computed, watchEffect, watch } from "vue";
 
 const store = useSetupStore();
 
@@ -104,13 +104,6 @@ const isPathEmpty = computed(() => {
   }
 });
 
-const showManualVersionWarning = computed(() => {
-  return (
-    selectedEspIdfVersion.value.filename === "manual" &&
-    hasWhitespaceInEspIdf.value
-  );
-});
-
 watchEffect(() => {
   if (!hasWhitespaceInEspIdf.value) {
     store.whiteSpaceErrorIDF = "";
@@ -118,6 +111,11 @@ watchEffect(() => {
   if (!hasWhitespaceInEspIdfContainer.value) {
     store.whiteSpaceErrorIDFContainer = "";
   }
+});
+
+watch(selectedEspIdfVersion, (newVal) => {
+  clearIDfErrorStatus();
+  validatePathOnBlur(newVal.filename === "manual" ? espIdf.value : espIdfContainer.value);
 });
 </script>
 
@@ -187,10 +185,6 @@ watchEffect(() => {
         selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
       "
     />
-    <div v-if="showManualVersionWarning" class="notification is-warning">
-      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
-      are not supported for earlier versions.
-    </div>
     <div
       v-if="
         selectedEspIdfVersion &&
@@ -200,7 +194,7 @@ watchEffect(() => {
       "
       class="notification is-danger"
     >
-      White spaces are only supported for ESP-IDF path for versions > 5.0.
+      White spaces are only supported for ESP-IDF path for versions >= 5.0.
     </div>
     <div v-if="isPathEmpty" class="notification is-danger">
       ESP-IDF path should not be empty.

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -115,8 +115,30 @@ watchEffect(() => {
 
 watch(selectedEspIdfVersion, (newVal) => {
   clearIDfErrorStatus();
-  validatePathOnBlur(newVal.filename === "manual" ? espIdf.value : espIdfContainer.value);
+  if (newVal.filename === "manual") {
+    validatePathOnBlur(espIdf.value);
+  } else {
+    validatePathOnBlur(espIdfContainer.value);
+  }
 });
+
+watch(
+  () => store.espIdf,
+  (newValue) => {
+    if (newValue && selectedEspIdfVersion.value.filename === "manual") {
+      store.validateEspIdfPath(newValue);
+    }
+  }
+);
+
+watch(
+  () => store.espIdfContainer,
+  (newValue) => {
+    if (newValue && selectedEspIdfVersion.value.filename !== "manual") {
+      store.validateEspIdfPath(newValue);
+    }
+  }
+);
 </script>
 
 <template>
@@ -128,7 +150,9 @@ watch(selectedEspIdfVersion, (newVal) => {
       <div class="control">
         <div class="select">
           <select v-model="selectedIdfMirror" @change="clearIDfErrorStatus">
-            <option :value="idfMirror.Espressif">Espressif</option>
+            <option :value="idfMirror.Espressif"
+              >Espressif (Better speed for China)</option
+            >
             <option :value="idfMirror.Github">Github</option>
           </select>
         </div>

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -43,6 +43,7 @@ const idfVersionList = computed(() => {
 function clearIDfErrorStatus() {
   store.espIdfErrorStatus = "";
   store.whiteSpaceErrorIDFContainer = "";
+  store.idfPathError = "";
 }
 
 function setEspIdfPath(idfPath: string) {
@@ -54,7 +55,9 @@ function setEspIdfContainerPath(idfContainerPath: string) {
 }
 
 function validatePathOnBlur(path: string) {
-  store.validateEspIdfPath(path);
+  if (selectedEspIdfVersion.value.filename === "manual") {
+    store.validateEspIdfPath(path);
+  }
 }
 
 const resultingIdfPath = computed(() => {

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -1,93 +1,3 @@
-<template>
-  <div id="select-esp-idf-version">
-    <div class="field">
-      <label for="idf-mirror-select" class="label"
-        >Select download server:</label
-      >
-      <div class="control">
-        <div class="select">
-          <select v-model="selectedIdfMirror" @change="clearIDfErrorStatus">
-            <option :value="idfMirror.Espressif">Espressif</option>
-            <option :value="idfMirror.Github">Github</option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="field">
-      <label class="checkbox is-small">
-        <input type="checkbox" v-model="showIdfTagList" />
-        Show all ESP-IDF tags
-      </label>
-    </div>
-    <div class="field">
-      <label for="idf-version-select" class="label"
-        >Select ESP-IDF version:</label
-      >
-      <div class="control">
-        <div class="select">
-          <select
-            v-model="selectedEspIdfVersion"
-            @change="clearIDfErrorStatus"
-            id="select-esp-idf"
-          >
-            <option
-              v-for="ver in idfVersionList"
-              :key="ver.name"
-              :value="ver"
-              >{{ ver.name }}</option
-            >
-          </select>
-        </div>
-      </div>
-    </div>
-    <folderOpen
-      propLabel="Enter ESP-IDF directory (IDF_PATH):"
-      :propModel.sync="espIdf"
-      :propMutate="setEspIdfPath"
-      :openMethod="store.openEspIdfFolder"
-      :onChangeMethod="clearIDfErrorStatus"
-      @blur="validatePathOnBlur"
-      v-if="
-        selectedEspIdfVersion && selectedEspIdfVersion.filename === 'manual'
-      "
-      data-config-id="manual-idf-directory"
-    />
-    <folderOpen
-      propLabel="Enter ESP-IDF container directory:"
-      :propModel.sync="espIdfContainer"
-      :propMutate="setEspIdfContainerPath"
-      :openMethod="store.openEspIdfContainerFolder"
-      :onChangeMethod="clearIDfErrorStatus"
-      :staticText="resultingIdfPath"
-      @blur="validatePathOnBlur"
-      v-if="
-        selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
-      "
-    />
-    <div v-if="showManualVersionWarning" class="notification is-warning">
-      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
-      are not supported for earlier versions.
-    </div>
-    <div
-      v-if="
-        selectedEspIdfVersion &&
-        selectedEspIdfVersion.filename !== 'manual' &&
-        isVersionLessThanFive &&
-        hasWhitespaceInEspIdfContainer
-      "
-      class="notification is-danger"
-    >
-      White spaces are only supported for ESP-IDF path for versions > 5.0.
-    </div>
-    <div v-if="isPathEmpty" class="notification is-danger">
-      ESP-IDF path should not be empty.
-    </div>
-    <div v-if="idfPathError" class="notification is-danger">
-      {{ idfPathError }}
-    </div>
-  </div>
-</template>
-
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
 import { useSetupStore } from "../store";
@@ -207,6 +117,96 @@ watchEffect(() => {
   }
 });
 </script>
+
+<template>
+  <div id="select-esp-idf-version">
+    <div class="field">
+      <label for="idf-mirror-select" class="label"
+        >Select download server:</label
+      >
+      <div class="control">
+        <div class="select">
+          <select v-model="selectedIdfMirror" @change="clearIDfErrorStatus">
+            <option :value="idfMirror.Espressif">Espressif</option>
+            <option :value="idfMirror.Github">Github</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="field">
+      <label class="checkbox is-small">
+        <input type="checkbox" v-model="showIdfTagList" />
+        Show all ESP-IDF tags
+      </label>
+    </div>
+    <div class="field">
+      <label for="idf-version-select" class="label"
+        >Select ESP-IDF version:</label
+      >
+      <div class="control">
+        <div class="select">
+          <select
+            v-model="selectedEspIdfVersion"
+            @change="clearIDfErrorStatus"
+            id="select-esp-idf"
+          >
+            <option
+              v-for="ver in idfVersionList"
+              :key="ver.name"
+              :value="ver"
+              >{{ ver.name }}</option
+            >
+          </select>
+        </div>
+      </div>
+    </div>
+    <folderOpen
+      propLabel="Enter ESP-IDF directory (IDF_PATH):"
+      :propModel.sync="espIdf"
+      :propMutate="setEspIdfPath"
+      :openMethod="store.openEspIdfFolder"
+      :onChangeMethod="clearIDfErrorStatus"
+      @blur="validatePathOnBlur"
+      v-if="
+        selectedEspIdfVersion && selectedEspIdfVersion.filename === 'manual'
+      "
+      data-config-id="manual-idf-directory"
+    />
+    <folderOpen
+      propLabel="Enter ESP-IDF container directory:"
+      :propModel.sync="espIdfContainer"
+      :propMutate="setEspIdfContainerPath"
+      :openMethod="store.openEspIdfContainerFolder"
+      :onChangeMethod="clearIDfErrorStatus"
+      :staticText="resultingIdfPath"
+      @blur="validatePathOnBlur"
+      v-if="
+        selectedEspIdfVersion && selectedEspIdfVersion.filename !== 'manual'
+      "
+    />
+    <div v-if="showManualVersionWarning" class="notification is-warning">
+      Make sure the ESP-IDF version is not lower than 5.0, since white spaces
+      are not supported for earlier versions.
+    </div>
+    <div
+      v-if="
+        selectedEspIdfVersion &&
+        selectedEspIdfVersion.filename !== 'manual' &&
+        isVersionLessThanFive &&
+        hasWhitespaceInEspIdfContainer
+      "
+      class="notification is-danger"
+    >
+      White spaces are only supported for ESP-IDF path for versions > 5.0.
+    </div>
+    <div v-if="isPathEmpty" class="notification is-danger">
+      ESP-IDF path should not be empty.
+    </div>
+    <div v-if="idfPathError" class="notification is-danger">
+      {{ idfPathError }}
+    </div>
+  </div>
+</template>
 
 <style scoped>
 #select-esp-idf-version {

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -122,15 +122,6 @@ watch(selectedEspIdfVersion, (newVal) => {
     validatePathOnBlur(espIdfContainer.value);
   }
 });
-
-watch(
-  () => store.espIdf,
-  (newValue) => {
-    if (newValue && selectedEspIdfVersion.value.filename === "manual") {
-      store.validateEspIdfPath(newValue);
-    }
-  }
-);
 </script>
 
 <template>

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -115,6 +115,7 @@ watchEffect(() => {
 
 watch(selectedEspIdfVersion, (newVal) => {
   clearIDfErrorStatus();
+  store.clearIdfPathError();
   if (newVal.filename === "manual") {
     validatePathOnBlur(espIdf.value);
   } else {

--- a/src/views/setup/components/selectEspIdf.vue
+++ b/src/views/setup/components/selectEspIdf.vue
@@ -130,15 +130,6 @@ watch(
     }
   }
 );
-
-watch(
-  () => store.espIdfContainer,
-  (newValue) => {
-    if (newValue && selectedEspIdfVersion.value.filename !== "manual") {
-      store.validateEspIdfPath(newValue);
-    }
-  }
-);
 </script>
 
 <template>

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -272,7 +272,9 @@ window.addEventListener("message", (event) => {
         store.idfPathError =
           "The path for ESP-IDF is not valid: /tools/idf.py not found.";
       } else {
-        store.idfPathError = "";
+        if(msg.noWhiteSpaceSupport)
+        store.idfPathError = 
+          "White spaces are only supported for ESP-IDF path for versions >= 5.0.";
       }
       break;
     default:

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -48,7 +48,7 @@ app.mount("#app");
 
 router.beforeEach((to, from, next) => {
   if (from.path === "/autoinstall" && to.path !== "/autoinstall") {
-    store.clearIdfPathError();
+    store.setIdfPathError("");
   }
   next();
 });
@@ -284,7 +284,7 @@ window.addEventListener("message", (event) => {
           "White spaces are only supported for ESP-IDF path for versions >= 5.0."
         );
       } else {
-        store.clearIdfPathError();
+        store.setIdfPathError("");
       }
       break;
     default:

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -267,6 +267,16 @@ window.addEventListener("message", (event) => {
         store.setStatusIdfPython(msg.status);
       }
       break;
+    case "checkFileExistsResponse":
+      if (typeof msg.exists !== "undefined") {
+        if (!msg.exists) {
+          store.idfPathError =
+            "The path for ESP-IDF is not valid: /tools/idf.py not found.";
+        } else {
+          store.idfPathError = "";
+        }
+      }
+      break;
     default:
       break;
   }

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -46,6 +46,13 @@ app.use(pinia);
 app.use(router);
 app.mount("#app");
 
+router.beforeEach((to, from, next) => {
+  if (from.path === "/autoinstall" && to.path !== "/autoinstall") {
+    store.clearIdfPathError();
+  }
+  next();
+});
+
 const store = useSetupStore();
 
 window.addEventListener("message", (event) => {
@@ -269,12 +276,15 @@ window.addEventListener("message", (event) => {
       break;
     case "canAccessFileResponse":
       if (!msg.exists) {
-        store.idfPathError =
-          "The path for ESP-IDF is not valid: /tools/idf.py not found.";
+        store.setIdfPathError(
+          "The path for ESP-IDF is not valid: /tools/idf.py not found."
+        );
+      } else if (msg.noWhiteSpaceSupport && msg.hasWhitespace) {
+        store.setIdfPathError(
+          "White spaces are only supported for ESP-IDF path for versions >= 5.0."
+        );
       } else {
-        if(msg.noWhiteSpaceSupport)
-        store.idfPathError = 
-          "White spaces are only supported for ESP-IDF path for versions >= 5.0.";
+        store.clearIdfPathError();
       }
       break;
     default:

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -267,14 +267,12 @@ window.addEventListener("message", (event) => {
         store.setStatusIdfPython(msg.status);
       }
       break;
-    case "checkFileExistsResponse":
-      if (typeof msg.exists !== "undefined") {
-        if (!msg.exists) {
-          store.idfPathError =
-            "The path for ESP-IDF is not valid: /tools/idf.py not found.";
-        } else {
-          store.idfPathError = "";
-        }
+    case "canAccessFileResponse":
+      if (!msg.exists) {
+        store.idfPathError =
+          "The path for ESP-IDF is not valid: /tools/idf.py not found.";
+      } else {
+        store.idfPathError = "";
       }
       break;
     default:

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -116,7 +116,6 @@ export const useSetupStore = defineStore("setup", () => {
     vscode.postMessage({
       command: "canAccessFile",
       path,
-      pathIdfPy: `${path}/tools/idf.py`,
       currentVersion: espIdfVersion.value,
     });
   }

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -38,6 +38,7 @@ try {
 }
 
 export const useSetupStore = defineStore("setup", () => {
+  let espIdfVersion: Ref<string> = ref("");
   let areToolsValid: Ref<boolean> = ref(false);
   let espIdf: Ref<string> = ref("");
   let espIdfContainer: Ref<string> = ref("");
@@ -100,16 +101,23 @@ export const useSetupStore = defineStore("setup", () => {
   let idfPathError: Ref<string> = ref("");
   let isInstallButtonDisabled: Ref<boolean> = ref(false);
 
+  function clearIdfPathError() {
+    idfPathError.value = "";
+    isInstallButtonDisabled.value = false;
+  }
+
   function setIdfPathError(error: string) {
     idfPathError.value = error;
     isInstallButtonDisabled.value = !!error;
   }
 
   function validateEspIdfPath(path: string) {
+    clearIdfPathError();
     vscode.postMessage({
       command: "canAccessFile",
       path,
-      pathIdfPy: `${path}/tools/idf.py`
+      pathIdfPy: `${path}/tools/idf.py`,
+      currentVersion: espIdfVersion.value,
     });
   }
 
@@ -315,7 +323,12 @@ export const useSetupStore = defineStore("setup", () => {
 
   function setSelectedEspIdfVersion(selectedEspIdfVer: IEspIdfLink) {
     selectedEspIdfVersion.value = selectedEspIdfVer;
+    espIdfVersion.value = selectedEspIdfVer.version;
     idfDownloadStatus.value.id = selectedEspIdfVer.name;
+    // Trigger validation whenever the version changes
+    if (espIdf.value) {
+      validateEspIdfPath(espIdf.value);
+    }
   }
 
   function setToolChecksum(toolData: { name: string; checksum: boolean }) {
@@ -500,5 +513,7 @@ export const useSetupStore = defineStore("setup", () => {
     isInstallButtonDisabled,
     setIdfPathError,
     validateEspIdfPath,
+    clearIdfPathError,
+    espIdfVersion,
   };
 });

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -107,7 +107,7 @@ export const useSetupStore = defineStore("setup", () => {
 
   function validateEspIdfPath(path: string) {
     vscode.postMessage({
-      command: "checkFileExists",
+      command: "canAccessFile",
       path: `${path}/tools/idf.py`,
     });
   }
@@ -156,7 +156,7 @@ export const useSetupStore = defineStore("setup", () => {
 
   window.addEventListener("message", (event) => {
     const message = event.data;
-    if (message.command === "checkFileExistsResponse") {
+    if (message.command === "canAccessFileResponse") {
       if (!message.exists) {
         setIdfPathError(
           "The path for ESP-IDF is not valid: /tools/idf.py not found."

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -108,7 +108,8 @@ export const useSetupStore = defineStore("setup", () => {
   function validateEspIdfPath(path: string) {
     vscode.postMessage({
       command: "canAccessFile",
-      path: `${path}/tools/idf.py`,
+      path,
+      pathIdfPy: `${path}/tools/idf.py`
     });
   }
 


### PR DESCRIPTION
## Description

Added validation for esp-idf path, when user selects "Find ESP-IDF in your system" while configuring the extension.

Jira: [VSC-1174](]https://jira.espressif.com:8443/browse/VSC-1174)

## Type of change
- Enhancement

## Steps to test this pull request

- Configure extension:
![image](https://github.com/espressif/vscode-esp-idf-extension/assets/25748706/83c85e72-7790-4774-afee-97e88c1c7eeb)
- Choose "Select ESP-IDF version:

1. Try to do it with a valid esp-idf folder (it should work)
2. Try to do it with an invalid esp-idf folder (error should appear and install button should be disabled)
![image](https://github.com/espressif/vscode-esp-idf-extension/assets/25748706/792ee64d-bcf3-4716-b19a-1ff3b5c07a83)


## How has this been tested?
As described above

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
