### PR TITLE
[VSC-1515] fix unit tests not being refresh

### DIFF
--- a/src/espIdf/unitTest/adapter.ts
+++ b/src/espIdf/unitTest/adapter.ts
@@ -53,6 +53,7 @@ export class UnitTest {
     this.unitTestController.refreshHandler = async (
       cancelToken?: CancellationToken
     ) => {
+      this.clearExistingTestCaseItems();
       const fileList = await getFileList();
       this.testComponents = await getTestComponents(fileList);
       await this.loadTests(fileList);
@@ -160,6 +161,12 @@ export class UnitTest {
     context.subscriptions.push(this.unitTestController);
   }
 
+  clearExistingTestCaseItems() {
+    this.unitTestController.items.forEach((item) =>
+      this.unitTestController.items.delete(item.id)
+    );
+  }
+
   async createFileTestCaseItems(file: Uri) {
     const existing = this.unitTestController.items.get(file.toString());
     if (existing) {
@@ -195,7 +202,7 @@ export class UnitTest {
       children: [],
       testName: "TEST_ALL",
     };
-    const testRegex = new RegExp("TEST_CASE\\(\"(.*)\",\\s*\"(.*)\"\\)", "gm");
+    const testRegex = new RegExp('TEST_CASE\\("(.*)",\\s*"(.*)"\\)', "gm");
     const fileText = await readFile(file.fsPath, "utf8");
     let match = testRegex.exec(fileText);
     while (match != null) {


### PR DESCRIPTION
## Description

Fix unit tests not being refreshed when Refresh tests button is clicked.

Fixes #1336

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Open a ESP-IDF project like **unity-test** that contains test cases as described in https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/unit-testing.html
2. Add a new test case in any file test_*.c file
3. Press menu **View** then **Testing** Click the Refresh Tests button in the top of the side (Looks like a loading button)
4. The new test should appear.

- Expected behaviour:
Test cases should be added, deleted or modified when Refresh Tests button is executed and test cases have changed.

- Expected output:

## How has this been tested?

Manual testing using the **unity-test** esp-idf example.

**Test Configuration**:
* ESP-IDF Version: 5.0
* OS (Windows,Linux and macOS): MacOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
