### PR TITLE
add kconfig name to info message

### DIFF
--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -147,7 +147,7 @@
   "Select the available serial port where your device is connected.": "选择连接您的设备的可用串行端口。",
   "Port has been updated to ": "端口已更新为 ",
   "SDK Configuration editor": "SDK配置编辑器",
-  "Save": "节省",
+  "Save": "保存",
   "Discard": "丢弃",
   "Reset": "重置",
   "Changes in SDK Configuration editor have not been saved. Would you like to save them?": "SDK 配置编辑器中的更改尚未保存。",

--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -170,7 +170,7 @@ function onChange(e) {
       </div>
     </div>
 
-    <p v-show="isHelpVisible" class="content">
+    <p v-show="isHelpVisible" class="help-kconfig-title">
       KCONFIG Name: <label style="font-weight: 900;">{{ config.name }}</label>
     </p>
     <div v-show="isHelpVisible" class="content" v-html="config.help" />
@@ -260,5 +260,9 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 .menu-title {
   display: inline-block;
+}
+.help-kconfig-title {
+  padding: 0 18px;
+  margin-left: 10px;
 }
 </style>

--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -169,6 +169,9 @@ function onChange(e) {
       </div>
     </div>
 
+    <p v-show="isHelpVisible" class="content">
+      KCONFIG Name <pre style="font-weight: 600;">{{ config.name }}</pre>
+    </p>
     <div v-show="isHelpVisible" class="content" v-html="config.help" />
 
     <div v-if="config.type !== 'choice'">

--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -97,6 +97,7 @@ function onChange(e) {
             class="input is-small"
             placeholder="0"
             @change="onChange"
+            @wheel.prevent
           />
         </div>
       </div>

--- a/src/views/menuconfig/components/configElement.vue
+++ b/src/views/menuconfig/components/configElement.vue
@@ -171,7 +171,7 @@ function onChange(e) {
     </div>
 
     <p v-show="isHelpVisible" class="content">
-      KCONFIG Name <pre style="font-weight: 600;">{{ config.name }}</pre>
+      KCONFIG Name: <label style="font-weight: 900;">{{ config.name }}</label>
     </p>
     <div v-show="isHelpVisible" class="content" v-html="config.help" />
 


### PR DESCRIPTION
## Description

Add KConfig name to SDK Configuration Editor setting information message.

Fix "save" l10n translation in SDK Configuration Editor. 

Remove wheel event on int elements in SDK Configuration Editor to avoid increase or decrease value when scroll.

Fixes #1240

Fixes #1236

Fixes #1189

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: SDK Configuration Editor "
2. Click (i) icon on any setting, you should see the config name in the information.
3. If vscode language is chinese, save button translation should be fixed.

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
