### PR TITLE
use getConfiguration launch to read debug config

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -46,8 +46,7 @@ In case the user wants more customized control, the basic arguments in launch.js
       "initCommands": [
         "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
         "mon reset halt",
-        "maintenance flush register-cache",
-        "thb app_main"
+        "maintenance flush register-cache"
       ],
       "gdb": "${command:espIdf.getToolchainGdb}",
       "target": {
@@ -62,7 +61,8 @@ In case the user wants more customized control, the basic arguments in launch.js
 ```
 
 - `program`: ELF file of your project build directory to execute the debug session. The command `${command:espIdf.getProjectName}` will query the extension to find the current build directory project name.
-- `initCommands`: GDB Commands to initialize GDB and target.
+- `initCommands`: GDB Commands to initialize GDB and target. The default value is `["set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}", "mon reset halt", "maintenance flush register-cache"]`.
+- `initialBreakpoint`: When `initCommands` is not defined, this command will add to default initCommands a hardward breakpoint at the given function name. For example `app_main`, the default value, will add `thb app_main` to default initCommmands. If set to "", an empty string, no initial breakpoint will be set.
 - `gdb`: GDB executable to be used. By default `"${command:espIdf.getToolchainGdb}"` will query the extension to find the ESP-IDF toolchain GDB for the current `IDF_TARGET` of your esp-idf project (esp32, esp32c6, etc.).
 
 > **NOTE** `{IDF_TARGET_CPU_WATCHPOINT_NUM}` is resolved by the extension according to the current `IDF_TARGET` of your esp-idf project (esp32, esp32c6, etc.).

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -62,7 +62,7 @@ In case the user wants more customized control, the basic arguments in launch.js
 
 - `program`: ELF file of your project build directory to execute the debug session. The command `${command:espIdf.getProjectName}` will query the extension to find the current build directory project name.
 - `initCommands`: GDB Commands to initialize GDB and target. The default value is `["set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}", "mon reset halt", "maintenance flush register-cache"]`.
-- `initialBreakpoint`: When `initCommands` is not defined, this command will add to default initCommands a hardward breakpoint at the given function name. For example `app_main`, the default value, will add `thb app_main` to default initCommmands. If set to "", an empty string, no initial breakpoint will be set.
+- `initialBreakpoint`: When `initCommands` is not defined, this command will add to default initCommands a hardward breakpoint at the given function name. For example `app_main`, the default value, will add `thb app_main` to default initCommmands. If set to "", an empty string, no initial breakpoint will be set and if let undefined it will use the default `thb app_main`.
 - `gdb`: GDB executable to be used. By default `"${command:espIdf.getToolchainGdb}"` will query the extension to find the ESP-IDF toolchain GDB for the current `IDF_TARGET` of your esp-idf project (esp32, esp32c6, etc.).
 
 > **NOTE** `{IDF_TARGET_CPU_WATCHPOINT_NUM}` is resolved by the extension according to the current `IDF_TARGET` of your esp-idf project (esp32, esp32c6, etc.).

--- a/package.json
+++ b/package.json
@@ -1581,7 +1581,7 @@
               },
               "initialBreakpoint": {
                 "type": "string",
-                "description": "Hardware breakpoint being set initially as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. Ignored if user defines initCommands",
+                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined it will use the default 'thb app_main'. Ignored if user defines initCommands argument.",
                 "default": "app_main"
               },
               "preRunCommands": {
@@ -1850,7 +1850,7 @@
               },
               "initialBreakpoint": {
                 "type": "string",
-                "description": "Hardware breakpoint being set initially as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. Ignored if user defines initCommands",
+                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined it will use the default 'thb app_main'. Ignored if user defines initCommands argument.",
                 "default": "app_main"
               },
               "preRunCommands": {

--- a/package.json
+++ b/package.json
@@ -1579,6 +1579,11 @@
                 },
                 "default": []
               },
+              "initialBreakpoint": {
+                "type": "string",
+                "description": "Hardware breakpoint being set initially as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. Ignored if user defines initCommands",
+                "default": "app_main"
+              },
               "preRunCommands": {
                 "type": "array",
                 "description": "List of GDB commands sent after loading image on target before resuming target.",
@@ -1842,6 +1847,11 @@
                   "type": "string"
                 },
                 "default": []
+              },
+              "initialBreakpoint": {
+                "type": "string",
+                "description": "Hardware breakpoint being set initially as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. Ignored if user defines initCommands",
+                "default": "app_main"
               },
               "preRunCommands": {
                 "type": "array",

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -64,6 +64,7 @@ export class CDTDebugConfigurationProvider
           "mon reset halt",
           "maintenance flush register-cache",
           "thb app_main",
+          "c"
         ];
       }
 

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -64,7 +64,9 @@ export class CDTDebugConfigurationProvider
           "mon reset halt",
           "maintenance flush register-cache",
         ];
-        if (config.initialBreakpoint) {
+        if (typeof config.initialBreakpoint === "undefined") {
+          config.initCommands.push(`thb app_main`);
+        } else if (config.initialBreakpoint) {
           config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`);
         }
       }

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -65,7 +65,7 @@ export class CDTDebugConfigurationProvider
           "maintenance flush register-cache",
         ];
         if (config.initialBreakpoint) {
-          config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`, "c");
+          config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`);
         }
       }
 

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -63,9 +63,10 @@ export class CDTDebugConfigurationProvider
           "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
           "mon reset halt",
           "maintenance flush register-cache",
-          "thb app_main",
-          "c"
         ];
+        if (config.initialBreakpoint) {
+          config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`, "c");
+        }
       }
 
       if (config.initCommands && Array.isArray(config.initCommands)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2633,13 +2633,14 @@ export async function activate(context: vscode.ExtensionContext) {
         );
         return;
       }
-      const launchJson = await readJson(launchJsonPath);
-      if (
-        launchJson &&
-        launchJson.configurations &&
-        launchJson.configurations.length
-      ) {
-        for (const conf of launchJson.configurations) {
+      const config = vscode.workspace.getConfiguration("launch", workspaceRoot);
+
+      // retrieve values
+      const configurations = config.get(
+        "configurations"
+      ) as vscode.DebugConfiguration[];
+      if (configurations && configurations.length) {
+        for (const conf of configurations) {
           if (conf.type === "gdbtarget") {
             await vscode.debug.startDebugging(workspaceFolder, conf.name);
             return;

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -247,7 +247,7 @@ export async function execProcessWithLog(
     undefined,
     undefined,
     cancelToken,
-    pyTracker.Log
+    undefined
   );
   Logger.info(processResult + "\n");
   if (pyTracker) {


### PR DESCRIPTION
## Description

Read launch.json configuration using vscode.workspace.getConfiguration instead to avoid trail comma issues. Add `initialBreakpoint` as launch.json argument to define initial breakpoint to set in default initCommands.

Fixes #1253 
Fixes #1259

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Say you have a launch.json with trailing comma like this:

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "gdbtarget",
      "request": "attach",
      "name": "Eclipse CDT GDB Adapter",
    }
  ]
}
```
If you click the debug button in the status bar `ESP-IDF: Debug` it was not working. With this PR, it should work now. 

When you start a debug session, the program will stop by default in `app_main`. If you want it NOT to stop at app_main you should set:

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "gdbtarget",
      "request": "attach",
      "name": "Eclipse CDT GDB Adapter",
      "initialBreakpoint": ""
    }
  ]
}
```

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing by debugging with status bar debug icon `ESP-IDF: Debug` any esp-idf project with launch.json as shown before.

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
