### PR TITLE
[VSC-1514] add idf path idf tools path to created example

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -107,7 +107,7 @@
   "ESP-IDF: Please wait mapping your rainmaker cloud account with the VS Code Extension, this could take a little while": "ESP-IDF: Espere a mapear su cuenta de nube Rainmaker con la extensión VS Code, esto podría tomar un poco de tiempo.",
   "Rainmaker Cloud is connected successfully (via OAuth)!": "¡Rainmaker Cloud está conectado correctamente (a través de OAuth)!",
   "Failed to sign-in with Rainmaker (via OAuth)": "No se pudo iniciar sesión con Rainmaker (a través de OAuth)",
-  "Use current ESP-IDF {espIdfPath}": "Utilice ESP-IDF actual {espIdfPath}",
+  "Use ESP-IDF {espIdfPath}": "Utilice ESP-IDF {espIdfPath}",
   "Use current ESP-ADF {espAdfPath}": "Utilice ESP-ADF actual {espAdfPath}",
   "Use current ESP-MDF {espMdfPath}": "Utilice ESP-MDF actual {espMdfPath}",
   "Use current ESP-Matter {matterPathDir}": "Utilice ESP-Matter actual {matterPathDir}",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -107,7 +107,7 @@
   "ESP-IDF: Please wait mapping your rainmaker cloud account with the VS Code Extension, this could take a little while": "ESP-IDF: Aguarde mapeando sua conta do Rainmaker Cloud com a extensão VS Code, isso pode demorar um pouco",
   "Rainmaker Cloud is connected successfully (via OAuth)!": "Rainmaker Cloud foi conectado com sucesso (via OAuth)!",
   "Failed to sign-in with Rainmaker (via OAuth)": "Falha ao fazer login com Rainmaker (via OAuth)",
-  "Use current ESP-IDF {espIdfPath}": "Usar ESP-IDF atual {espIdfPath}",
+  "Use ESP-IDF {espIdfPath}": "Usar ESP-IDF {espIdfPath}",
   "Use current ESP-ADF {espAdfPath}": "Usar ESP-ADF atual {espAdfPath}",
   "Use current ESP-MDF {espMdfPath}": "Use ESP-MDF atual {espMdfPath}",
   "Use current ESP-Matter {matterPathDir}": "Use ESP-Matter atual {matterPathDir}",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -107,7 +107,7 @@
   "ESP-IDF: Please wait mapping your rainmaker cloud account with the VS Code Extension, this could take a little while": "ESP-IDF: подождите, сопоставьте свою облачную учетную запись Rainmaker с расширением VS Code Extension, это может занять некоторое время.",
   "Rainmaker Cloud is connected successfully (via OAuth)!": "Rainmaker Cloud успешно подключен (через OAuth)!",
   "Failed to sign-in with Rainmaker (via OAuth)": "Не удалось войти в систему с помощью Rainmaker (через OAuth).",
-  "Use current ESP-IDF {espIdfPath}": "Использовать текущий ESP-IDF {espIdfPath}",
+  "Use current ESP-IDF {espIdfPath}": "Используйте ESP-IDF {espIdfPath}",
   "Use current ESP-ADF {espAdfPath}": "Использовать текущий ESP-ADF {espAdfPath}",
   "Use current ESP-MDF {espMdfPath}": "Использовать текущий ESP-MDF {espMdfPath}",
   "Use current ESP-Matter {matterPathDir}": "Использовать текущий ESP-Matter {matterPathDir}",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -107,7 +107,7 @@
   "ESP-IDF: Please wait mapping your rainmaker cloud account with the VS Code Extension, this could take a little while": "ESP-IDF：请等待使用 VS Code 扩展映射您的 Rainmaker 帐户，这可能需要一些时间",
   "Rainmaker Cloud is connected successfully (via OAuth)!": "Rainmaker Cloud 已成功连接（通过 OAuth）！",
   "Failed to sign-in with Rainmaker (via OAuth)": "无法使用 Rainmaker 登录（通过 OAuth）",
-  "Use current ESP-IDF {espIdfPath}": "使用当前 ESP-IDF {espIdfPath}",
+  "Use ESP-IDF {espIdfPath}": "使用 ESP-IDF {espIdfPath}",
   "Use current ESP-ADF {espAdfPath}": "使用当前 ESP-ADF {espAdfPath}",
   "Use current ESP-MDF {espMdfPath}": "使用当前 ESP-MDF {espMdfPath}",
   "Use current ESP-Matter {matterPathDir}": "使用当前 ESP-Matter {matterPathDir}",

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -124,6 +124,8 @@ export class NewProjectPanel {
             message.template
           ) {
             this.createProject(
+              newProjectArgs.espIdfPath,
+              newProjectArgs.espIdfToolsPath,
               JSON.parse(message.components),
               message.port,
               message.containerFolder,
@@ -197,6 +199,8 @@ export class NewProjectPanel {
   }
 
   private async createProject(
+    idfPath: string,
+    idfToolsPath: string,
     components: IComponent[],
     port: string,
     projectDirectory: string,
@@ -283,6 +287,8 @@ export class NewProjectPanel {
           );
           const settingsJson = await setCurrentSettingsInTemplate(
             settingsJsonPath,
+            idfPath,
+            idfToolsPath,
             port,
             openOcdConfigs,
             workspaceFolder

--- a/src/newProject/utils.ts
+++ b/src/newProject/utils.ts
@@ -22,15 +22,15 @@ import { Uri } from "vscode";
 
 export async function setCurrentSettingsInTemplate(
   settingsJsonPath: string,
+  idfPathDir: string,
+  toolsPath: string,
   port: string,
   openOcdConfigs?: string,
   workspace?: Uri
 ) {
   const settingsJson = await readJSON(settingsJsonPath);
-  const idfPathDir = readParameter("idf.espIdfPath", workspace);
   const adfPathDir = readParameter("idf.espAdfPath", workspace);
   const mdfPathDir = readParameter("idf.espMdfPath", workspace);
-  const toolsDir = readParameter("idf.toolsPath", workspace);
   const isWin = process.platform === "win32" ? "Win" : "";
   if (idfPathDir) {
     settingsJson["idf.espIdfPath" + isWin] = idfPathDir;
@@ -50,8 +50,8 @@ export async function setCurrentSettingsInTemplate(
   if (port.indexOf("no port") === -1) {
     settingsJson["idf.port" + isWin] = port;
   }
-  if (toolsDir) {
-    settingsJson["idf.toolsPath" + isWin] = toolsDir;
+  if (toolsPath) {
+    settingsJson["idf.toolsPath" + isWin] = toolsPath;
   }
   return settingsJson;
 }

--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -149,6 +149,8 @@ suite("Project tests", () => {
       "interface/ftdi/esp32_devkitj_v1.cfg,target/esp32.cfg";
     const newSettingsJson = await setCurrentSettingsInTemplate(
       settingsJsonPath,
+      process.env.IDF_PATH,
+      process.env.IDF_TOOLS_PATH,
       "no port",
       openOcdConfigs,
       Uri.file(projectPath)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -403,9 +403,9 @@ export async function copyFromSrcProject(
   srcDirPath: string,
   destinationDir: vscode.Uri
 ) {
+  await copy(srcDirPath, destinationDir.fsPath);
   await createVscodeFolder(destinationDir);
   await createDevContainer(destinationDir.fsPath);
-  await copy(srcDirPath, destinationDir.fsPath);
 }
 
 export function getVariableFromCMakeLists(workspacePath: string, key: string) {


### PR DESCRIPTION
## Description

- Add the whole list of ESP-IDF setups saved in extension global state to `ESP-IDF: Show Examples` framework selection dropdown.
- Add the whole list of ESP-IDF setups saved in extension global state to `ESP-IDF: New Project` before UI is loaded to select esp-idf to use.
- Use current IDF Setup in newly created project from `ESP-IDF: Show Examples` (when different that esp-idf framework is selected).
- Use selected esp-idf in newly created project settings.json idf.espIdfPath and idf.toolsPath.
 
## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Show Examples". Pick a esp-idf version. Create a project
2. The newly created project should include settings.json with selected esp-idf version from step 1.
3. Observe results.
4. Repeat with `ESP-IDF: New Project` to select esp-idf version
5. The newly created project should include settings.json with selected esp-idf version from step 4.

- Expected behaviour:
Selecte esp-idf version from both examples and new project wizard should be saved in new created project settings.json

- Expected output:

## How has this been tested?

Manual testing with steps from above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1 and 5.4
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
