### PR TITLE
✨ Hoist linker (ld) errors to VS Code 'Problems' window

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,21 @@
           "severity": 4,
           "message": 5
         }
+      },
+      {
+        "name": "espIdfLd",
+        "owner": "cpp",
+        "fileLocation": [
+          "autoDetect",
+          "${workspaceFolder}"
+        ],
+        "severity": "error",
+        "pattern": {
+            "regexp": "^.+\\/bin\\/ld[^:]+:\\s*(.+):(\\d+):(.+)$",
+            "file": 1,
+            "line": 2,
+            "message": 3
+          }
       }
     ],
     "viewsContainers": {

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -210,7 +210,7 @@ export class BuildTask {
         currentWorkspaceFolder || vscode.TaskScope.Workspace,
         "ESP-IDF Compile",
         compileExecution,
-        ["espIdf"],
+        ["espIdf", "espIdfLd"],
         compilePresentationOptions
       );
       compilerArgs = [];
@@ -237,7 +237,7 @@ export class BuildTask {
       currentWorkspaceFolder || vscode.TaskScope.Workspace,
       "ESP-IDF Build",
       buildExecution,
-      ["espIdf"],
+      ["espIdf", "espIdfLd"],
       buildPresentationOptions
     );
   }

--- a/src/customTasks/customTaskProvider.ts
+++ b/src/customTasks/customTaskProvider.ts
@@ -130,7 +130,7 @@ export class CustomTask {
       currentWorkspaceFolder || TaskScope.Workspace,
       `ESP-IDF ${taskName}`,
       customExecution,
-      ["espIdf"],
+      ["espIdf", "espIdfLd"],
       customTaskPresentationOptions
     );
   }


### PR DESCRIPTION
## Description

When building a project in VS Code ESP IDF Extension (v 1.8.1), any linker error is reported in the terminal. These errors are not reported in the 'Problems' list of VS Code. Users have to sift through the build log and extract linker errors. This can also confuse new users as ESP IDF will say "build failed" and the problems list will be empty.

![image](https://github.com/user-attachments/assets/dd01dd6d-dc63-4aa8-b6b9-5c4a93625d4f)

Fixes #1315

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open any ESP-IDF project in VS Code,
2. Ensure there is at least one or more linker (ld) errors. A simple way to create an ld error is to rename 'app_main' to 'app_mainXXX',
3. Build project in VS Code by clicking the wrench icon (Build).

- Expected behaviour:
1. Linker (ld) errors appear in the VS Code 'Problems' window.
2. Errors are clickable and will navigate to the adequate source file, at the correct line

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Perform the steps 1 to 3 above
- Add missing variables (extern int foo) in the code and observe the error is properly captured

**Test Configuration**:
* ESP-IDF Version: v5.3.0, v5.3.1
* OS: Windows, Linux (on WSL)

## Dependent components impacted by this PR:

N/A

## Checklist
- [x] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
