### PR TITLE
[VSC-1412] Add validation for debug session status for monitor start with no reset flag

### DIFF
--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -18,7 +18,7 @@
 
 import { ESP } from "../../config";
 import { appendIdfAndToolsToPath, getUserShell } from "../../utils";
-import { window, Terminal, Uri, env } from "vscode";
+import { window, Terminal, Uri, env, debug } from "vscode";
 
 export interface MonitorConfig {
   baudRate: string;
@@ -97,7 +97,10 @@ export class IDFMonitor {
       "--toolchain-prefix",
       this.config.toolchainPrefix,
     ];
-    if (this.config.noReset && this.config.idfVersion >= "5.0") {
+    if (
+      this.isDebugSessionActive() ||
+      (this.config.noReset && this.config.idfVersion >= "5.0")
+    ) {
       args.splice(2, 0, "--no-reset");
     }
     if (this.config.enableTimestamps && this.config.idfVersion >= "4.4") {
@@ -143,5 +146,9 @@ export class IDFMonitor {
       this.terminal.sendText(ESP.CTRL_RBRACKET);
       this.terminal.sendText(`exit`);
     } catch (error) {}
+  }
+
+  private isDebugSessionActive(): boolean {
+    return debug.activeDebugSession !== undefined;
   }
 }

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -148,7 +148,7 @@ export class IDFMonitor {
     } catch (error) {}
   }
 
-  private isDebugSessionActive(): boolean {
+  private static isDebugSessionActive(): boolean {
     return debug.activeDebugSession !== undefined;
   }
 }


### PR DESCRIPTION
## Description

JIRA: https://jira.espressif.com:8443/browse/VSC-1412

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

1. Debug a project (ex: blink)
2. While debugging, start monitoring

- Expected behaviour:

The board should not reset itself, monitor should start from the current state of the board

## How has this been tested?

As described above using the blink example on a ESP32-C6 board

**Test Configuration**:
* ESP-IDF Version: 5.3
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
