### PR TITLE
[VSC-1409] Add check for missing compile_commands.json in IDF projects

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -186,5 +186,7 @@
   "Execute Custom Task": "Ejecutar tarea personalizada",
   "Wait for ESP-IDF build or flash to finish": "Espere a que finalice la compilación o la actualización de ESP-IDF",
   "Target {0} Set Successfully.": "Objetivo {0} configurado con éxito.",
-  "Unknown error occurred while setting IDF target.": "Ocurrió un error desconocido al configurar el objetivo IDF."
+  "Unknown error occurred while setting IDF target.": "Ocurrió un error desconocido al configurar el objetivo IDF.",
+  "compile_commands.json is missing. This may cause errors with code analysis extensions.": "Falta compile_commands.json. Esto puede causar errores con las extensiones de análisis de código.",
+  "Generate compile_commands.json": "Generar compile_commands.json"
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -186,5 +186,7 @@
   "Execute Custom Task": "Executar tarefa personalizada",
   "Wait for ESP-IDF build or flash to finish": "Aguarde a conclusão da compilação ou flash do ESP-IDF",
   "Target {0} Set Successfully.": "Alvo {0} definido com sucesso.",
-  "Unknown error occurred while setting IDF target.": "Ocorreu um erro desconhecido ao definir o alvo IDF."
+  "Unknown error occurred while setting IDF target.": "Ocorreu um erro desconhecido ao definir o alvo IDF.",
+  "compile_commands.json is missing. This may cause errors with code analysis extensions.": "O arquivo compile_commands.json está faltando. Isso pode causar erros com extensões de análise de código.",
+  "Generate compile_commands.json": "Gerar compile_commands.json"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -186,5 +186,7 @@
   "Execute Custom Task": "Выполнить пользовательскую задачу",
   "Wait for ESP-IDF build or flash to finish": "Подождите завершения сборки или прошивки ESP-IDF.",
   "Target {0} Set Successfully.": "Цель {0} успешно установлена.",
-  "Unknown error occurred while setting IDF target.": "Произошла неизвестная ошибка при установке цели IDF."
+  "Unknown error occurred while setting IDF target.": "Произошла неизвестная ошибка при установке цели IDF.",
+  "compile_commands.json is missing. This may cause errors with code analysis extensions.": "Отсутствует файл compile_commands.json. Это может вызвать ошибки в работе расширений для анализа кода.",
+  "Generate compile_commands.json": "Создать compile_commands.json"
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -186,5 +186,7 @@
   "Execute Custom Task": "执行自定义任务",
   "Wait for ESP-IDF build or flash to finish": "等待 ESP-IDF 构建或刷新完成",
   "Target {0} Set Successfully.": "目标 {0} 设置成功",
-  "Unknown error occurred while setting IDF target.": "设置 IDF 目标时发生未知错误"
+  "Unknown error occurred while setting IDF target.": "设置 IDF 目标时发生未知错误",
+  "compile_commands.json is missing. This may cause errors with code analysis extensions.": "缺少 compile_commands.json 文件。这可能会导致代码分析扩展出错。",
+  "Generate compile_commands.json": "生成 compile_commands.json"
 }

--- a/package.json
+++ b/package.json
@@ -559,7 +559,12 @@
           },
           "idf.cmakeCompilerArgs": {
             "type": "array",
-            "default": [],
+            "default": [
+              "-G",
+              "Ninja",
+              "-DPYTHON_DEPS_CHECKED=1",
+              "-DESP_PLATFORM=1"
+            ],
             "description": "%param.cmakeCompilerArgs%",
             "scope": "resource",
             "items": {

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -123,12 +123,6 @@ export class BuildTask {
           "Could not determine ESP-IDF version. Using default compiler arguments for the latest known version."
         );
         defaultCompilerArgs = [
-          "-G=Ninja",
-          "-DPYTHON_DEPS_CHECKED=1",
-          "-DESP_PLATFORM=1",
-        ];
-      } else {
-        defaultCompilerArgs = [
           "-G",
           "Ninja",
           "-DPYTHON_DEPS_CHECKED=1",

--- a/src/espIdf/reconfigure/task.ts
+++ b/src/espIdf/reconfigure/task.ts
@@ -27,7 +27,7 @@ import {
   workspace,
 } from "vscode";
 import { NotificationMode, readParameter } from "../../idfConfiguration";
-import { appendIdfAndToolsToPath, compareVersion, getEspIdfFromCMake, getSDKConfigFilePath } from "../../utils";
+import { appendIdfAndToolsToPath, getSDKConfigFilePath } from "../../utils";
 import { join } from "path";
 import { TaskManager } from "../../taskManager";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
@@ -65,18 +65,12 @@ export class IdfReconfigureTask {
 
     const idfPy = join(this.idfPathDir, "tools", "idf.py");
     const reconfigureArgs = [idfPy];
-    const espIdfVersion = await getEspIdfFromCMake(this.idfPathDir);
-    const useEqualSign = compareVersion(espIdfVersion, "4.4") >= 0;
 
     let buildPathArgsIndex = reconfigureArgs.indexOf("-B");
     if (buildPathArgsIndex !== -1) {
-      reconfigureArgs.splice(buildPathArgsIndex, useEqualSign ? 1 : 2);
+      reconfigureArgs.splice(buildPathArgsIndex, 2);
     }
-    if (useEqualSign) {
-      reconfigureArgs.push(`-B=${this.buildDirPath}`);
-    } else {
-      reconfigureArgs.push("-B", this.buildDirPath);
-    }
+    reconfigureArgs.push("-B", this.buildDirPath);
 
     const sdkconfigFile = await getSDKConfigFilePath(this.curWorkspace);
     if (reconfigureArgs.indexOf("SDKCONFIG") === -1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3678,9 +3678,12 @@ function checkAndNotifyMissingCompileCommands() {
       try {
         const isIdfProject = utils.checkIsProjectCmakeLists(folder.uri.fsPath);
         if (isIdfProject) {
+          const buildDirPath = idfConf.readParameter(
+            "idf.buildPath",
+            workspaceRoot
+          ) as string;
           const compileCommandsPath = path.join(
-            folder.uri.fsPath,
-            "build",
+            buildDirPath,
             "compile_commands.json"
           );
           const compileCommandsExists = await pathExists(compileCommandsPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -404,8 +404,9 @@ export async function activate(context: vscode.ExtensionContext) {
             );
             if (statusBarItems && statusBarItems["port"]) {
               statusBarItems["port"].text =
-                `$(${commandDictionary[CommandKeys.SelectSerialPort].iconId}) ` +
-                idfConf.readParameter("idf.port", workspaceRoot);
+                `$(${
+                  commandDictionary[CommandKeys.SelectSerialPort].iconId
+                }) ` + idfConf.readParameter("idf.port", workspaceRoot);
             }
             if (statusBarItems["projectConf"]) {
               statusBarItems["projectConf"].dispose();
@@ -425,10 +426,12 @@ export async function activate(context: vscode.ExtensionContext) {
             if (statusBarItems["currentIdfVersion"]) {
               statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
                 ? `$(${
-                    commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                    commandDictionary[CommandKeys.SelectCurrentIdfVersion]
+                      .iconId
                   }) ESP-IDF v${currentIdfSetup.version}`
                 : `$(${
-                    commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                    commandDictionary[CommandKeys.SelectCurrentIdfVersion]
+                      .iconId
                   }) ESP-IDF InvalidSetup`;
             }
             const coverageOptions = getCoverageOptions(workspaceRoot);
@@ -463,7 +466,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
       ConfserverProcess.dispose();
     })
-  )
+  );
 
   vscode.debug.onDidTerminateDebugSession((e) => {
     if (isOpenOCDLaunchedByDebug && !isDebugRestarted) {
@@ -3702,7 +3705,11 @@ function checkAndNotifyMissingCompileCommands() {
         const msg = error.message
           ? error.message
           : "Error checking for compile_commands.json file.";
-        Logger.error(msg, error, "extension checkAndNotifyMissingCompileCommands");
+        Logger.error(
+          msg,
+          error,
+          "extension checkAndNotifyMissingCompileCommands"
+        );
       }
     });
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ import { ExamplesPlanel } from "./examples/ExamplesPanel";
 import * as idfConf from "./idfConfiguration";
 import { Logger } from "./logger/logger";
 import { OutputChannel } from "./logger/outputChannel";
-import { showInfoNotificationWithAction, executeCommand } from "./logger/utils";
+import { showInfoNotificationWithAction } from "./logger/utils";
 import * as utils from "./utils";
 import { PreCheck } from "./utils";
 import {
@@ -392,77 +392,78 @@ export async function activate(context: vscode.ExtensionContext) {
     binTimestampEventFunc
   );
   context.subscriptions.push(buildWatcherCreateDisposable);
-
-  vscode.workspace.onDidChangeWorkspaceFolders(async (e) => {
-    if (PreCheck.isWorkspaceFolderOpen()) {
-      for (const ws of e.removed) {
-        if (workspaceRoot && ws.uri === workspaceRoot) {
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(async (e) => {
+      if (PreCheck.isWorkspaceFolderOpen()) {
+        for (const ws of e.removed) {
+          if (workspaceRoot && ws.uri === workspaceRoot) {
+            workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+            await getIdfTargetFromSdkconfig(
+              workspaceRoot,
+              statusBarItems["target"]
+            );
+            if (statusBarItems && statusBarItems["port"]) {
+              statusBarItems["port"].text =
+                `$(${commandDictionary[CommandKeys.SelectSerialPort].iconId}) ` +
+                idfConf.readParameter("idf.port", workspaceRoot);
+            }
+            if (statusBarItems["projectConf"]) {
+              statusBarItems["projectConf"].dispose();
+              statusBarItems["projectConf"] = undefined;
+              const selectedConfig = ESP.ProjectConfiguration.store.get<string>(
+                ESP.ProjectConfiguration.SELECTED_CONFIG
+              );
+              ESP.ProjectConfiguration.store.clear(selectedConfig);
+              ESP.ProjectConfiguration.store.clear(
+                ESP.ProjectConfiguration.SELECTED_CONFIG
+              );
+            }
+            const currentIdfSetup = await getCurrentIdfSetup(
+              workspaceRoot,
+              false
+            );
+            if (statusBarItems["currentIdfVersion"]) {
+              statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
+                ? `$(${
+                    commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                  }) ESP-IDF v${currentIdfSetup.version}`
+                : `$(${
+                    commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
+                  }) ESP-IDF InvalidSetup`;
+            }
+            const coverageOptions = getCoverageOptions(workspaceRoot);
+            covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
+            break;
+          }
+        }
+        if (typeof workspaceRoot === undefined) {
           workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
           await getIdfTargetFromSdkconfig(
             workspaceRoot,
             statusBarItems["target"]
           );
-          if (statusBarItems && statusBarItems["port"]) {
-            statusBarItems["port"].text =
-              `$(${commandDictionary[CommandKeys.SelectSerialPort].iconId}) ` +
-              idfConf.readParameter("idf.port", workspaceRoot);
-          }
-          if (statusBarItems["projectConf"]) {
-            statusBarItems["projectConf"].dispose();
-            statusBarItems["projectConf"] = undefined;
-            const selectedConfig = ESP.ProjectConfiguration.store.get<string>(
-              ESP.ProjectConfiguration.SELECTED_CONFIG
-            );
-            ESP.ProjectConfiguration.store.clear(selectedConfig);
-            ESP.ProjectConfiguration.store.clear(
-              ESP.ProjectConfiguration.SELECTED_CONFIG
-            );
-          }
-          const currentIdfSetup = await getCurrentIdfSetup(
-            workspaceRoot,
-            false
-          );
-          if (statusBarItems["currentIdfVersion"]) {
-            statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
-              ? `$(${
-                  commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
-                }) ESP-IDF v${currentIdfSetup.version}`
-              : `$(${
-                  commandDictionary[CommandKeys.SelectCurrentIdfVersion].iconId
-                }) ESP-IDF InvalidSetup`;
-          }
           const coverageOptions = getCoverageOptions(workspaceRoot);
           covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
-          break;
         }
+        const buildDirPath = idfConf.readParameter(
+          "idf.buildPath",
+          workspaceRoot
+        ) as string;
+        const projectName = await getProjectName(buildDirPath);
+        const projectElfFile = `${path.join(buildDirPath, projectName)}.elf`;
+        const debugAdapterConfig = {
+          currentWorkspace: workspaceRoot,
+          elfFile: projectElfFile,
+        } as IDebugAdapterConfig;
+        debugAdapterManager.configureAdapter(debugAdapterConfig);
+        const openOCDConfig: IOpenOCDConfig = {
+          workspace: workspaceRoot,
+        } as IOpenOCDConfig;
+        openOCDManager.configureServer(openOCDConfig);
       }
-      if (typeof workspaceRoot === undefined) {
-        workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
-        await getIdfTargetFromSdkconfig(
-          workspaceRoot,
-          statusBarItems["target"]
-        );
-        const coverageOptions = getCoverageOptions(workspaceRoot);
-        covRenderer = new CoverageRenderer(workspaceRoot, coverageOptions);
-      }
-      const buildDirPath = idfConf.readParameter(
-        "idf.buildPath",
-        workspaceRoot
-      ) as string;
-      const projectName = await getProjectName(buildDirPath);
-      const projectElfFile = `${path.join(buildDirPath, projectName)}.elf`;
-      const debugAdapterConfig = {
-        currentWorkspace: workspaceRoot,
-        elfFile: projectElfFile,
-      } as IDebugAdapterConfig;
-      debugAdapterManager.configureAdapter(debugAdapterConfig);
-      const openOCDConfig: IOpenOCDConfig = {
-        workspace: workspaceRoot,
-      } as IOpenOCDConfig;
-      openOCDManager.configureServer(openOCDConfig);
-    }
-    ConfserverProcess.dispose();
-  });
+      ConfserverProcess.dispose();
+    })
+  )
 
   vscode.debug.onDidTerminateDebugSession((e) => {
     if (isOpenOCDLaunchedByDebug && !isDebugRestarted) {
@@ -3669,11 +3670,6 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   checkAndNotifyMissingCompileCommands();
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      checkAndNotifyMissingCompileCommands();
-    })
-  );
 }
 
 function checkAndNotifyMissingCompileCommands() {
@@ -3691,9 +3687,11 @@ function checkAndNotifyMissingCompileCommands() {
 
           if (!compileCommandsExists) {
             showInfoNotificationWithAction(
-              "compile_commands.json is missing. This may cause errors with the Microsoft C/C++ extension.",
-              "Generate compile_commands.json",
-              executeCommand("espIdf.idfReconfigureTask")
+              vscode.l10n.t(
+                "compile_commands.json is missing. This may cause errors with code analysis extensions."
+              ),
+              vscode.l10n.t("Generate compile_commands.json"),
+              () => vscode.commands.executeCommand("espIdf.idfReconfigureTask")
             );
           }
         }
@@ -3701,7 +3699,7 @@ function checkAndNotifyMissingCompileCommands() {
         const msg = error.message
           ? error.message
           : "Error checking for compile_commands.json file.";
-        Logger.error(msg, error);
+        Logger.error(msg, error, "extension checkAndNotifyMissingCompileCommands");
       }
     });
   }

--- a/src/logger/utils.ts
+++ b/src/logger/utils.ts
@@ -1,0 +1,33 @@
+import * as vscode from "vscode";
+
+type NotificationAction = () => Thenable<unknown> | Promise<void> | void;
+
+/**
+ * Shows an information notification with a button that executes a custom action when clicked.
+ * @param {string} infoMessage - The information message to display.
+ * @param {string} buttonLabel - The label for the button.
+ * @param {NotificationAction} action - The action to perform when the button is clicked.
+ * @returns {Promise<void>} - A promise that resolves when the notification is shown and handled.
+ */
+export async function showInfoNotificationWithAction(
+  infoMessage: string,
+  buttonLabel: string,
+  action: NotificationAction
+): Promise<void> {
+  const selectedOption = await vscode.window.showInformationMessage(
+    infoMessage,
+    buttonLabel
+  );
+
+  if (selectedOption === buttonLabel) {
+    await Promise.resolve(action());
+  }
+}
+
+// Helper functions for common actions
+export function executeCommand(
+  commandId: string,
+  ...args: any[]
+): NotificationAction {
+  return () => vscode.commands.executeCommand(commandId, ...args);
+}

--- a/src/logger/utils.ts
+++ b/src/logger/utils.ts
@@ -23,11 +23,3 @@ export async function showInfoNotificationWithAction(
     await Promise.resolve(action());
   }
 }
-
-// Helper functions for common actions
-export function executeCommand(
-  commandId: string,
-  ...args: any[]
-): NotificationAction {
-  return () => vscode.commands.executeCommand(commandId, ...args);
-}


### PR DESCRIPTION
## Description

This pull request adds a new feature to improve the user experience when working with ESP-IDF projects in VS Code, particularly when using the Microsoft C/C++ extension.

Key changes:
1. Implements a check for the existence of the `compile_commands.json` file when opening an ESP-IDF project.
2. If the file is missing, displays a notification to the user with an option to generate it.

For users using the Microsoft's C/C++  `compile_commands.json` file is crucial for proper IntelliSense functionality in ESP-IDF projects.

JIRA https://jira.espressif.com:8443/browse/VSC-1409

## Type of change

- New feature (breaking change which adds functionality)

## Steps to test this pull request

1. Open an ESP-IDF project that doesn't have a `compile_commands.json` file in its `build` directory.
2. Verify that a notification appears, informing about the missing file and offering to generate it.
3. Click the "Generate compile_commands.json" button and confirm that it triggers the `espIdf.idfReconfigureTask` command that generates the `compile_command.json` file in `build` folder of the project.

We should also test the following scenarios:

1. https://github.com/espressif/vscode-esp-idf-extension/pull/1252
2. https://github.com/espressif/vscode-esp-idf-extension/pull/1220
3. Building should be tested for esp-idf v4.3.6 as well (it was reported in the past by a customer that -S was not accepted, only -S=)

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.3
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
