### PR TITLE
Fix monitoring for Command Prompt

### DIFF
--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -66,6 +66,8 @@ export class IDFMonitor {
     const quotePath = (path) => {
       if (shellType === "PowerShell") {
         return `'${path.replace(/'/g, "''")}'`;
+      } else if (shellType === "Command Prompt") {
+        return `"${path}"`;
       } else {
         return `'${path}'`;
       }
@@ -114,6 +116,9 @@ export class IDFMonitor {
     if (shellType === "PowerShell") {
       this.terminal.sendText(`& ${envSetCmd} IDF_PATH=${quotedIdfPath}`);
       this.terminal.sendText(`& ${args.join(" ")}`);
+    } else if (shellType === "Command Prompt") {
+      this.terminal.sendText(`${envSetCmd} IDF_PATH=${modifiedEnv.IDF_PATH}`);
+      this.terminal.sendText(args.join(" "));
     } else {
       this.terminal.sendText(`${envSetCmd} IDF_PATH=${quotedIdfPath}`);
       this.terminal.sendText(args.join(" "));

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -64,9 +64,9 @@ export class IDFMonitor {
 
     // Function to quote paths for PowerShell and correctly handle spaces for Bash
     const quotePath = (path) => {
-      if (shellType === "PowerShell") {
+      if (shellType.includes("powershell")) {
         return `'${path.replace(/'/g, "''")}'`;
-      } else if (shellType === "Command Prompt") {
+      } else if (shellType.includes("cmd")) {
         return `"${path}"`;
       } else {
         return `'${path}'`;
@@ -113,10 +113,10 @@ export class IDFMonitor {
     const envSetCmd = process.platform === "win32" ? "set" : "export";
     const quotedIdfPath = quotePath(modifiedEnv.IDF_PATH);
 
-    if (shellType === "PowerShell") {
+    if (shellType.includes("powershell")) {
       this.terminal.sendText(`& ${envSetCmd} IDF_PATH=${quotedIdfPath}`);
       this.terminal.sendText(`& ${args.join(" ")}`);
-    } else if (shellType === "Command Prompt") {
+    } else if (shellType.includes("cmd")) {
       this.terminal.sendText(`${envSetCmd} IDF_PATH=${modifiedEnv.IDF_PATH}`);
       this.terminal.sendText(args.join(" "));
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1255,34 +1255,23 @@ export function markdownToWebviewHtml(
 }
 
 export function getUserShell() {
-  if (idfConf.readParameter("idf.customTerminalExecutable")) {
-    return "custom";
-  }
 
-  const config = vscode.workspace.getConfiguration("terminal.integrated");
-
-  const shellWindows = config.get("defaultProfile.windows") as string;
-  const shellMac = config.get("defaultProfile.osx") as string;
-  const shellLinux = config.get("defaultProfile.linux") as string;
+  const shell = vscode.env.shell;
 
   // list of shells to check
-  const shells = ["PowerShell", "Command Prompt", "bash", "zsh", "Git Bash"];
+  const shells = ["powershell", "cmd", "bash", "zsh"];
 
   // if user's shell is in the list, return it
   for (let i = 0; i < shells.length; i++) {
-    if (shellWindows && shellWindows.includes(shells[i])) {
-      return shells[i];
-    } else if (shellMac && shellMac.includes(shells[i])) {
-      return shells[i];
-    } else if (shellLinux && shellLinux.includes(shells[i])) {
+    if (shell && shell.includes(shells[i])) {
       return shells[i];
     }
   }
 
-  // if no match or no defaultProfile, pick one based on user's OS
+  // if no match, pick one based on user's OS
   const userOS = platform();
   if (userOS === "win32") {
-    return "PowerShell";
+    return "powershell";
   } else if (userOS === "darwin") {
     return "zsh";
   } else if (userOS === "linux") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1255,7 +1255,6 @@ export function markdownToWebviewHtml(
 }
 
 export function getUserShell() {
-
   const shell = vscode.env.shell;
 
   // list of shells to check

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1266,7 +1266,7 @@ export function getUserShell() {
   const shellLinux = config.get("defaultProfile.linux") as string;
 
   // list of shells to check
-  const shells = ["PowerShell", "Command Prompt", "bash", "zsh"];
+  const shells = ["PowerShell", "Command Prompt", "bash", "zsh", "Git Bash"];
 
   // if user's shell is in the list, return it
   for (let i = 0; i < shells.length; i++) {


### PR DESCRIPTION
## Description

- Fix monitoring for Command Prompt
- Fix "Git Bash" white space support
- Fix edge-case for users that have default terminal settings from older setups. We now correctly identify the shell that's been used by the user

Fix https://github.com/espressif/vscode-esp-idf-extension/issues/1230
Fix https://github.com/espressif/vscode-esp-idf-extension/issues/1233
Fix #1239 
Fix #1242

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Monitor a flashed project while having "Command Prompt" as default terminal.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
