### PR TITLE
Improve UX/UI for creating project from examples

### DIFF
--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -93,6 +93,8 @@ export class ExamplesPlanel {
                 canSelectFolders: true,
                 canSelectFiles: false,
                 canSelectMany: false,
+                openLabel: "Select Folder for New Project",
+                title: `Choose Project Location for ${message.name} example`,
               });
             }
             if (!selectedFolder) {
@@ -144,7 +146,9 @@ export class ExamplesPlanel {
                 example_detail: contentStr,
               });
             } catch (err) {
-              const notAvailable = vscode.l10n.t("No README.md available for this project.");
+              const notAvailable = vscode.l10n.t(
+                "No README.md available for this project."
+              );
               Logger.info(notAvailable);
               Logger.info(err);
               this.panel.webview.postMessage({

--- a/src/ui-test/project-test.ts
+++ b/src/ui-test/project-test.ts
@@ -44,7 +44,7 @@ describe("Example Create testing", async () => {
       By.id("create-button")
     );
     expect(await createProjectButton.getText()).has.string(
-      "Create project using example"
+      "Select location for creating"
     );
 
     const containerPath = resolve(__dirname, "..", "..", "testFiles");

--- a/src/views/examples/Examples.vue
+++ b/src/views/examples/Examples.vue
@@ -40,7 +40,7 @@ onMounted(() => {
           class="button"
           id="create-button"
         >
-          Create project using example {{ selectedExample.name }}
+          Select location for creating {{ selectedExample.name }} project
         </button>
       </div>
       <div


### PR DESCRIPTION
## Description

Improved UX/UI for creating project from examples by:

- Changing the name of button from example projects to:
![image](https://github.com/user-attachments/assets/8d014129-92ea-4534-8a72-5f30176ff3c4)

- Make use of VS Code API to use window title and window button custom names
![image](https://github.com/user-attachments/assets/fa8a8266-31f0-45ec-9c90-ca35bbe5a5f3)

JIRA: https://jira.espressif.com:8443/browse/VSC-1413

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

1. Use `Command Palette` --> ` ESP-IDF: Show Examples Projects`
2. After choosing an example you should see the button name as shown in the first screenshot
3. When pressing the button the newly opened window should look like the second screenshot on windows and similar on Mac/Linux (having a custom title and the button for choosing the folder should have as well custom text)

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.3
* OS (Windows,Linux and macOS): All

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
