### PR TITLE
Fix for pwsh users

### DIFF
--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -46,6 +46,7 @@ export class IDFMonitor {
     IDFMonitor.config = config;
   }
 
+
   static async start() {
     const modifiedEnv = await appendIdfAndToolsToPath(this.config.workspaceFolder);
     if (!IDFMonitor.terminal) {
@@ -122,8 +123,10 @@ export class IDFMonitor {
     const quotedIdfPath = quotePath(modifiedEnv.IDF_PATH);
 
     if (shellType.includes("powershell") || shellType.includes("pwsh")) {
-      this.terminal.sendText(`& ${envSetCmd} IDF_PATH=${quotedIdfPath}`);
-      this.terminal.sendText(`& ${args.join(" ")}`);
+      this.terminal.sendText(`$env:IDF_PATH = ${quotedIdfPath};`);
+      // For pwsh users on Linux, we need to add delay between commands
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      this.terminal.sendText(` & ${args.join(" ")}\r`);
     } else if (shellType.includes("cmd")) {
       this.terminal.sendText(`${envSetCmd} IDF_PATH=${modifiedEnv.IDF_PATH}`);
       this.terminal.sendText(args.join(" "));

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -72,7 +72,7 @@ export class IDFMonitor {
 
     // Function to quote paths for PowerShell and correctly handle spaces for Bash
     const quotePath = (path) => {
-      if (shellType.includes("powershell")) {
+      if (shellType.includes("powershell") || shellType.includes("pwsh")) {
         return `'${path.replace(/'/g, "''")}'`;
       } else if (shellType.includes("cmd")) {
         return `"${path}"`;
@@ -121,7 +121,7 @@ export class IDFMonitor {
     const envSetCmd = process.platform === "win32" ? "set" : "export";
     const quotedIdfPath = quotePath(modifiedEnv.IDF_PATH);
 
-    if (shellType.includes("powershell")) {
+    if (shellType.includes("powershell") || shellType.includes("pwsh")) {
       this.terminal.sendText(`& ${envSetCmd} IDF_PATH=${quotedIdfPath}`);
       this.terminal.sendText(`& ${args.join(" ")}`);
     } else if (shellType.includes("cmd")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1286,7 +1286,7 @@ export function getUserShell() {
   const shell = vscode.env.shell;
 
   // list of shells to check
-  const shells = ["powershell", "cmd", "bash", "zsh"];
+  const shells = ["powershell", "cmd", "bash", "zsh", "pwsh"];
 
   // if user's shell is in the list, return it
   for (let i = 0; i < shells.length; i++) {


### PR DESCRIPTION
## Description

Fixes monitoring for users that have Powershell executable as pwsh.exe

Fixes #1275

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Download the installer:
Go to the official PowerShell GitHub repository release page: https://github.com/PowerShell/PowerShell/releases
Look for the latest stable release and download the appropriate installer for your system (e.g., PowerShell-7.3.x-win-x64.msi for 64-bit Windows).
2. Run the installer:
Double-click the downloaded MSI file and follow the installation wizard.
3. Verify the installation:
Open a new command prompt or Windows PowerShell window and type: `pwsh`
4. Set `pwsh` as default terminal in vscode and to build, flash monitor a project on an esp board.
5. Everything should work fine.

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
