### PR TITLE
[VSC-1472/1207] add new idf size format support

### DIFF
--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -60,8 +60,10 @@ export class IDFSize {
       ) as string;
       const version = await utils.getEspIdfFromCMake(espIdfPath);
       const formatArgs =
-        utils.compareVersion(version, "5.1.0") >= 0
-          ? ["--format", "json"]
+        utils.compareVersion(version, "5.3.0") >= 0
+          ? ["--format", "json2"]
+          : utils.compareVersion(version, "5.1.0") >= 0
+          ? ["--format", "json"] 
           : ["--json"];
       const overview = await this.idfCommandInvoker([
         "idf_size.py",

--- a/src/espIdf/size/idfSizePanel.ts
+++ b/src/espIdf/size/idfSizePanel.ts
@@ -2,20 +2,19 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Thursday, 20th June 2019 10:39:58 am
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { Logger } from "../../logger/logger";
@@ -76,14 +75,19 @@ export class IDFSizePanel {
     this._panel = panel;
     this._extensionPath = extensionPath;
     this._webviewData = webviewData;
-    this.initWebview();
+    const isNewIdfSize: boolean =
+      webviewData["overview"] && webviewData["overview"].version;
+    this.initWebview(isNewIdfSize);
   }
   private disposeWebview() {
     IDFSizePanel.currentPanel = undefined;
   }
-  private initWebview() {
+  private initWebview(isNewIdfSize: boolean) {
     this._panel.iconPath = getWebViewFavicon(this._extensionPath);
-    this._panel.webview.html = this.getHtmlContent(this._panel.webview);
+    this._panel.webview.html = this.getHtmlContent(
+      this._panel.webview,
+      isNewIdfSize
+    );
     this._panel.onDidDispose(this.disposeWebview, null, this._disposables);
     this._panel.webview.onDidReceiveMessage(
       (msg) => {
@@ -94,7 +98,7 @@ export class IDFSizePanel {
           case "requestInitialValues":
             this._panel.webview.postMessage({
               command: "initialLoad",
-              ...this._webviewData
+              ...this._webviewData,
             });
             break;
           default:
@@ -110,10 +114,18 @@ export class IDFSizePanel {
     );
   }
 
-  private getHtmlContent(webview: vscode.Webview): string {
+  private getHtmlContent(
+    webview: vscode.Webview,
+    isNewIdfSize: boolean
+  ): string {
     const scriptPath = webview.asWebviewUri(
       vscode.Uri.file(
-        path.join(this._extensionPath, "dist", "views", "size-bundle.js")
+        path.join(
+          this._extensionPath,
+          "dist",
+          "views",
+          isNewIdfSize ? "newSize-bundle.js" : "size-bundle.js"
+        )
       )
     );
     return `<!DOCTYPE html>

--- a/src/espIdf/size/types.ts
+++ b/src/espIdf/size/types.ts
@@ -1,0 +1,60 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 21st October 2024 3:24:53 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface IDFSizeOverviewSectionPart {
+  size: number;
+}
+
+export interface IDFSizeOverviewSection {
+  name: string;
+  total: number;
+  used: number;
+  free: number;
+  parts: { [key: string]: IDFSizeOverviewSectionPart };
+}
+
+// Archives or files
+
+export interface IDFSizeSection {
+  size: number;
+  size_diff: number;
+  abbrev_name: string;
+}
+
+export interface IDFSizeMemoryType {
+  size: number;
+  size_diff: number;
+  sections: { [key: string]: IDFSizeSection };
+}
+
+export interface IDFSizeFile {
+  abbrev_name: string;
+  size: number;
+  size_diff: number;
+  memory_types: { [key: string]: IDFSizeMemoryType };
+}
+
+export interface IDFSizeArchive extends IDFSizeFile {
+  files: { [key: string]: IDFSizeFile };
+  isFileInfoVisible: boolean;
+}
+
+export interface IDFSizeOverview {
+  version: string;
+  layout: IDFSizeOverviewSection[];
+}

--- a/src/views/commons/espCommons.scss
+++ b/src/views/commons/espCommons.scss
@@ -54,6 +54,10 @@ body.vscode-dark table.is-hoverable tbody tr:not(.is-selected):hover {
   background-color: var(--vscode-sideBar-dropBackground);
 }
 
+.table.is-striped tbody tr:not(.is-selected):nth-child(even) {
+  background-color: var(--vscode-badge-background);
+}
+
 .button {
   background-color: var(--vscode-button-background);
   border-color: var(--vscode-button-background);

--- a/src/views/newSize/App.vue
+++ b/src/views/newSize/App.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { useNewSizeStore } from "./store";
+import { storeToRefs } from "pinia";
+import { IconSearch } from "@iconify-prerendered/vue-codicon";
+import Header from "./components/Header.vue";
+import Overview from "./components/Overview.vue";
+import ProgressBar from "./components/ProgressBar.vue";
+import ArchiveItem from "./components/ArchiveItem.vue";
+import FileTable from "./components/FileTable.vue";
+import SizeFilter from "./components/SizeFilter.vue";
+import { IDFSizeArchive } from "../../espIdf/size/types";
+
+const store = useNewSizeStore();
+
+const { archives, isOverviewEnabled, overviewData, searchText } = storeToRefs(
+  store
+);
+
+const filteredArchives = computed<{ [key: string]: IDFSizeArchive }>(() => {
+  let filteredObj = archives.value;
+  if (searchText.value !== "") {
+    filteredObj = {};
+    Object.keys(archives.value).forEach((archive) => {
+      // tslint:disable-next-line: max-line-length
+      if (
+        archive.toLowerCase().match(searchText.value.toLowerCase()) ||
+        (archives.value[archive].files &&
+          Object.keys(archives.value[archive].files).filter((file) =>
+            file.toLowerCase().match(searchText.value.toLowerCase())
+          ).length > 0)
+      ) {
+        filteredObj[archive] = archives.value[archive];
+      }
+    });
+  }
+  return filteredObj;
+});
+
+onMounted(() => {
+  store.requestInitialValues();
+});
+</script>
+
+<template>
+  <div id="app">
+    <Header />
+    <div class="section no-padding-top">
+      <div class="container is-mobile">
+        <SizeFilter />
+        <div v-if="isOverviewEnabled">
+          <Overview />
+          <ProgressBar
+            v-for="section in overviewData.layout"
+            :key="section.name"
+            :name="section.name"
+            :usedData="section.used"
+            :totalData="section.total"
+          />
+        </div>
+        <div v-else>
+          <div class="field">
+            <p class="control has-icons-right">
+              <input
+                class="input"
+                type="text"
+                placeholder="Search"
+                v-model="searchText"
+              />
+              <span class="icon is-right">
+                <IconSearch />
+              </span>
+            </p>
+          </div>
+          <div
+            v-for="(archiveInfo, archiveName) in filteredArchives"
+            :key="archiveName"
+            class="notification is-clipped"
+          >
+            <ArchiveItem
+              :archiveInfo="archiveInfo"
+              :archiveName="archiveName.toString()"
+            />
+            <div
+              class="columns"
+              style="overflow: auto;"
+              v-if="archiveInfo.files && archiveInfo.isFileInfoVisible"
+            >
+              <div class="column">
+                <FileTable :archiveInfo="archiveInfo" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+@import "../commons/espCommons.scss";
+</style>

--- a/src/views/newSize/components/ArchiveItem.vue
+++ b/src/views/newSize/components/ArchiveItem.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconChevronRight,
+  IconFileZip,
+} from "@iconify-prerendered/vue-codicon";
+import { useNewSizeStore } from "../store";
+import ArchiveItemColumn from "./ArchiveItemColumn.vue";
+import { IDFSizeArchive } from "../../../espIdf/size/types";
+
+const store = useNewSizeStore();
+
+defineProps<{
+  archiveInfo: IDFSizeArchive;
+  archiveName: string;
+}>();
+
+function toggleArchiveFileInfoTable(archiveName: string) {
+  Object.keys(store.archives).forEach((archive) => {
+    let toggleVisibility = false;
+    if (archive === archiveName) {
+      toggleVisibility = !store.archives[archive]["isFileInfoVisible"];
+    }
+    store.archives[archive]["isFileInfoVisible"] = toggleVisibility;
+  });
+}
+</script>
+
+<template>
+  <div
+    class="columns is-vcentered has-text-right is-mobile"
+    v-on:click="toggleArchiveFileInfoTable(archiveName)"
+    :title="archiveName"
+  >
+    <div class="column is-hidden-mobile">
+      <div class="control">
+        <span class="icon is-large">
+          <IconFileZip class="is-size-4" />
+        </span>
+      </div>
+    </div>
+    <div class="column is-3 is-clipped">
+      <p
+        class="is-size-7-mobile is-size-6-tablet is-size-5-desktop has-text-weight-medium"
+      >
+        {{ archiveInfo.abbrev_name }}
+      </p>
+    </div>
+    <ArchiveItemColumn
+      v-for="(memType, propName) in archiveInfo.memory_types"
+      :key="propName"
+      :archiveMemoryType="memType"
+      :propName="propName.toString()"
+    />
+
+    <div v-if="archiveInfo['files']" class="column">
+      <div v-if="archiveInfo['isFileInfoVisible']">
+        <span class="icon is-large is-hidden-mobile">
+          <IconChevronDown />
+        </span>
+        <span class="icon is-small is-hidden-tablet">
+          <IconChevronDown />
+        </span>
+      </div>
+      <div v-else>
+        <span class="icon is-large is-hidden-mobile">
+          <IconChevronRight />
+        </span>
+        <span class="icon is-small is-hidden-tablet">
+          <IconChevronRight />
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/newSize/components/ArchiveItemColumn.vue
+++ b/src/views/newSize/components/ArchiveItemColumn.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { IDFSizeMemoryType } from '../../../espIdf/size/types';
+
+defineProps<{
+  archiveMemoryType: IDFSizeMemoryType;
+  propName: string;
+}>();
+
+function convertToKB(byte: number) {
+  return typeof byte === "number" ? Math.round(byte / 1024) : 0;
+}
+</script>
+
+<template>
+  <div class="column">
+    <p class="is-size-7-mobile is-size-6-tablet is-size-5-desktop">
+      {{
+        archiveMemoryType.size
+          ? convertToKB(archiveMemoryType.size)
+          : convertToKB(0)
+      }}<span class="has-text-weight-light is-uppercase">kb</span>
+    </p>
+    <p class="heading">{{ propName }}</p>
+  </div>
+</template>

--- a/src/views/newSize/components/FileTable.vue
+++ b/src/views/newSize/components/FileTable.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, Ref } from "vue";
+import { IDFSizeArchive } from "../../../espIdf/size/types";
+
+const props = defineProps<{
+  archiveInfo: IDFSizeArchive;
+}>();
+
+let tableHeaders: Ref<string[]> = ref([]);
+
+let tableData: Ref<{ [key: string]: number | string }[]> = ref([]);
+
+let tableHeadersAbbrev: Ref<{ [key: string]: string }> = ref({});
+
+function generateTableData() {
+  const columnSet: Set<string> = new Set();
+  for (const fileName in props.archiveInfo.files) {
+    const fileData = props.archiveInfo.files[fileName];
+    const memoryTypes = fileData.memory_types;
+
+    for (const memoryType in memoryTypes) {
+      columnSet.add(`${memoryType}`);
+      const sections = memoryTypes[memoryType].sections;
+
+      for (const section in sections) {
+        const columnKey = `${memoryTypes[memoryType].sections[section].abbrev_name}`;
+        tableHeadersAbbrev.value[section] = columnKey;
+        columnSet.add(`${section}`);
+      }
+    }
+  }
+  const columns = Array.from(columnSet);
+
+  for (const fileName in props.archiveInfo.files) {
+    const fileData = props.archiveInfo.files[fileName];
+    const memoryTypes = fileData.memory_types;
+    const row: { [key: string]: number | string } = {
+      "Object File": fileName,
+      "Total Size": fileData.size,
+    };
+
+    columns.forEach((col) => {
+      row[col] = 0;
+    });
+
+    for (const memoryType in memoryTypes) {
+      row[`${memoryType}`] = memoryTypes[memoryType].size;
+      for (const section in memoryTypes[memoryType].sections) {
+        row[section] = memoryTypes[memoryType].sections[section].size;
+      }
+    }
+    tableData.value.push(row);
+  }
+  tableHeaders.value = ["Object File", "Total Size", ...Array.from(columnSet)];
+}
+
+onMounted(() => {
+  console.log(props.archiveInfo.files);
+  generateTableData();
+});
+</script>
+
+<template>
+  <table
+    class="table is-fullwidth is-hoverable is-size-7-mobile is-size-7-tablet is-size-6-desktop"
+  >
+    <thead>
+      <tr class="is-uppercase">
+        <td v-for="(header, i) in tableHeaders" :key="i" class="has-text-right">
+          {{ tableHeadersAbbrev[header] ? tableHeadersAbbrev[header] : header }}
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(row, rowIndex) in tableData" :key="rowIndex">
+        <td
+          v-for="(header, colIndex) in tableHeaders"
+          :key="colIndex"
+          class="has-text-right"
+        >
+          {{ row[header] }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/src/views/newSize/components/FileTable.vue
+++ b/src/views/newSize/components/FileTable.vue
@@ -62,7 +62,7 @@ onMounted(() => {
 
 <template>
   <table
-    class="table is-fullwidth is-hoverable is-size-7-mobile is-size-7-tablet is-size-6-desktop"
+    class="table is-striped is-fullwidth is-hoverable is-size-7-mobile is-size-7-tablet is-size-6-desktop"
   >
     <thead>
       <tr class="is-uppercase">

--- a/src/views/newSize/components/Header.vue
+++ b/src/views/newSize/components/Header.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { useNewSizeStore } from "../store";
+import { IconSymbolEvent } from "@iconify-prerendered/vue-codicon";
+const store = useNewSizeStore();
+</script>
+
+<template>
+  <header class="section">
+    <div class="container">
+      <nav class="level is-mobile">
+        <div class="level-left">
+          <div class="level-item">
+            <h1 class="title is-size-5-mobile">
+              <strong>ESP-IDF</strong>&nbsp;Size Analysis
+            </h1>
+          </div>
+        </div>
+        <div class="level-right">
+          <div class="level-item">
+            <p class="buttons are-small">
+              <button
+                class="button"
+                title="Flash"
+                v-on:click="store.flashClicked"
+                v-bind:disabled="store.isFlashing"
+              >
+                <span class="icon">
+                  <IconSymbolEvent />
+                </span>
+                &nbsp; Flash
+              </button>
+            </p>
+          </div>
+        </div>
+      </nav>
+      <p class="subtitle is-size-6-mobile">
+        Size analysis will provide users with in-depth analysis of the binary
+        file generated from the project.
+      </p>
+    </div>
+  </header>
+</template>

--- a/src/views/newSize/components/Overview.vue
+++ b/src/views/newSize/components/Overview.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { useNewSizeStore } from "../store";
+
+const store = useNewSizeStore();
+
+const { overviewData } = storeToRefs(store);
+function convertToKB(byte: number) {
+  return typeof byte === "number" ? Math.round(byte / 1024) : 0;
+}
+</script>
+
+<template>
+  <div class="notification is-clipped">
+    <nav class="level is-mobile">
+      <div
+        class="level-item has-text-centered"
+        v-for="overviewSection in overviewData.layout"
+        :key="overviewSection.name"
+      >
+        <div>
+          <p class="heading is-size-7-mobile">{{ overviewSection.name }}</p>
+          <p class="title is-size-5-mobile">
+            {{ convertToKB(overviewSection.used) }}KB
+          </p>
+        </div>
+      </div>
+    </nav>
+  </div>
+</template>

--- a/src/views/newSize/components/ProgressBar.vue
+++ b/src/views/newSize/components/ProgressBar.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { IconServer } from "@iconify-prerendered/vue-codicon";
+defineProps<{
+  usedData: number;
+  totalData: number;
+  name: string;
+}>();
+
+function convertToKB(byte: number) {
+  return typeof byte === "number" ? Math.round(byte / 1024) : 0;
+}
+
+function progressBarColorClass(ratio: number) {
+  if (ratio <= 0.3) {
+    return { "is-success": true };
+  }
+  if (ratio <= 0.7) {
+    return { "is-warning": true };
+  }
+  return { "is-danger": true };
+}
+</script>
+
+<template>
+  <div class="notification is-clipped">
+    <div class="columns is-vcentered has-text-centered is-mobile">
+      <div class="column is-1-tablet is-2-mobile is-clipped">
+        <div>
+          <span class="icon is-large is-hidden-mobile">
+            <IconServer class="is-size-3" />
+          </span>
+          <br />
+          <strong style="vertical-align: super;">{{ name }}</strong>
+        </div>
+      </div>
+      <div class="column">
+        <progress
+          class="progress"
+          v-bind:class="progressBarColorClass(usedData / totalData)"
+          v-bind:title="Math.round((usedData / totalData) * 100) + '%'"
+          v-bind:value="usedData"
+          v-bind:max="totalData"
+        ></progress>
+      </div>
+      <div
+        class="column is-3-mobile is-2-tablet is-2-desktop is-size-7-tablet is-size-7-mobile"
+      >
+        {{ convertToKB(usedData) }}KB / {{ convertToKB(totalData) }}KB
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/newSize/components/SizeFilter.vue
+++ b/src/views/newSize/components/SizeFilter.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { useNewSizeStore } from "../store";
+
+const store = useNewSizeStore();
+
+function toggleOverviewAndDetails() {
+  store.isOverviewEnabled = !store.isOverviewEnabled;
+}
+</script>
+
+<template>
+  <nav class="level is-mobile">
+    <div class="level-left"></div>
+    <div class="level-right">
+      <div class="field has-addons">
+        <p class="control">
+          <button
+            class="button is-size-7-mobile is-size-7-tablet"
+            v-on:click="toggleOverviewAndDetails"
+            v-bind:class="{ 'is-static': store.isOverviewEnabled }"
+          >
+            Overview
+          </button>
+        </p>
+        <p class="control">
+          <button
+            class="button is-size-7-mobile is-size-7-tablet"
+            v-on:click="toggleOverviewAndDetails"
+            v-bind:class="{ 'is-static': !store.isOverviewEnabled }"
+          >
+            Detailed
+          </button>
+        </p>
+      </div>
+    </div>
+  </nav>
+</template>

--- a/src/views/newSize/main.ts
+++ b/src/views/newSize/main.ts
@@ -1,0 +1,42 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 21st October 2024 3:23:05 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApp } from "vue";
+import { createPinia } from "pinia";
+import App from "./App.vue";
+import { useNewSizeStore } from "./store";
+
+const app = createApp(App);
+const pinia = createPinia();
+app.use(pinia);
+app.mount("#app");
+
+const store = useNewSizeStore();
+
+window.addEventListener("message", (m: any) => {
+  const msg = m.data;
+  switch (msg.command) {
+    case "initialLoad":
+      store.archives = msg.archives;
+      store.overviewData = msg.overview;
+      store.setFiles(msg.files);
+      break;
+    default:
+      break;
+  }
+});

--- a/src/views/newSize/store.ts
+++ b/src/views/newSize/store.ts
@@ -60,9 +60,9 @@ export const useNewSizeStore = defineStore("newSize", () => {
 
   function setFiles(files) {
     Object.keys(files).forEach((file) => {
-      const archiveFileName = file.split(":");
-      const archiveName = archiveFileName[0];
-      const fileName = archiveFileName[1];
+      const lastColonIndex = file.lastIndexOf(":");
+      const archiveName = file.substring(0, lastColonIndex);
+      const fileName = file.substring(lastColonIndex + 1);
       if (archives.value[archiveName] && !archives.value[archiveName].files) {
         archives.value[archiveName].files = {};
       }

--- a/src/views/newSize/store.ts
+++ b/src/views/newSize/store.ts
@@ -1,0 +1,97 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Monday, 21st October 2024 3:23:34 pm
+ * Copyright 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineStore } from "pinia";
+import { ref, Ref } from "vue";
+import { IDFSizeArchive, IDFSizeOverview } from "../../espIdf/size/types";
+
+declare var acquireVsCodeApi: any;
+let vscode: any;
+try {
+  vscode = acquireVsCodeApi();
+} catch (error) {
+  console.error(error);
+}
+
+const SEC = 1000;
+
+export const useNewSizeStore = defineStore("newSize", () => {
+  const archives: Ref<{ [key: string]: IDFSizeArchive }> = ref({});
+  const isFlashing: Ref<boolean> = ref(false);
+  const isOverviewEnabled: Ref<boolean> = ref(true);
+  const overviewData: Ref<IDFSizeOverview> = ref({
+    version: "",
+    layout: [],
+  });
+  const searchText: Ref<string> = ref("");
+
+  function flashClicked() {
+    if (vscode) {
+      isFlashing.value = true;
+      setTimeout(() => {
+        isFlashing.value = false;
+      }, 10 * SEC);
+      vscode.postMessage({
+        command: "flash",
+      });
+    }
+  }
+
+  function requestInitialValues() {
+    vscode.postMessage({
+      command: "requestInitialValues",
+    });
+  }
+
+  function setFiles(files) {
+    Object.keys(files).forEach((file) => {
+      const archiveFileName = file.split(":");
+      const archiveName = archiveFileName[0];
+      const fileName = archiveFileName[1];
+      if (archives.value[archiveName] && !archives.value[archiveName].files) {
+        archives.value[archiveName].files = {};
+      }
+      archives.value[archiveName].files[fileName] = files[file];
+    });
+    Object.keys(archives.value).forEach((archive) => {
+      archives.value[archive].isFileInfoVisible = false;
+    });
+  }
+
+  function toggleArchiveFileInfoTable(archiveName: string) {
+    Object.keys(archives.value).forEach((archive) => {
+      let toggleVisibility = false;
+      if (archive === archiveName) {
+        toggleVisibility = !archives.value[archive].isFileInfoVisible;
+      }
+      archives.value[archive].isFileInfoVisible = toggleVisibility;
+    });
+  }
+
+  return {
+    archives,
+    isFlashing,
+    isOverviewEnabled,
+    overviewData,
+    searchText,
+    flashClicked,
+    setFiles,
+    toggleArchiveFileInfoTable,
+    requestInitialValues,
+  };
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,6 +94,7 @@ const webViewConfig = {
     ),
     examples: path.resolve(__dirname, "src", "views", "examples", "main.ts"),
     size: path.resolve(__dirname, "src", "views", "size", "main.ts"),
+    newSize: path.resolve(__dirname, "src", "views", "newSize", "main.ts"),
     tracing: path.resolve(__dirname, "src", "views", "tracing", "main.ts"),
     menuconfig: path.resolve(
       __dirname,


### PR DESCRIPTION
## Description

Support new esp-idf-size JSON format which provide more map file information in `ESP-IDF: Size analysis of the binaries` command UI.

This feature is supported for ESP-IDF v5.3 and higher, when older versions are used the extension will use previous IDF Size UI
![Screenshot 2024-10-23 at 17 10 38](https://github.com/user-attachments/assets/4fc7eb7e-a191-487e-8676-13241ab911f2)



## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on menu **View**, **Command Palette** and search for `ESP-IDF: Size analysis of the binaries` command with ESP-IDF v5.3.0 or higher
2. Execute action. The rendered UI should show more fields and information.
3. Observe results.
4. Repeat step 1 with ESP-IDF version older than v5.3.0. Results should show previous behavior.

- Expected behaviour:
Result similar to https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-size.html?highlight=size

- Expected output:

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-size.html?highlight=size

## How has this been tested?

Manual testing of extension command using both v5.4.0 and v.5.2.2

**Test Configuration**:
* ESP-IDF Version: v5.4.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
