### PR TITLE
modify env for matter bootstrap script task

### DIFF
--- a/src/espMatter/espMatterDownload.ts
+++ b/src/espMatter/espMatterDownload.ts
@@ -40,6 +40,7 @@ import { OutputChannel } from "../logger/outputChannel";
 import { PackageProgress } from "../PackageProgress";
 import { installEspMatterPyReqs } from "../pythonManager";
 import { platform } from "os";
+import { appendIdfAndToolsToPath } from "../utils";
 
 export class EspMatterCloning extends AbstractCloning {
   public static isBuildingGn: boolean;
@@ -86,9 +87,11 @@ export class EspMatterCloning extends AbstractCloning {
     if (!bootstrapFilePathExists) {
       return;
     }
+    const modifiedEnv = appendIdfAndToolsToPath(this.currWorkspace);
     EspMatterCloning.isBuildingGn = true;
     const shellOptions: ShellExecutionOptions = {
       cwd: workingDir,
+      env: modifiedEnv
     };
     const shellExecutablePath = readParameter(
       "idf.customTerminalExecutable",


### PR DESCRIPTION
## Description

Fix ESP-Matter bootstrap not using Python virtual env by adding the modified env to shell execution.

Fixes #1254

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Install ESP-Matter"
2. ESP-Matter should install packages in the ESP-IDF virtual environment.
3. ESP-Matter install should be completed without issues.

- Expected behaviour:
Python packages installed in the Python virtual environment.

- Expected output:
 ESP-Matter install should be completed without issues.

## How has this been tested?

Manual testing of installing ESP-Matter.

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
