### PR TITLE
[VSC-1430] Fix duplicate output; Add notification for success

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -182,5 +182,6 @@
   "Open ESP-IDF Terminal": "Abrir terminal ESP-IDF",
   "Doctor Command": "Comando médico",
   "Execute Custom Task": "Ejecutar tarea personalizada",
-  "Wait for ESP-IDF build or flash to finish": "Espere a que finalice la compilación o la actualización de ESP-IDF"
+  "Wait for ESP-IDF build or flash to finish": "Espere a que finalice la compilación o la actualización de ESP-IDF",
+  "Target {0} Set Successfully": "Objetivo {0} configurado con éxito."
 }

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -183,5 +183,6 @@
   "Doctor Command": "Comando médico",
   "Execute Custom Task": "Ejecutar tarea personalizada",
   "Wait for ESP-IDF build or flash to finish": "Espere a que finalice la compilación o la actualización de ESP-IDF",
-  "Target {0} Set Successfully": "Objetivo {0} configurado con éxito."
+  "Target {0} Set Successfully.": "Objetivo {0} configurado con éxito.",
+  "Unknown error occurred while setting IDF target.": "Ocurrió un error desconocido al configurar el objetivo IDF."
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -182,5 +182,6 @@
   "Open ESP-IDF Terminal": "Abra o terminal ESP-IDF",
   "Doctor Command": "Comando Médico",
   "Execute Custom Task": "Executar tarefa personalizada",
-  "Wait for ESP-IDF build or flash to finish": "Aguarde a conclusão da compilação ou flash do ESP-IDF"
+  "Wait for ESP-IDF build or flash to finish": "Aguarde a conclusão da compilação ou flash do ESP-IDF",
+  "Target {0} Set Successfully": "Alvo {0} definido com sucesso."
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -183,5 +183,6 @@
   "Doctor Command": "Comando Médico",
   "Execute Custom Task": "Executar tarefa personalizada",
   "Wait for ESP-IDF build or flash to finish": "Aguarde a conclusão da compilação ou flash do ESP-IDF",
-  "Target {0} Set Successfully": "Alvo {0} definido com sucesso."
+  "Target {0} Set Successfully.": "Alvo {0} definido com sucesso.",
+  "Unknown error occurred while setting IDF target.": "Ocorreu um erro desconhecido ao definir o alvo IDF."
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -183,5 +183,6 @@
   "Doctor Command": "Доктор Команда",
   "Execute Custom Task": "Выполнить пользовательскую задачу",
   "Wait for ESP-IDF build or flash to finish": "Подождите завершения сборки или прошивки ESP-IDF.",
-  "Target {0} Set Successfully": "Цель {0} успешно установлена."
+  "Target {0} Set Successfully.": "Цель {0} успешно установлена.",
+  "Unknown error occurred while setting IDF target.": "Произошла неизвестная ошибка при установке цели IDF."
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -182,5 +182,6 @@
   "Open ESP-IDF Terminal": "Открыть терминал ESP-IDF",
   "Doctor Command": "Доктор Команда",
   "Execute Custom Task": "Выполнить пользовательскую задачу",
-  "Wait for ESP-IDF build or flash to finish": "Подождите завершения сборки или прошивки ESP-IDF."
+  "Wait for ESP-IDF build or flash to finish": "Подождите завершения сборки или прошивки ESP-IDF.",
+  "Target {0} Set Successfully": "Цель {0} успешно установлена."
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -183,5 +183,6 @@
   "Doctor Command": "医生指挥",
   "Execute Custom Task": "执行自定义任务",
   "Wait for ESP-IDF build or flash to finish": "等待 ESP-IDF 构建或刷新完成",
-  "Target {0} Set Successfully": "目标 {0} 设置成功"
+  "Target {0} Set Successfully.": "目标 {0} 设置成功",
+  "Unknown error occurred while setting IDF target.": "设置 IDF 目标时发生未知错误"
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -182,5 +182,6 @@
   "Open ESP-IDF Terminal": "打开 ESP-IDF 终端",
   "Doctor Command": "医生指挥",
   "Execute Custom Task": "执行自定义任务",
-  "Wait for ESP-IDF build or flash to finish": "等待 ESP-IDF 构建或刷新完成"
+  "Wait for ESP-IDF build or flash to finish": "等待 ESP-IDF 构建或刷新完成",
+  "Target {0} Set Successfully": "目标 {0} 设置成功"
 }

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -22,6 +22,7 @@ import {
   ProgressLocation,
   WorkspaceFolder,
   window,
+  l10n,
 } from "vscode";
 import {
   NotificationMode,
@@ -34,7 +35,10 @@ import { getBoards, getOpenOcdScripts } from "../openOcd/boardConfiguration";
 import { getTargetsFromEspIdf } from "./getTargets";
 import { setTargetInIDF } from "./setTargetInIdf";
 
-export async function setIdfTarget(placeHolderMsg: string, workspaceFolder: WorkspaceFolder) {
+export async function setIdfTarget(
+  placeHolderMsg: string,
+  workspaceFolder: WorkspaceFolder
+) {
   const configurationTarget = ConfigurationTarget.WorkspaceFolder;
   if (!workspaceFolder) {
     return;
@@ -98,17 +102,19 @@ export async function setIdfTarget(placeHolderMsg: string, workspaceFolder: Work
             workspaceFolder.uri
           );
         }
-
         await setTargetInIDF(workspaceFolder, selectedTarget);
       } catch (err) {
         const errMsg =
-          err && err.message ? err.message : "Error running idf.py set-target";
-        if (errMsg.indexOf("are satisfied") > -1) {
-          Logger.info(err.message.toString());
-          OutputChannel.append(err.message.toString());
+          err instanceof Error
+            ? err.message
+            : l10n.t("Unknown error occurred while setting IDF target.");
+
+        if (errMsg.includes("are satisfied")) {
+          Logger.info(errMsg);
+          OutputChannel.appendLine(errMsg);
         } else {
-          Logger.errorNotify(err, err, "setIdfTarget");
-          OutputChannel.append(err);
+          Logger.errorNotify(errMsg, err, "setIdfTarget");
+          OutputChannel.appendLine(errMsg);
         }
       }
     }

--- a/src/espIdf/setTarget/setTargetInIdf.ts
+++ b/src/espIdf/setTarget/setTargetInIdf.ts
@@ -29,6 +29,7 @@ import {
 import { ConfserverProcess } from "../menuconfig/confServerProcess";
 import { IdfTarget } from "./getTargets";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
+import * as vscode from "vscode";
 
 export async function setTargetInIDF(
   workspaceFolder: WorkspaceFolder,
@@ -76,6 +77,11 @@ export async function setTargetInIDF(
     env: modifiedEnv,
   });
   Logger.info(setTargetResult.toString());
-  OutputChannel.append(setTargetResult.toString());
+  const msg = vscode.l10n.t(
+    "Target {0} Set Successfully.",
+    selectedTarget.target.toLocaleUpperCase()
+  );
+  OutputChannel.appendLineAndShow(msg, "Set Target");
+  Logger.infoNotify(msg);
   setCCppPropertiesJsonCompilerPath(workspaceFolder.uri);
 }

--- a/src/espIdf/setTarget/setTargetInIdf.ts
+++ b/src/espIdf/setTarget/setTargetInIdf.ts
@@ -72,16 +72,22 @@ export async function setTargetInIDF(
 
   setTargetArgs.push("set-target", selectedTarget.target);
   const pythonBinPath = await getVirtualEnvPythonPath(workspaceFolder.uri);
-  const setTargetResult = await spawn(pythonBinPath, setTargetArgs, {
-    cwd: workspaceFolder.uri.fsPath,
-    env: modifiedEnv,
-  });
-  Logger.info(setTargetResult.toString());
-  const msg = vscode.l10n.t(
-    "Target {0} Set Successfully.",
-    selectedTarget.target.toLocaleUpperCase()
-  );
-  OutputChannel.appendLineAndShow(msg, "Set Target");
-  Logger.infoNotify(msg);
-  setCCppPropertiesJsonCompilerPath(workspaceFolder.uri);
+  try {
+    const setTargetResult = await spawn(pythonBinPath, setTargetArgs, {
+      cwd: workspaceFolder.uri.fsPath,
+      env: modifiedEnv,
+    });
+    Logger.info(setTargetResult.toString());
+    const msg = vscode.l10n.t(
+      "Target {0} Set Successfully.",
+      selectedTarget.target.toLocaleUpperCase()
+    );
+    OutputChannel.appendLineAndShow(msg, "Set Target");
+    Logger.infoNotify(msg);
+    setCCppPropertiesJsonCompilerPath(workspaceFolder.uri);
+  } catch (error) {
+    throw new Error(
+      `Failed to set target ${selectedTarget.target}: ${error.message}.`
+    );
+  }
 }


### PR DESCRIPTION
## Description

Removed duplicated output to ESP-IDF channel, when user sets device target (ex: esp32, esp32s2 etc)
Added notification for successfully setting the target
Improved error message

JIRA: https://jira.espressif.com:8443/browse/VSC-1430

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1) Open a project
2) Set any device target
3) Check "ESP-IDF" Output channel. There should be no duplicates of `Executing "cmake`
4) When setting the device is finished, you should get a notification no matter if it's successful or not.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.2.2
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
