### PR TITLE
[VSC-1473/1495] update dockerfile and qemu options

### DIFF
--- a/docs_espressif/en/additionalfeatures/docker-container.rst
+++ b/docs_espressif/en/additionalfeatures/docker-container.rst
@@ -123,11 +123,11 @@ for a list of USB serial devices.
 .. note::
   this command needs to be used only one time,unless the computer has restarted. **1-1** is the device's bus id ``<BUSID>`` I would like to bind.
 
-5. After binding, please attach the specified device to WSL with this command in the Powershell command prompt.
+5. After binding, please attach the specified device to WSL with this command in the Powershell command prompt. The ``--auto-attach`` parameter allows the device to be visible in the container after unplug and plug.
 
 .. code-block::
 
-  usbipd attach --wsl --busid <BUSID>
+  usbipd attach --wsl --busid <BUSID> --auto-attach
 
 6. At last, let us check if it works well on both side and type this command on WSL side.
 
@@ -230,6 +230,9 @@ Create a Container
 .. image:: ../../../media/tutorials/using_docker_container/create_container.gif
 
 At this moment, you can start to use the ``Blink`` example project for building, flashing, monitoring, debugging, etc.
+
+.. warning::
+  * In order to have access to the serial port from the Docker container, make sure you have attached the device with ``usbipd attach --wsl --busid <BUSID> --auto-attach`` **BEFORE** opening the folder in container in VS Code otherwise it won't be visible. If you want to be able to plug and unplug the device and still see it in the docker container don't forget the  ``--auto-attach`` usbipd parameter.
 
 3. Here taking the esp32-c3 as an example, users only need to change the target device from ``esp32`` to ``esp32-c3``, as below:
 

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -62,6 +62,8 @@
   "{destFolder} already exists.": "{destFolder} ya existe.",
   "ESP-IDF Project has been imported": "El proyecto ESP-IDF ha sido importado.",
   "Merging binaries for flashing": "Fusionar binarios para flashear",
+  "ESP-IDF: Starting ESP-IDF QEMU Debug": "ESP-IDF: Iniciando la depuración QEMU de ESP-IDF",
+  "Error launching QEMU debugging": "Error al iniciar la depuración de QEMU",
   "Select a partition to use": "Seleccione una partición para usar",
   "Enter custom partition table offset": "Ingrese el desplazamiento de la tabla de particiones personalizada",
   "Flash binary to this partition": "Flash binario a esta partición",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -62,6 +62,8 @@
   "{destFolder} already exists.": "{destFolder} já existe.",
   "ESP-IDF Project has been imported": "O projeto ESP-IDF foi importado",
   "Merging binaries for flashing": "Mesclando binários para piscar",
+  "ESP-IDF: Starting ESP-IDF QEMU Debug": "ESP-IDF: Iniciando a depuração ESP-IDF QEMU",
+  "Error launching QEMU debugging": "Erro ao iniciar a depuração do QEMU",
   "Select a partition to use": "Selecione uma partição para usar",
   "Enter custom partition table offset": "Insira o deslocamento da tabela de partição personalizada",
   "Flash binary to this partition": "Flash binário para esta partição",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -62,6 +62,8 @@
   "{destFolder} already exists.": "{destFolder} уже существует.",
   "ESP-IDF Project has been imported": "Проект ESP-IDF импортирован.",
   "Merging binaries for flashing": "Объединение бинарников для перепрошивки",
+  "ESP-IDF: Starting ESP-IDF QEMU Debug": "ESP-IDF: запуск отладки ESP-IDF QEMU",
+  "Error launching QEMU debugging": "Ошибка запуска отладки QEMU",
   "Select a partition to use": "Выберите раздел для использования",
   "Enter custom partition table offset": "Введите пользовательское смещение таблицы разделов",
   "Flash binary to this partition": "Записать двоичный файл в этот раздел",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -62,6 +62,8 @@
   "{destFolder} already exists.": "{destFolder} 已存在。",
   "ESP-IDF Project has been imported": "ESP-IDF 项目已导入",
   "Merging binaries for flashing": "合并二进制文件以进行闪烁",
+  "ESP-IDF: Starting ESP-IDF QEMU Debug": "ESP-IDF：启动 ESP-IDF QEMU 调试",
+  "Error launching QEMU debugging": "启动 QEMU 调试时出错",
   "Select a partition to use": "选择要使用的分区",
   "Enter custom partition table offset": "输入自定义分区表偏移量",
   "Flash binary to this partition": "将二进制文件烧录到该分区",

--- a/src/build/buildCmd.ts
+++ b/src/build/buildCmd.ts
@@ -86,6 +86,15 @@ export async function buildCommand(
         await TaskManager.runTasks();
       }
     }
+    const buildDirPath = readParameter(
+      "idf.buildPath",
+      workspace
+    ) as string;
+    const qemuBinPath = join(buildDirPath, "merged_qemu.bin");
+    const qemuBinExists = await pathExists(qemuBinPath);
+    if (qemuBinExists) {
+      await vscode.workspace.fs.delete(vscode.Uri.file(qemuBinPath));
+    }
     if (!cancelToken.isCancellationRequested) {
       updateIdfComponentsTree(workspace);
       Logger.infoNotify("Build Successfully");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -356,6 +356,7 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
       UpdateCmakeLists.updateSrcsInCmakeLists(e.fsPath, srcOp.other);
     }
+    await binTimestampEventFunc(e);
   });
   context.subscriptions.push(srcWatchOnChangeDisposable);
 
@@ -374,7 +375,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const qemuBinPath = path.join(buildDirPath, "merged_qemu.bin");
     const qemuBinExists = await pathExists(qemuBinPath);
     if (qemuBinExists) {
-      vscode.workspace.fs.delete(vscode.Uri.file(qemuBinPath));
+      await vscode.workspace.fs.delete(vscode.Uri.file(qemuBinPath));
     }
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2468,7 +2468,7 @@ export async function activate(context: vscode.ExtensionContext) {
         {
           cancellable: true,
           location: ProgressLocation,
-          title: "ESP-IDF: Starting ESP-IDF QEMU Debug",
+          title: vscode.l10n.t("ESP-IDF: Starting ESP-IDF QEMU Debug"),
         },
         async (
           progress: vscode.Progress<{ message: string; increment: number }>,
@@ -2523,7 +2523,7 @@ export async function activate(context: vscode.ExtensionContext) {
           } catch (error) {
             const msg = error.message
               ? error.message
-              : "Error launching QEMU debugging";
+              : vscode.l10n.t("Error launching QEMU debugging");
             Logger.errorNotify(msg, error, "extension qemu debug");
           }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -360,7 +360,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(srcWatchOnChangeDisposable);
 
   const buildWatcher = vscode.workspace.createFileSystemWatcher(
-    ".bin_timestamp",
+    "**/.bin_timestamp",
     true,
     false,
     true

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -361,12 +361,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const buildWatcher = vscode.workspace.createFileSystemWatcher(
     "**/.bin_timestamp",
-    true,
+    false,
     false,
     true
   );
 
-  const buildWatcherDisposable = buildWatcher.onDidChange(async (e) => {
+  const binTimestampEventFunc = async (e: vscode.Uri) => {
     const buildDirPath = idfConf.readParameter(
       "idf.buildPath",
       workspaceRoot
@@ -376,8 +376,16 @@ export async function activate(context: vscode.ExtensionContext) {
     if (qemuBinExists) {
       vscode.workspace.fs.delete(vscode.Uri.file(qemuBinPath));
     }
-  });
+  };
+
+  const buildWatcherDisposable = buildWatcher.onDidChange(
+    binTimestampEventFunc
+  );
   context.subscriptions.push(buildWatcherDisposable);
+  const buildWatcherCreateDisposable = buildWatcher.onDidCreate(
+    binTimestampEventFunc
+  );
+  context.subscriptions.push(buildWatcherCreateDisposable);
 
   vscode.workspace.onDidChangeWorkspaceFolders(async (e) => {
     if (PreCheck.isWorkspaceFolderOpen()) {

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -114,7 +114,7 @@ export class QemuManager extends EventEmitter {
         "-machine",
         idfTarget,
         "-drive",
-        `file=${qemuFile.fsPath},if=mtd,format=raw`,
+        `file='${qemuFile.fsPath}',if=mtd,format=raw`,
       ];
     } else {
       return [

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -25,22 +25,20 @@ import {
   TreeItemCheckboxState,
   Uri,
   window,
-  workspace,
 } from "vscode";
 import { ESP } from "../config";
 import { readParameter } from "../idfConfiguration";
 import { Logger } from "../logger/logger";
-import { appendIdfAndToolsToPath, isBinInPath, PreCheck } from "../utils";
 import { statusBarItems } from "../statusBar";
 import {
   CommandKeys,
   createCommandDictionary,
 } from "../cmdTreeView/cmdStore";
+import { appendIdfAndToolsToPath, isBinInPath } from "../utils";
 
-export interface IQemuOptions {
-  launchArgs: string[];
-  tcpPort: string;
-  workspaceFolder: Uri;
+export enum QemuLaunchMode {
+  Debug,
+  Monitor,
 }
 
 export class QemuManager extends EventEmitter {
@@ -51,14 +49,12 @@ export class QemuManager extends EventEmitter {
     return QemuManager.instance;
   }
   private static instance: QemuManager;
-  private execString = "qemu-system-xtensa";
   private qemuTerminal: Terminal;
-  private options: IQemuOptions;
   private _statusBarItem: StatusBarItem;
 
   private constructor() {
     super();
-    this.configureWithDefValues();
+    this.registerQemuStatusBarItem();
   }
 
   public statusBarItem(): StatusBarItem {
@@ -71,30 +67,20 @@ export class QemuManager extends EventEmitter {
   }
 
   public async commandHandler() {
-    const pickItems = [];
-    if (!QemuManager.instance.isRunning()) {
-      pickItems.push({
-        label: "Start QEMU",
-        description: "",
-      });
-    } else {
-      pickItems.push({
+    const pickItems = [
+      {
         label: "Stop QEMU",
         description: "",
-      });
-    }
+      },
+    ];
     const selectedOption = await window.showQuickPick(pickItems);
     if (!selectedOption) {
       return;
     }
-
     try {
       switch (selectedOption.label) {
-        case "Start QEMU":
-          await QemuManager.instance.start();
-          break;
         case "Stop QEMU":
-          await QemuManager.instance.stop();
+          QemuManager.instance.stop();
           break;
         default:
           break;
@@ -105,103 +91,91 @@ export class QemuManager extends EventEmitter {
     }
   }
 
-  public configure(config: IQemuOptions) {
-    if (!this.options) {
-      this.options = {} as IQemuOptions;
-    }
-    if (config.launchArgs) {
-      this.options.launchArgs = config.launchArgs;
-    }
-    if (config.tcpPort) {
-      this.options.tcpPort = config.tcpPort;
-    }
-    if (config.workspaceFolder) {
-      this.options.workspaceFolder = config.workspaceFolder;
-    }
-    this.registerQemuStatusBarItem();
-  }
+  public getLaunchArguments(
+    mode: QemuLaunchMode,
+    idfTarget: string,
+    workspaceFolder: Uri
+  ) {
+    const buildPath = readParameter(
+      "idf.buildPath",
+      workspaceFolder
+    ) as string;
+    const qemuFile = Uri.joinPath(Uri.file(buildPath), "merged_qemu.bin");
+    const qemuTcpPort = readParameter(
+      "idf.qemuTcpPort",
+      workspaceFolder
+    ) as string;
 
-  public configureWithDefValues() {
-    let workspaceFolder: Uri;
-    if (PreCheck.isWorkspaceFolderOpen()) {
-      workspaceFolder = workspace.workspaceFolders[0].uri;
-    }
-    const defOptions = {
-      launchArgs: [
+    if (mode === QemuLaunchMode.Debug) {
+      return [
         "-nographic",
         "-s",
         "-S",
         "-machine",
-        "esp32",
+        idfTarget,
         "-drive",
-        "file=build/merged_qemu.bin,if=mtd,format=raw",
-      ],
-      tcpPort: readParameter("idf.qemuTcpPort", workspaceFolder),
-      workspaceFolder,
-    } as IQemuOptions;
-    this.configure(defOptions);
+        `file=${qemuFile.fsPath},if=mtd,format=raw`,
+      ];
+    } else {
+      return [
+        "-nographic",
+        "-machine",
+        idfTarget,
+        "-drive",
+        `file=${qemuFile.fsPath},if=mtd,format=raw`,
+        "-monitor stdio",
+        `-serial tcp::${qemuTcpPort},server,nowait`,
+      ];
+    }
   }
 
   public isRunning(): boolean {
     return !!this.qemuTerminal;
   }
 
-  public async promptToQemuLaunch(): Promise<boolean> {
-    if (QemuManager.instance && QemuManager.instance.isRunning()) {
-      return true;
-    }
-    const launchQemuResponse = await window.showInformationMessage(
-      "QEMU is not running, Do you want to execute it?",
-      { modal: true },
-      { title: "Yes" },
-      { title: "Cancel", isCloseAffordance: true }
-    );
-    if (launchQemuResponse && launchQemuResponse.title === "Yes") {
-      await QemuManager.init().start();
-      return true;
-    }
-    return false;
-  }
-
-  public async start() {
+  public async start(mode: QemuLaunchMode, workspaceFolder: Uri) {
     if (this.isRunning()) {
       return;
     }
     const modifiedEnv = await appendIdfAndToolsToPath(
-      this.options.workspaceFolder
+      workspaceFolder
     );
+    const qemuExecutable =
+      modifiedEnv.IDF_TARGET === "esp32"
+        ? "qemu-system-xtensa"
+        : modifiedEnv.IDF_TARGET === "esp32c3"
+        ? "qemu-system-riscv32"
+        : "";
+    if (!qemuExecutable) {
+      throw new Error(
+        `Current IDF_TARGET ${modifiedEnv.IDF_TARGET} is not supported in Espressif QEMU. Only esp32 or esp32c3`
+      );
+    }
     const isQemuBinInPath = await isBinInPath(
-      this.execString,
-      this.options.workspaceFolder.fsPath,
+      qemuExecutable,
+      workspaceFolder.fsPath,
       modifiedEnv
     );
     if (!isQemuBinInPath) {
-      throw new Error("qemu-system-xtensa is not in PATH or access is denied");
+      throw new Error(
+        `${qemuExecutable} is not found in PATH or access is denied`
+      );
     }
-    if (typeof this.options === "undefined") {
-      throw new Error("No QEMU options found.");
-    }
+
+    const qemuArgs: string[] = this.getLaunchArguments(mode, modifiedEnv.IDF_TARGET, workspaceFolder);
     if (
-      typeof this.options.launchArgs === "undefined" ||
-      this.options.launchArgs.length < 1
+      typeof qemuArgs === "undefined" ||
+      qemuArgs.length < 1
     ) {
       throw new Error("No QEMU launch arguments found.");
     }
-    if (typeof this.options.tcpPort === "undefined") {
-      throw new Error("No QEMU tcp port for serial port was found.");
-    }
-
-    const qemuArgs: string[] = [];
-    this.options.launchArgs.forEach((arg) => {
-      qemuArgs.push(arg);
-    });
 
     if (typeof this.qemuTerminal === "undefined") {
       this.qemuTerminal = window.createTerminal({
         name: "ESP-IDF QEMU",
         env: modifiedEnv,
         cwd:
-          this.options.workspaceFolder.fsPath ||
+          workspaceFolder.fsPath ||
           modifiedEnv.IDF_PATH ||
           process.cwd(),
         shellArgs: [],
@@ -214,7 +188,7 @@ export class QemuManager extends EventEmitter {
         }
       });
     }
-    this.qemuTerminal.sendText(`${this.execString} ${qemuArgs.join(" ")}`);
+    this.qemuTerminal.sendText(`${qemuExecutable} ${qemuArgs.join(" ")}`);
     this.qemuTerminal.show(true);
     this.updateStatusText("❇️ ESP-IDF: QEMU Server (Running)");
   }

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -122,7 +122,7 @@ export class QemuManager extends EventEmitter {
         "-machine",
         idfTarget,
         "-drive",
-        `file=${qemuFile.fsPath},if=mtd,format=raw`,
+        `file='${qemuFile.fsPath}',if=mtd,format=raw`,
         "-monitor stdio",
         `-serial tcp::${qemuTcpPort},server,nowait`,
       ];

--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -1,40 +1,16 @@
-FROM espressif/idf
+ARG DOCKER_TAG=latest
+FROM espressif/idf:${DOCKER_TAG}
 
-ARG DEBIAN_FRONTEND=nointeractive
 ARG CONTAINER_USER=esp
 ARG USER_UID=1050
 ARG USER_GID=$USER_UID
 
-RUN apt-get update \
-  && apt install -y -q \
-  cmake \
-  git \
-  libglib2.0-0 \
-  libnuma1 \
-  libpixman-1-0 \
-  && rm -rf /var/lib/apt/lists/*
-
-# QEMU
-ENV QEMU_REL=esp_develop_8.2.0_20240122
-ENV QEMU_SHA256=e7c72ef5705ad1444d391711088c8717fc89f42e9bf6d1487f9c2a326b8cfa83
-ENV QEMU_DIST=qemu-xtensa-softmmu-${QEMU_REL}-x86_64-linux-gnu.tar.xz
-ENV QEMU_URL=https://github.com/espressif/qemu/releases/download/esp-develop-8.2.0-20240122/${QEMU_DIST}
-
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-
-RUN wget --no-verbose ${QEMU_URL} \
-  && echo "${QEMU_SHA256} *${QEMU_DIST}" | sha256sum --check --strict - \
-  && tar -xf $QEMU_DIST -C /opt \
-  && rm ${QEMU_DIST}
-
-ENV PATH=/opt/qemu/bin:${PATH}
 
 RUN groupadd --gid $USER_GID $CONTAINER_USER \
   && adduser --uid $USER_UID --gid $USER_GID --disabled-password --gecos "" ${CONTAINER_USER} \
   && usermod -a -G root $CONTAINER_USER && usermod -a -G dialout $CONTAINER_USER
-
-RUN chmod -R 775 /opt/esp/python_env/
 
 USER ${CONTAINER_USER}
 ENV USER=${CONTAINER_USER}

--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ ARG USER_GID=$USER_UID
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+RUN apt-get update -y && apt-get install udev -y
+
 RUN groupadd --gid $USER_GID $CONTAINER_USER \
   && adduser --uid $USER_UID --gid $USER_GID --disabled-password --gecos "" ${CONTAINER_USER} \
   && usermod -a -G root $CONTAINER_USER && usermod -a -G dialout $CONTAINER_USER

--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -1,22 +1,10 @@
 ARG DOCKER_TAG=latest
 FROM espressif/idf:${DOCKER_TAG}
 
-ARG CONTAINER_USER=esp
-ARG USER_UID=1050
-ARG USER_GID=$USER_UID
-
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 RUN apt-get update -y && apt-get install udev -y
-
-RUN groupadd --gid $USER_GID $CONTAINER_USER \
-  && adduser --uid $USER_UID --gid $USER_GID --disabled-password --gecos "" ${CONTAINER_USER} \
-  && usermod -a -G root $CONTAINER_USER && usermod -a -G dialout $CONTAINER_USER
-
-USER ${CONTAINER_USER}
-ENV USER=${CONTAINER_USER}
-WORKDIR /home/${CONTAINER_USER}
 
 RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
 

--- a/templates/.devcontainer/devcontainer.json
+++ b/templates/.devcontainer/devcontainer.json
@@ -15,18 +15,6 @@
 				"espressif.esp-idf-extension",
 				"espressif.esp-idf-web"
 			]
-		},
-		"codespaces": {
-			"settings": {
-				"terminal.integrated.defaultProfile.linux": "bash",
-				"idf.espIdfPath": "/opt/esp/idf",
-				"idf.toolsPath": "/opt/esp",
-				"idf.gitPath": "/usr/bin/git"
-			},
-			"extensions": [
-				"espressif.esp-idf-extension",
-				"espressif.esp-idf-web"
-			]
 		}
 	},
 	"runArgs": ["--privileged"]


### PR DESCRIPTION
## Description

Update Dockerfile and QEMU options.:

- Remove adding QEMU in Dockerfile and using the one from ESP-IDF tools. 
- Adding QEMU options to support both esp32 and esp32c3 as target.
- Add `${idf.buildPath}/merged-qemu.bin` delete when `${idf.buildPath}/.bin_timestamp` changes to trigger rebuilding the merged QEMU bin image.

Fixes #1281
Fixes #1320

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Launch QEMU Debug Session" or `ESP-IDF: Monitor QEMU Device` should work for esp32 or esp32c3 and show error for other IDF_TARGET. 
2. Change the source code. The `merged-qemu.bin` should be deleted.
4. Click on "ESP-IDF: Launch QEMU Debug Session" or `ESP-IDF: Monitor QEMU Device` and the new image should be generated and used.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing in a Dev Container in Visual Studio Code running previous code on ESP-IDF project like the blink example.

**Test Configuration**: Using VSCode Devcontainer Docker container in either Windows or MacOS
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
