### PR TITLE
Fix CMake args for esp-idf lower than 4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -575,11 +575,7 @@
           },
           "idf.cmakeCompilerArgs": {
             "type": "array",
-            "default": [
-              "-G=Ninja",
-              "-DPYTHON_DEPS_CHECKED=1",
-              "-DESP_PLATFORM=1"
-            ],
+            "default": [],
             "description": "%param.cmakeCompilerArgs%",
             "scope": "resource"
           },

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -152,11 +152,14 @@ export class BuildTask {
           "-DESP_PLATFORM=1",
         ];
       }
-      let compilerArgs =
-        (idfConf.readParameter(
-          "idf.cmakeCompilerArgs",
-          this.currentWorkspace
-        ) as Array<string>) || defaultCompilerArgs;
+      let compilerArgs = idfConf.readParameter(
+        "idf.cmakeCompilerArgs",
+        this.currentWorkspace
+      ) as Array<string>;
+
+      if (!compilerArgs || compilerArgs.length === 0) {
+        compilerArgs = defaultCompilerArgs;
+      }
       let buildPathArgsIndex = compilerArgs.indexOf("-B");
       if (buildPathArgsIndex !== -1) {
         compilerArgs.splice(buildPathArgsIndex, useEqualSign ? 1 : 2);


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes #1260 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request
- Download esp-idf version 4.3.6 from https://[dl.espressif.com/dl/esp-idf/?idf=4.3](https://dl.espressif.com/dl/esp-idf/?idf=4.3) 
- Configure extension to use existing esp-idf (select the folder where 4.3.6 was installed)
- Create a project from examples (ex: hello world)
- Build the project

The project should build with no issues.

## How has this been tested?

Manual testing

**Test Configuration**:
* ESP-IDF Version: 4.3.6
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
