### PR TITLE
use static monitor terminal

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -30,6 +30,7 @@ import { verifyAppBinary } from "../espIdf/debugAdapter/verifyApp";
 import { OpenOCDManager } from "../espIdf/openOcd/openOcdManager";
 import { Logger } from "../logger/logger";
 import { getToolchainPath } from "../utils";
+import { createNewIdfMonitor } from "../espIdf/monitor/command";
 
 export class CDTDebugConfigurationProvider
   implements DebugConfigurationProvider {
@@ -123,6 +124,17 @@ export class CDTDebugConfigurationProvider
             `Current app binary is different from your project. Flash first.`
           );
         }
+      }
+      const useMonitorWithDebug = readParameter(
+        "idf.launchMonitorOnDebugSession",
+        folder
+      );
+      if (
+        config.sessionID !== "core-dump.debug.session.ws" &&
+        config.sessionID !== "gdbstub.debug.session.ws" &&
+        useMonitorWithDebug
+      ) {
+        await createNewIdfMonitor(folder.uri, true);
       }
       const openOCDManager = OpenOCDManager.init();
       if (

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 10th June 2020 4:53:23 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,27 +39,30 @@ export interface MonitorConfig {
 }
 
 export class IDFMonitor {
-  private config: MonitorConfig;
-  private terminal: Terminal;
-  constructor(config: MonitorConfig) {
-    this.config = config;
+  public static config: MonitorConfig;
+  public static terminal: Terminal;
+
+  static updateConfiguration(config: MonitorConfig) {
+    IDFMonitor.config = config;
   }
 
-  start() {
+  static start() {
     const modifiedEnv = appendIdfAndToolsToPath(this.config.workspaceFolder);
-    this.terminal = window.createTerminal({
-      name: `ESP-IDF Monitor ${this.config.wsPort ? "(--ws enabled)" : ""}`,
-      env: modifiedEnv,
-      cwd:
-        this.config.workspaceFolder.fsPath ||
-        modifiedEnv.IDF_PATH ||
-        process.cwd(),
-      strictEnv: true,
-      shellArgs: this.config.shellExecutableArgs || [],
-      shellPath: this.config.shellPath || env.shell,
-    });
-    this.terminal.show();
-    this.terminal.dispose = this.dispose.bind(this);
+    if (!IDFMonitor.terminal) {
+      IDFMonitor.terminal = window.createTerminal({
+        name: `ESP-IDF Monitor ${this.config.wsPort ? "(--ws enabled)" : ""}`,
+        env: modifiedEnv,
+        cwd:
+          this.config.workspaceFolder.fsPath ||
+          modifiedEnv.IDF_PATH ||
+          process.cwd(),
+        strictEnv: true,
+        shellArgs: this.config.shellExecutableArgs || [],
+        shellPath: this.config.shellPath || env.shell,
+      });
+    }
+    IDFMonitor.terminal.show();
+    IDFMonitor.terminal.dispose = this.dispose.bind(this);
     const shellType = getUserShell();
 
     // Function to quote paths for PowerShell and correctly handle spaces for Bash
@@ -126,7 +129,8 @@ export class IDFMonitor {
 
     return this.terminal;
   }
-  async dispose() {
+
+  static async dispose() {
     try {
       this.terminal.sendText(ESP.CTRL_RBRACKET);
       this.terminal.sendText(`exit`);

--- a/src/espIdf/monitor/index.ts
+++ b/src/espIdf/monitor/index.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 10th June 2020 4:53:23 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,9 +60,14 @@ export class IDFMonitor {
         shellArgs: this.config.shellExecutableArgs || [],
         shellPath: this.config.shellPath || env.shell,
       });
+
+      window.onDidCloseTerminal((e) => {
+        if (e.processId === IDFMonitor.terminal.processId) {
+          IDFMonitor.terminal = undefined;
+        }
+      });
     }
     IDFMonitor.terminal.show();
-    IDFMonitor.terminal.dispose = this.dispose.bind(this);
     const shellType = getUserShell();
 
     // Function to quote paths for PowerShell and correctly handle spaces for Bash

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,6 @@ const openOCDManager = OpenOCDManager.init();
 let isOpenOCDLaunchedByDebug: boolean = false;
 let isDebugRestarted: boolean = false;
 let debugAdapterManager: DebugAdapterManager;
-let isMonitorLaunchedByDebug: boolean = false;
 
 // QEMU
 const qemuManager = QemuManager.init();
@@ -197,9 +196,6 @@ let eFuseExplorer: ESPEFuseTreeDataProvider;
 // Peripheral Tree Data Provider
 let peripheralTreeProvider: PeripheralTreeView;
 let peripheralTreeView: vscode.TreeView<PeripheralBaseNode>;
-
-// Process to execute build, debug or monitor
-let monitorTerminal: vscode.Terminal;
 
 // Websocket Server
 let wsServer: WSServer;
@@ -413,10 +409,6 @@ export async function activate(context: vscode.ExtensionContext) {
       openOCDManager.stop();
     }
     debugAdapterManager.stop();
-    if (isMonitorLaunchedByDebug) {
-      isMonitorLaunchedByDebug = false;
-      monitorTerminal.dispose();
-    }
   });
 
   const sdkconfigWatcher = vscode.workspace.createFileSystemWatcher(
@@ -625,8 +617,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.eraseFlash", async () => {
     PreCheck.perform([webIdeCheck, openFolderCheck], async () => {
-      if (monitorTerminal) {
-        monitorTerminal.sendText(ESP.CTRL_RBRACKET);
+      if (IDFMonitor.terminal) {
+        IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
       }
       const pythonBinPath = idfConf.readParameter(
         "idf.pythonBinPath",
@@ -1201,8 +1193,7 @@ export async function activate(context: vscode.ExtensionContext) {
           session.configuration.sessionID !== "core-dump.debug.session.ws" &&
           useMonitorWithDebug
         ) {
-          isMonitorLaunchedByDebug = true;
-          await createIdfMonitor(true);
+          await createNewIdfMonitor(workspaceRoot, true);
         }
         if (
           launchMode === "auto" &&
@@ -2388,9 +2379,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.qemuDebug", () => {
     PreCheck.perform([openFolderCheck], async () => {
-      if (monitorTerminal) {
-        monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-        monitorTerminal.sendText(`exit`);
+      if (IDFMonitor.terminal) {
+        IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
       }
       const buildDirPath = idfConf.readParameter(
         "idf.buildPath",
@@ -3023,7 +3013,7 @@ export async function activate(context: vscode.ExtensionContext) {
           "idf.customTerminalExecutableArgs",
           workspaceRoot
         ) as string[];
-        const monitor = new IDFMonitor({
+        IDFMonitor.updateConfiguration({
           port,
           baudRate: sdkMonitorBaudRate,
           pythonBinPath,
@@ -3046,8 +3036,12 @@ export async function activate(context: vscode.ExtensionContext) {
         wsServer = new WSServer(wsPort);
         wsServer.start();
         wsServer
-          .on("started", () => {
-            monitor.start();
+          .on("started", async () => {
+            if (IDFMonitor.terminal) {
+              IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
+              await utils.sleep(500);
+            }
+            IDFMonitor.start();
           })
           .on("core-dump-detected", async (resp) => {
             const notificationMode = idfConf.readParameter(
@@ -3118,7 +3112,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         "core-dump.debug.session.ws"
                       ) {
                         wsServer.done();
-                        monitor.dispose();
+                        IDFMonitor.dispose();
                         wsServer.close();
                       }
                     });
@@ -3160,7 +3154,7 @@ export async function activate(context: vscode.ExtensionContext) {
                   session.configuration.sessionID === "gdbstub.debug.session.ws"
                 ) {
                   wsServer.done();
-                  monitor.dispose();
+                  IDFMonitor.dispose();
                   wsServer.close();
                 }
               });
@@ -3929,11 +3923,7 @@ const flash = (
   });
 };
 
-function createQemuMonitor(
-  noReset: boolean = false,
-  enableTimestamps: boolean = false,
-  customTimestampFormat: string = ""
-) {
+function createQemuMonitor() {
   PreCheck.perform([openFolderCheck], async () => {
     const isQemuLaunched = qemuManager.isRunning();
     if (isQemuLaunched) {
@@ -3956,18 +3946,15 @@ function createQemuMonitor(
     } as IQemuOptions);
     qemuManager.start();
     const serialPort = `socket://localhost:${qemuTcpPort}`;
-    const idfMonitor = await createNewIdfMonitor(
-      workspaceRoot,
-      noReset,
-      enableTimestamps,
-      customTimestampFormat,
-      serialPort
-    );
-    if (monitorTerminal) {
-      monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-      monitorTerminal.sendText(`exit`);
+    if (IDFMonitor.terminal) {
+      IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
     }
-    monitorTerminal = idfMonitor.start();
+    const noReset = idfConf.readParameter(
+      "idf.monitorNoReset",
+      workspaceRoot
+    ) as boolean;
+    await createNewIdfMonitor(workspaceRoot, noReset, serialPort);
+    IDFMonitor.start();
   });
 }
 
@@ -4015,9 +4002,8 @@ const buildFlashAndMonitor = async (runMonitor: boolean = true) => {
             message: "Launching monitor...",
             increment: 10,
           });
-          if (monitorTerminal) {
-            monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-            monitorTerminal.sendText(`exit`);
+          if (IDFMonitor.terminal) {
+            IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
           }
           createMonitor();
         }
@@ -4066,8 +4052,8 @@ async function startFlashing(
     "idf.flashBaudRate",
     workspaceRoot
   );
-  if (monitorTerminal) {
-    monitorTerminal.sendText(ESP.CTRL_RBRACKET);
+  if (IDFMonitor.terminal) {
+    IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
   }
   const canFlash = await verifyCanFlash(flashBaudRate, port, workspaceRoot);
   if (!canFlash) {
@@ -4132,54 +4118,14 @@ function createMonitor() {
       "idf.monitorNoReset",
       workspaceRoot
     ) as boolean;
-    const enableTimestamps = idfConf.readParameter(
-      "idf.monitorEnableTimestamps",
-      workspaceRoot
-    ) as boolean;
-    const customTimestampFormat = idfConf.readParameter(
-      "idf.monitorCustomTimestampFormat",
-      workspaceRoot
-    ) as string;
-    await createIdfMonitor(noReset, enableTimestamps, customTimestampFormat);
+    await createNewIdfMonitor(workspaceRoot, noReset);
   });
-}
-
-async function createIdfMonitor(
-  noReset: boolean = false,
-  enableTimestamps: boolean = false,
-  customTimestampFormat: string = ""
-) {
-  const idfMonitor = await createNewIdfMonitor(
-    workspaceRoot,
-    noReset,
-    enableTimestamps,
-    customTimestampFormat
-  );
-  if (monitorTerminal) {
-    monitorTerminal.sendText(ESP.CTRL_RBRACKET);
-    monitorTerminal.sendText(`exit`);
-  }
-  monitorTerminal = idfMonitor.start();
-  if (noReset) {
-    const idfPath = idfConf.readParameter(
-      "idf.espIdfPath",
-      workspaceRoot
-    ) as string;
-    const idfVersion = await utils.getEspIdfFromCMake(idfPath);
-    if (idfVersion <= "5.0") {
-      const monitorDelay = idfConf.readParameter(
-        "idf.monitorStartDelayBeforeDebug",
-        workspaceRoot
-      ) as number;
-      await utils.sleep(monitorDelay);
-    }
-  }
 }
 
 export function deactivate() {
   Telemetry.dispose();
-  if (monitorTerminal) {
-    monitorTerminal.dispose();
+  if (IDFMonitor.terminal) {
+    IDFMonitor.dispose();
   }
   OutputChannel.end();
   ConfserverProcess.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3944,17 +3944,16 @@ function createQemuMonitor() {
         `-serial tcp::${qemuTcpPort},server,nowait`,
       ],
     } as IQemuOptions);
-    qemuManager.start();
-    const serialPort = `socket://localhost:${qemuTcpPort}`;
+    await qemuManager.start();
     if (IDFMonitor.terminal) {
-      IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
+      await utils.sleep(1000);
     }
+    const serialPort = `socket://localhost:${qemuTcpPort}`;
     const noReset = idfConf.readParameter(
       "idf.monitorNoReset",
       workspaceRoot
     ) as boolean;
     await createNewIdfMonitor(workspaceRoot, noReset, serialPort);
-    IDFMonitor.start();
   });
 }
 

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -201,7 +201,7 @@ export class QemuManager extends EventEmitter {
         strictEnv: true,
       });
       window.onDidCloseTerminal((e) => {
-        if (e.name === this.qemuTerminal.name) {
+        if (e.processId === this.qemuTerminal.processId) {
           this.stop();
         }
       });


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.

Fixes #1132 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Monitor". Click on "ESP-IDF: Build, flash and monitor". Monitor terminal should be reused and the same.
2. 

## How has this been tested?

Manual testing of above.

**Test Configuration**:
* ESP-IDF Version: 5.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
