### PR TITLE
Update recommended cp command

### DIFF
--- a/src/views/setup/App.vue
+++ b/src/views/setup/App.vue
@@ -21,7 +21,7 @@ const isLinuxPlatform = computed(() => {
 
 const openOCDRulesPathText = computed(() => {
   return openOCDRulesPath.value !== ""
-    ? `sudo cp -n ${openOCDRulesPath.value} /etc/udev/rules.d`
+    ? `sudo cp --update=none ${openOCDRulesPath.value} /etc/udev/rules.d`
     : "";
 });
 </script>


### PR DESCRIPTION
## Description

Updated the command we tell our Linux users to use in order to add 60-openocd.rules for permission delegation in USB devices to be added in /etc/udev/rules.d/

Fixes [#1256](https://github.com/espressif/vscode-esp-idf-extension/issues/1256)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Configure extension on Linux
2. After configuration it's done the command we show should be:
`sudo cp --update=none /home/hmp/.espressif/tools/openocd-esp32/v0.12.0-esp32-20240318/openocd-esp32/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d`

Previously the command was:
`sudo cp -n /home/hmp/.espressif/tools/openocd-esp32/v0.12.0-esp32-20240318/openocd-esp32/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d`

## How has this been tested?

As described above.

**Test Configuration**:
* ESP-IDF Version: 5.3
* OS (Windows,Linux and macOS): Linux

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
