### PR TITLE
fix support for multiple sdkconfig files

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/docs_espressif/en/additionalfeatures/project-configuration.rst
+++ b/docs_espressif/en/additionalfeatures/project-configuration.rst
@@ -22,8 +22,6 @@ To allow you to have multiple configurations for the same project, you can defin
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **idf.customExtraVars**           | Variables to be added to system environment variables                                     |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.adapterTargetName**         | ESP-IDF Target Chip (Example: esp32)                                                      |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
 | **idf.flashBaudRate**             | Flash Baud rate                                                                           |
 +-----------------------------------+-------------------------------------------------------------------------------------------+
 | **idf.monitorBaudRate**           | Monitor Baud Rate (Empty by default to use SDKConfig CONFIG_ESP_CONSOLE_UART_BAUDRATE)    |

--- a/docs_espressif/en/settings.rst
+++ b/docs_espressif/en/settings.rst
@@ -110,7 +110,7 @@ This is how the extension uses them:
 6. **idf.openOcdLaunchArgs**: Launch arguments string array for OpenOCD. The resulting OpenOCD launch command looks like this: ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}``.
 
 .. note::
-  * When you use the command **ESP-IDF: Set Espressif Device Target** it will override **idf.adapterTargetName** with selected chip and **idf.openOcdConfigs** with its default OpenOCD Configuration Files.
+  * When you use the command **ESP-IDF: Set Espressif Device Target** it will override the current sdkconfig IDF_TARGET with selected Espressif chip and **idf.openOcdConfigs** with its default OpenOCD Configuration Files.
   * If you want to customize the **idf.openOcdConfigs** alone, you can use the **ESP-IDF: Select OpenOCD Board Configuration** or modify your settings.json directly.
 
 Code Coverage Specific Settings

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -168,7 +168,7 @@ export class BuildTask {
         }
       }
 
-      const sdkconfigFile = getSDKConfigFilePath(this.currentWorkspace);
+      const sdkconfigFile = await getSDKConfigFilePath(this.currentWorkspace);
       if (compilerArgs.indexOf("SDKCONFIG") === -1) {
         compilerArgs.push(`-DSDKCONFIG=${sdkconfigFile}`);
       }

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -23,9 +23,10 @@ import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
 import {
   appendIdfAndToolsToPath,
-  isBinInPath,
-  getEspIdfFromCMake,
   compareVersion,
+  getEspIdfFromCMake,
+  getSDKConfigFilePath,
+  isBinInPath,
 } from "../utils";
 import { TaskManager } from "../taskManager";
 import { selectedDFUAdapterId } from "../flash/dfu";
@@ -165,6 +166,11 @@ export class BuildTask {
         } else {
           compilerArgs.push("-S", this.currentWorkspace.fsPath);
         }
+      }
+
+      const sdkconfigFile = getSDKConfigFilePath(this.currentWorkspace);
+      if (compilerArgs.indexOf("SDKCONFIG") === -1) {
+        compilerArgs.push(`-DSDKCONFIG=${sdkconfigFile}`);
       }
 
       const sdkconfigDefaults =

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,6 @@ export namespace ESP {
 
   export namespace ProjectConfiguration {
     export let store: ProjectConfigStore;
-    export const CONFIGURATION_LIST_KEY = "PROJECT_CONFIGURATION_KEYS";
     export const SELECTED_CONFIG = "SELECTED_PROJECT_CONFIG";
     export const PROJECT_CONFIGURATION_FILENAME =
       "esp_idf_project_configuration.json";

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -317,6 +317,27 @@ export class ConfserverProcess {
     if (enableCCache) {
       confServerArgs.push("--ccache");
     }
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
+      workspaceFolder
+    ) as string;
+    confServerArgs.push("-B", buildDirPath);
+    const sdkconfigDefaults =
+      (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+
+    if (confServerArgs.indexOf("SDKCONFIG") === -1) {
+      confServerArgs.push(`-DSDKCONFIG=${this.configFile}`)
+    }
+
+    if (
+      confServerArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&
+      sdkconfigDefaults &&
+      sdkconfigDefaults.length
+    ) {
+      confServerArgs.push(
+        `-DSDKCONFIG_DEFAULTS='${sdkconfigDefaults.join(";")}'`
+      );
+    }
     confServerArgs.push("-C", workspaceFolder.fsPath, "confserver");
     this.confServerProcess = spawn(pythonBinPath, confServerArgs, {
       env: modifiedEnv,

--- a/src/espIdf/setTarget/setTargetInIdf.ts
+++ b/src/espIdf/setTarget/setTargetInIdf.ts
@@ -59,6 +59,16 @@ export async function setTargetInIDF(
   } else {
     modifiedEnv.IDF_CCACHE_ENABLE = undefined;
   }
+  if (modifiedEnv.SDKCONFIG) {
+    setTargetArgs.push(`-DSDKCONFIG='${modifiedEnv.SDKCONFIG}'`);
+  }
+  const sdkconfigDefaults =
+    (readParameter("idf.sdkconfigDefaults") as string[]) || [];
+
+  if (sdkconfigDefaults && sdkconfigDefaults.length) {
+    setTargetArgs.push(`-DSDKCONFIG_DEFAULTS='${sdkconfigDefaults.join(";")}'`);
+  }
+
   setTargetArgs.push("set-target", selectedTarget.target);
   const pythonBinPath = await getVirtualEnvPythonPath(workspaceFolder.uri);
   const setTargetResult = await spawn(pythonBinPath, setTargetArgs, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ import { getFileList, getTestComponents } from "./espIdf/unitTest/utils";
 import { saveDefSdkconfig } from "./espIdf/menuconfig/saveDefConfig";
 import { createSBOM, installEspSBOM } from "./espBom";
 import { getEspHomeKitSdk } from "./espHomekit/espHomekitDownload";
-import { selectIdfSetup } from "./versionSwitcher";
+import { getCurrentIdfSetup, selectIdfSetup } from "./versionSwitcher";
 import { checkDebugAdapterRequirements } from "./espIdf/debugAdapter/checkPyReqs";
 import { CDTDebugConfigurationProvider } from "./cdtDebugAdapter/debugConfProvider";
 import { CDTDebugAdapterDescriptorFactory } from "./cdtDebugAdapter/server";
@@ -383,6 +383,19 @@ export async function activate(context: vscode.ExtensionContext) {
             ESP.ProjectConfiguration.store.clear(
               ESP.ProjectConfiguration.SELECTED_CONFIG
             );
+          }
+          const currentIdfSetup = await getCurrentIdfSetup(
+            workspaceRoot,
+            false
+          );
+          if (statusBarItems["currentIdfVersion"]) {
+            statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
+              ? `$(${
+                  commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                }) ESP-IDF v${currentIdfSetup.version}`
+              : `$(${
+                  commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                }) ESP-IDF InvalidSetup`;
           }
           const coverageOptions = getCoverageOptions(workspaceRoot);
           covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
@@ -928,6 +941,16 @@ export async function activate(context: vscode.ExtensionContext) {
           ESP.ProjectConfiguration.store.clear(
             ESP.ProjectConfiguration.SELECTED_CONFIG
           );
+        }
+        const currentIdfSetup = await getCurrentIdfSetup(workspaceRoot, false);
+        if (statusBarItems["currentIdfVersion"]) {
+          statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
+            ? `$(${
+                commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+              }) ESP-IDF v${currentIdfSetup.version}`
+            : `$(${
+                commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+              }) ESP-IDF InvalidSetup`;
         }
         const debugAdapterConfig = {
           currentWorkspace: workspaceRoot,
@@ -1817,6 +1840,7 @@ export async function activate(context: vscode.ExtensionContext) {
         workspaceRoot
       );
       await setIdfTarget(enterDeviceTargetMsg, workspaceFolder);
+      await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -373,6 +373,17 @@ export async function activate(context: vscode.ExtensionContext) {
               `$(${commandDictionary[CommandKeys.SelectSerialPort].iconId}) ` +
               idfConf.readParameter("idf.port", workspaceRoot);
           }
+          if (statusBarItems["projectConf"]) {
+            statusBarItems["projectConf"].dispose();
+            statusBarItems["projectConf"] = undefined;
+            const selectedConfig = ESP.ProjectConfiguration.store.get<string>(
+              ESP.ProjectConfiguration.SELECTED_CONFIG
+            );
+            ESP.ProjectConfiguration.store.clear(selectedConfig);
+            ESP.ProjectConfiguration.store.clear(
+              ESP.ProjectConfiguration.SELECTED_CONFIG
+            );
+          }
           const coverageOptions = getCoverageOptions(workspaceRoot);
           covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
           break;
@@ -907,6 +918,17 @@ export async function activate(context: vscode.ExtensionContext) {
           tooltip: option.uri.fsPath,
         };
         utils.updateStatus(statusBarItems["workspace"], workspaceFolderInfo);
+        if (statusBarItems["projectConf"]) {
+          statusBarItems["projectConf"].dispose();
+          statusBarItems["projectConf"] = undefined;
+          const selectedConfig = ESP.ProjectConfiguration.store.get<string>(
+            ESP.ProjectConfiguration.SELECTED_CONFIG
+          );
+          ESP.ProjectConfiguration.store.clear(selectedConfig);
+          ESP.ProjectConfiguration.store.clear(
+            ESP.ProjectConfiguration.SELECTED_CONFIG
+          );
+        }
         const debugAdapterConfig = {
           currentWorkspace: workspaceRoot,
         } as IDebugAdapterConfig;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1090,6 +1090,7 @@ export async function activate(context: vscode.ExtensionContext) {
         commandDictionary[CommandKeys.SelectProjectConfiguration].checkboxState
       );
       await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
+      await utils.setCCppPropertiesJsonCompileCommands(workspaceRoot);
       ConfserverProcess.dispose();
     });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1090,6 +1090,7 @@ export async function activate(context: vscode.ExtensionContext) {
         commandDictionary[CommandKeys.SelectProjectConfiguration].checkboxState
       );
       await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
+      ConfserverProcess.dispose();
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ import { ArduinoComponentInstaller } from "./espIdf/arduino/addArduinoComponent"
 import { PartitionTableEditorPanel } from "./espIdf/partition-table";
 import { ESPEFuseTreeDataProvider } from "./efuse/view";
 import { ESPEFuseManager } from "./efuse";
-import { constants, createFileSync, pathExists, readJson } from "fs-extra";
+import { constants, createFileSync, pathExists } from "fs-extra";
 import { getEspAdf } from "./espAdf/espAdfDownload";
 import { getEspMdf } from "./espMdf/espMdfDownload";
 import { SetupPanel } from "./setup/SetupPanel";

--- a/src/project-conf/index.ts
+++ b/src/project-conf/index.ts
@@ -43,13 +43,6 @@ export class ProjectConfigStore {
   public clear(key: string) {
     return this.set(key, undefined);
   }
-
-  public getKeys() {
-    return this.ctx.workspaceState.get<string[]>(
-      ESP.ProjectConfiguration.CONFIGURATION_LIST_KEY,
-      undefined
-    );
-  }
 }
 
 export async function getProjectConfigurationElements(workspaceFolder: Uri) {

--- a/src/project-conf/index.ts
+++ b/src/project-conf/index.ts
@@ -69,7 +69,6 @@ export async function getProjectConfigurationElements(workspaceFolder: Uri) {
       },
       env: projectConfJson[elem].env,
       flashBaudRate: projectConfJson[elem].flashBaudRate,
-      idfTarget: projectConfJson[elem].idfTarget,
       monitorBaudRate: projectConfJson[elem].monitorBaudRate,
       openOCD: {
         debugLevel: projectConfJson[elem].openOCD?.debugLevel,

--- a/src/project-conf/projectConfPanel.ts
+++ b/src/project-conf/projectConfPanel.ts
@@ -126,15 +126,6 @@ export class projectConfigurationPanel {
     this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
   }
 
-  private async clearProjectConfFile() {
-    let projectConfKeys = ESP.ProjectConfiguration.store.getKeys();
-    if (projectConfKeys && projectConfKeys.length) {
-      for (const confKey of projectConfKeys) {
-        ESP.ProjectConfiguration.store.clear(confKey);
-      }
-    }
-  }
-
   private async openFolder() {
     const selectedFolder = await window.showOpenDialog({
       canSelectFolders: true,
@@ -163,7 +154,6 @@ export class projectConfigurationPanel {
   private async saveProjectConfFile(projectConfDict: {
     [key: string]: ProjectConfElement;
   }) {
-    this.clearProjectConfFile();
     const projectConfKeys = Object.keys(projectConfDict);
     this.clearSelectedProject(projectConfKeys);
     await saveProjectConfFile(this.workspaceFolder, projectConfDict);

--- a/src/project-conf/projectConfPanel.ts
+++ b/src/project-conf/projectConfPanel.ts
@@ -119,6 +119,17 @@ export class projectConfigurationPanel {
             });
           }
           break;
+        case "openFilePath":
+          let selectedFile = await this.openFile();
+          if (selectedFile) {
+            this.panel.webview.postMessage({
+              command: "setFilePath",
+              confKey: message.confKey,
+              newPath: selectedFile,
+              sectionsKeys: message.sectionsKeys,
+            });
+          }
+          break;
         default:
           break;
       }
@@ -134,6 +145,17 @@ export class projectConfigurationPanel {
     });
     if (selectedFolder && selectedFolder.length > 0) {
       return selectedFolder[0].fsPath;
+    }
+  }
+
+  private async openFile() {
+    const selectedFile = await window.showOpenDialog({
+      canSelectFolders: false,
+      canSelectFiles: true,
+      canSelectMany: false,
+    });
+    if (selectedFile && selectedFile.length > 0) {
+      return selectedFile[0].fsPath;
     }
   }
 

--- a/src/project-conf/projectConfiguration.ts
+++ b/src/project-conf/projectConfiguration.ts
@@ -26,7 +26,6 @@ export interface ProjectConfElement {
   };
   env: { [key: string]: string };
   flashBaudRate: string;
-  idfTarget: string;
   monitorBaudRate: string;
   openOCD: {
     debugLevel: number;

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -269,6 +269,12 @@ export async function getVirtualEnvPythonPath(workspaceFolder: Uri) {
   let pythonPath = readParameter("idf.pythonInstallPath") as string;
   let espIdfDir = readParameter("idf.espIdfPath", workspaceFolder) as string;
   let idfToolsDir = readParameter("idf.toolsPath", workspaceFolder) as string;
+  const idfPathExists = await pathExists(espIdfDir);
+  const idfToolsPathExists = await pathExists(idfToolsDir);
+  const pythonPathExists = await pathExists(pythonPath);
+  if (!idfPathExists || !idfToolsPathExists || !pythonPathExists) {
+    return;
+  }
   const virtualEnvPython = await getPythonEnvPath(
     espIdfDir,
     idfToolsDir,

--- a/src/statusBar/index.ts
+++ b/src/statusBar/index.ts
@@ -29,6 +29,7 @@ import { readParameter } from "../idfConfiguration";
 import { ESP } from "../config";
 import { CommandItem } from "../cmdTreeView/cmdTreeDataProvider";
 import { CommandKeys, createCommandDictionary } from "../cmdTreeView/cmdStore";
+import { getIdfTargetFromSdkconfig } from "../workspaceConfig";
 
 export const statusBarItems: { [key: string]: StatusBarItem } = {};
 
@@ -54,14 +55,11 @@ export async function createCmdsStatusBarItems(workspaceFolder: Uri) {
     return {};
   }
   const port = readParameter("idf.port", workspaceFolder) as string;
-  let idfTarget = readParameter("idf.adapterTargetName", workspaceFolder);
+  let idfTarget = await getIdfTargetFromSdkconfig(workspaceFolder);
   let flashType = readParameter("idf.flashType", workspaceFolder) as string;
   let projectConf = ESP.ProjectConfiguration.store.get<string>(
     ESP.ProjectConfiguration.SELECTED_CONFIG
   );
-  if (idfTarget === "custom") {
-    idfTarget = readParameter("idf.customAdapterTargetName", workspaceFolder);
-  }
   let currentIdfVersion = await getCurrentIdfSetup(workspaceFolder, false);
 
 

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -154,7 +154,6 @@ export async function writeTextReport(
         }
       }
       output += `Flash baud rate: ${reportedResult.projectConfigurations[key].flashBaudRate}${EOL}`;
-      output += `IDF Target: ${reportedResult.projectConfigurations[key].idfTarget}${EOL}`;
       output += `Monitor baud rate: ${reportedResult.projectConfigurations[key].monitorBaudRate}${EOL}`;
 
       if (reportedResult.projectConfigurations[key].openOCD) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,15 +241,6 @@ export async function createVscodeFolder(curWorkspaceFsPath: vscode.Uri) {
 export async function setCCppPropertiesJsonCompilerPath(
   curWorkspaceFsPath: vscode.Uri
 ) {
-  const cCppPropertiesJsonPath = path.join(
-    curWorkspaceFsPath.fsPath,
-    ".vscode",
-    "c_cpp_properties.json"
-  );
-  const doesPathExists = await pathExists(cCppPropertiesJsonPath);
-  if (!doesPathExists) {
-    return;
-  }
   const modifiedEnv = await appendIdfAndToolsToPath(curWorkspaceFsPath);
   const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
   const gccTool = getToolchainToolName(idfTarget, "gcc");
@@ -258,22 +249,65 @@ export async function setCCppPropertiesJsonCompilerPath(
     curWorkspaceFsPath.fsPath,
     modifiedEnv
   );
+  if (!compilerAbsolutePath) {
+    return;
+  }
+  let compilerRelativePath = compilerAbsolutePath.split(
+    modifiedEnv.IDF_TOOLS_PATH
+  )[1];
+  const settingToUse =
+    process.platform === "win32"
+      ? "${config:idf.toolsPathWin}"
+      : "${config:idf.toolsPath}";
 
+  await updateCCppPropertiesJson(
+    curWorkspaceFsPath,
+    "compilerPath",
+    settingToUse + compilerRelativePath
+  );
+}
+
+export async function setCCppPropertiesJsonCompileCommands(
+  curWorkspaceFsPath: vscode.Uri
+) {
+  const buildDirPath = idfConf.readParameter(
+    "idf.buildPath",
+    curWorkspaceFsPath
+  ) as string;
+  const compileCommandsPath = path.join(buildDirPath, "compile_commands.json");
+
+  await updateCCppPropertiesJson(
+    curWorkspaceFsPath,
+    "compileCommands",
+    compileCommandsPath
+  );
+}
+
+export async function updateCCppPropertiesJson(
+  workspaceUri: vscode.Uri,
+  fieldToUpdate: string,
+  newFieldValue: string
+) {
+  const cCppPropertiesJsonPath = path.join(
+    workspaceUri.fsPath,
+    ".vscode",
+    "c_cpp_properties.json"
+  );
+  const doesPathExists = await pathExists(cCppPropertiesJsonPath);
+  if (!doesPathExists) {
+    return;
+  }
   const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
   if (
     cCppPropertiesJson &&
     cCppPropertiesJson.configurations &&
     cCppPropertiesJson.configurations.length
   ) {
-    let compilerRelativePath = compilerAbsolutePath.split(
-      modifiedEnv.IDF_TOOLS_PATH
-    )[1];
-    const settingToUse =
-      process.platform === "win32"
-        ? "${config:idf.toolsPathWin}"
-        : "${config:idf.toolsPath}";
-    cCppPropertiesJson.configurations[0].compilerPath =
-      settingToUse + compilerRelativePath;
+    const buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
+      workspaceUri
+    ) as string;
+    cCppPropertiesJson.configurations[0][fieldToUpdate] = newFieldValue;
     await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
       spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1109,7 +1109,8 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   }
 
   let sdkconfigFilePath = idfConf.readParameter(
-    "idf.sdkconfigFilePath"
+    "idf.sdkconfigFilePath",
+    curWorkspace
   ) as string;
   if (sdkconfigFilePath) {
     modifiedEnv.SDKCONFIG = sdkconfigFilePath;

--- a/src/views/project-conf/components/projectConfElem.vue
+++ b/src/views/project-conf/components/projectConfElem.vue
@@ -107,13 +107,6 @@ function removeValueFromArray(sections: string[], index: number) {
       :sections="['flashBaudRate']"
       :updateMethod="updateElement"
     />
-    <SelectElement
-      :selectValue="el.idfTarget ? el.idfTarget : ''"
-      title="IDF Target"
-      :options="idfTargets"
-      :sections="['idfTarget']"
-      :updateMethod="updateElement"
-    />
     <StringElement
       title="Monitor baud rate"
       :value="el.monitorBaudRate ? el.monitorBaudRate : ''"

--- a/src/views/project-conf/components/projectConfElem.vue
+++ b/src/views/project-conf/components/projectConfElem.vue
@@ -21,22 +21,16 @@ const openOcdDebugLevelOptions: { name: string; value: number }[] = [
   { name: "Verbose", value: 4 },
 ];
 
-const idfTargets: { name: string; value: string }[] = [
-  { name: "esp32", value: "esp32" },
-  { name: "ESP32 S2", value: "esp32s2" },
-  { name: "ESP32 S3", value: "esp32s3" },
-  { name: "ESP32 C2", value: "esp32c2" },
-  { name: "ESP32 C3", value: "esp32c3" },
-  { name: "ESP32 C6", value: "esp32c6" },
-  { name: "ESP32 H2", value: "esp32h2" },
-];
-
 function updateElement(sections: string[], newValue: any) {
   store.updateConfigElement({ confKey: props.title, sections, newValue });
 }
 
 function openBuildDir(sections: string[]) {
   store.openBuildPath({ confKey: props.title, sections });
+}
+
+function openFilePath(sections: string[]) {
+  store.openFilePath({ confKey: props.title, sections });
 }
 
 function addValueToArray(sections: string[], newValue: any) {
@@ -93,6 +87,7 @@ function removeValueFromArray(sections: string[], index: number) {
         "
         :sections="['build', 'sdkconfigFilePath']"
         :updateMethod="updateElement"
+        :openMethod="openFilePath"
       />
     </div>
     <DictionaryElement

--- a/src/views/project-conf/main.ts
+++ b/src/views/project-conf/main.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Thursday, 31st August 2023 12:31:23 pm
  * Copyright 2023 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,15 @@ window.addEventListener("message", (event: MessageEvent) => {
           confKey: msg.confKey,
           sections: msg.sectionsKeys,
           newValue: msg.buildPath,
+        });
+      }
+      break;
+    case "setFilePath":
+      if (msg.confKey) {
+        store.updateConfigElement({
+          confKey: msg.confKey,
+          sections: msg.sectionsKeys,
+          newValue: msg.newPath,
         });
       }
       break;

--- a/src/views/project-conf/store.ts
+++ b/src/views/project-conf/store.ts
@@ -86,6 +86,14 @@ export const useProjectConfStore = defineStore("project-config", () => {
     });
   }
 
+  function openFilePath(payload: { confKey: string; sections: string[] }) {
+    vscode.postMessage({
+      command: "openFilePath",
+      sectionsKeys: payload.sections,
+      confKey: payload.confKey,
+    });
+  }
+
   function addNewConfigToList(confKey: string) {
     let newConf = {
       build: {
@@ -174,6 +182,7 @@ export const useProjectConfStore = defineStore("project-config", () => {
     addNewConfigToList,
     addValueToConfigElement,
     openBuildPath,
+    openFilePath,
     updateConfigElement,
     removeValueFromConfigElement,
     requestInitValues,

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -82,21 +82,23 @@ export async function getIdfTargetFromSdkconfig(
   workspacePath: vscode.Uri,
   statusItem?: vscode.StatusBarItem
 ) {
-  let sdkConfigPath = await getSDKConfigFilePath(workspacePath);
-  const doesSdkconfigExists = await pathExists(sdkConfigPath);
-  if (!doesSdkconfigExists) {
-    return;
+  try {
+    const configIdfTarget = await utils.getConfigValueFromSDKConfig(
+      "CONFIG_IDF_TARGET",
+      workspacePath
+    );
+    let idfTarget = configIdfTarget.replace(/\"/g, "");
+    if (!idfTarget) {
+      idfTarget = "esp32";
+    }
+    if (statusItem) {
+      statusItem.text = "$(chip) " + idfTarget;
+    }
+    return idfTarget;
+  } catch (error) {
+    if (statusItem) {
+      statusItem.text = "$(chip) esp32";
+    }
+    return "esp32";
   }
-  const configIdfTarget = await utils.getConfigValueFromSDKConfig(
-    "CONFIG_IDF_TARGET",
-    workspacePath
-  );
-  const idfTarget = configIdfTarget.replace(/\"/g, "");
-  if (!idfTarget) {
-    return;
-  }
-  if (statusItem) {
-    statusItem.text = "$(chip) " + idfTarget;
-  }
-  return idfTarget;
 }


### PR DESCRIPTION
## Description

Fix support of multiple sdkconfig when using Project Configuration and multiple profiles.

Fixes #1202
Fixes #1265
Fixes #1283
Fixes #1299

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Using a project with multiple configurations like https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config run the `ESP-IDF: Open Project Configuration` and configure 2 profiles with different SDK Configuration Editor, resulting in a `esp_idf_project_configuration.json` like this:

```json
{
  "gen1": {
    "build": {
      "compileArgs": [],
      "ninjaArgs": [],
      "buildDirectoryPath": "${workspaceFolder}/build_gen1",
      "sdkconfigDefaults": [
        "sdkconfig.prod_common",
        "sdkconfig.prod1"
      ],
      "sdkconfigFilePath": "${workspaceFolder}/sdkconfig1"
    },
    "env": {},
    "flashBaudRate": "",
    "idfTarget": "",
    "monitorBaudRate": "",
    "openOCD": {
      "debugLevel": 0,
      "configs": [],
      "args": []
    },
    "tasks": {
      "preBuild": "",
      "preFlash": "",
      "postBuild": "",
      "postFlash": ""
    }
  },
  "gen2": {
    "build": {
      "compileArgs": [],
      "ninjaArgs": [],
      "buildDirectoryPath": "${workspaceFolder}/build_gen2",
      "sdkconfigDefaults": [
        "sdkconfig.prod_common",
        "sdkconfig.prod2"
      ],
      "sdkconfigFilePath": "${workspaceFolder}/sdkconfig2"
    },
    "env": {},
    "flashBaudRate": "",
    "idfTarget": "",
    "monitorBaudRate": "",
    "openOCD": {
      "debugLevel": 0,
      "configs": [],
      "args": []
    },
    "tasks": {
      "preBuild": "",
      "preFlash": "",
      "postBuild": "",
      "postFlash": ""
    }
  }
}

```

Note: If using the former ESP-IDF multi config example, remember to remove from root CMakeLists.txt the line:

```
set(SDKCONFIG "${CMAKE_BINARY_DIR}/sdkconfig")
```

1. Click on "SDK Configuration Editor" using profile 1. SDK Configuration changes should be saved in `${workspaceFolder}/sdkconfig1` and c_cpp_properties.json should have compileCommands set to the build path of profile 1.
2. Click on "SDK Configuration Editor" using profile 2. SDK Configuration changes should be saved in `${workspaceFolder}/sdkconfig2` and c_cpp_properties.json should have compileCommands set to the build path of profile 2.

3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual Testing 

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
