### PR TITLE
fix: publish docs to production server

### DIFF
--- a/.github/workflows/docs_production.yml
+++ b/.github/workflows/docs_production.yml
@@ -1,11 +1,8 @@
 name: Documentation Build and Production Deploy CI
 
 on:
-  release:
-    types: [published]
   push:
     branches:
-    - release/*
     - master
     paths:
     - 'docs_espressif/**'

--- a/.github/workflows/docs_production.yml
+++ b/.github/workflows/docs_production.yml
@@ -1,0 +1,53 @@
+name: Documentation Build and Production Deploy CI
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+    - release/*
+    - master
+    paths:
+    - 'docs_espressif/**'
+    - '.github/workflows/docs_production.yml'
+ 
+jobs:
+
+  deploy-prod-docs:
+    name: Deploy Documentation on Production
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/setup-python@v5
+      with:
+        cache-dependency-path: docs_espressif/requirements.txt
+        cache: 'pip'
+        python-version: '3.10'
+    - name: Deploy Documentation
+      env:
+        # Deploy to production server
+        # DOCS_BUILD_DIR: "./docs/_build/"
+        DOCS_DEPLOY_PRIVATEKEY: ${{ secrets.DOCS_PROD_PRIVATEKEY }}
+        DOCS_DEPLOY_PATH: ${{ secrets.DOCS_PROD_PATH }}
+        DOCS_DEPLOY_SERVER: ${{ secrets.DOCS_PROD_SERVER }}
+        DOCS_DEPLOY_SERVER_USER: ${{ secrets.DOCS_PROD_USER }}
+        DOCS_DEPLOY_URL_BASE: ${{ secrets.DOCS_PROD_URL_BASE }}
+      run: |
+        sudo apt update
+        sudo apt install python3-pip python3-setuptools
+        source ./docs_espressif/utils.sh
+        add_doc_server_ssh_keys $DOCS_DEPLOY_PRIVATEKEY $DOCS_DEPLOY_SERVER $DOCS_DEPLOY_SERVER_USER
+        export GIT_VER=$(git describe --always)
+        echo "PIP install requirements..."
+        pip3 install --user -r ./docs_espressif/requirements.txt
+        echo "Building the Docs..."
+        cd ./docs_espressif && build-docs -l en
+        echo "Deploy the Docs..."
+        export DOCS_BUILD_DIR=$GITHUB_WORKSPACE/docs_espressif/
+        cd $GITHUB_WORKSPACE/docs_espressif
+        deploy-docs


### PR DESCRIPTION
## Description

Publish vscode extension docs to docs.espressif production server. 
Required production keys are added.


## Type of change

- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
