### PR TITLE
debugConfProvider: add number of watchpoints for esp32p4

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -83,7 +83,8 @@ export class CDTDebugConfigurationProvider
           | "esp32c2"
           | "esp32c3"
           | "esp32c6"
-          | "esp32h2";
+          | "esp32h2"
+          | "esp32p4";
         // Mapping of idfTarget to corresponding CPU watchpoint numbers
         const idfTargetWatchpointMap: Record<IdfTarget, number> = {
           esp32: 2,
@@ -93,6 +94,7 @@ export class CDTDebugConfigurationProvider
           esp32c3: 8,
           esp32c6: 4,
           esp32h2: 4,
+          esp32p4: 3,
         };
         config.initCommands = config.initCommands.map((cmd: string) =>
           cmd.replace(


### PR DESCRIPTION
## Description

Should fix error reported when trying to start a debug session:
```
set remote hardware-watchpoint-limit undefined
No symbol "undefined" in current context.
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Set up project for ESP32-P4 with built-in JTAG debugging
2. Start OpenOCD server
3. Start debugging

- Expected behaviour:
- It should start the debug session


## How has this been tested?

~~I haven't figured out how to build/test a development copy of the extension yet, so it hasn't been tested~~

I have figured out how to build/test the extension and can confirm this resolves the issue and I can debug on esp32p4