### PR TITLE
[VSC-1521] use idf tools export to get env vars

### DIFF
--- a/src/setup/setupValidation/espIdfSetup.ts
+++ b/src/setup/setupValidation/espIdfSetup.ts
@@ -78,7 +78,7 @@ export async function checkIdfSetup(setupConf: IdfSetup,
     let sysPythonBinPath = readParameter("idf.pythonInstallPath") as string;
     const virtualEnvPython = await getPythonEnvPath(setupConf.idfPath, setupConf.toolsPath, sysPythonBinPath);
 
-    const pyEnvReqs = checkPyVenv(virtualEnvPython, setupConf.idfPath);
+    const pyEnvReqs = await checkPyVenv(virtualEnvPython, setupConf.idfPath);
     return pyEnvReqs;
   } catch (error) {
     const msg =

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -17,10 +17,7 @@
  */
 import { join } from "path";
 import { IdfToolsManager } from "../idfToolsManager";
-import {
-  getEnvVarsFromIdfTools,
-  getVirtualEnvPythonPath,
-} from "../pythonManager";
+import { getEnvVarsFromIdfTools, getPythonEnvPath } from "../pythonManager";
 import { reportObj } from "./types";
 import { Uri, workspace } from "vscode";
 
@@ -33,7 +30,7 @@ export async function getConfigurationSettings(
   reportedResult.workspaceFolder = scope
     ? scope.fsPath
     : "No workspace folder is open";
-  const pythonVenvPath = await getVirtualEnvPythonPath(scope);
+  // const pythonVenvPath = await getVirtualEnvPythonPath(scope);
   const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
     conf.get("idf.espIdfPath" + winFlag)
   );
@@ -43,6 +40,16 @@ export async function getConfigurationSettings(
   );
   const customVars = await idfToolsManager.exportVars(
     join(conf.get("idf.toolsPath" + winFlag), "tools")
+  );
+
+  const pythonVenvPath = await getPythonEnvPath(
+    conf
+      .get<string>("idf.espIdfPath" + winFlag)
+      .replace("${env:IDF_PATH}", process.env.IDF_PATH),
+    conf
+      .get<string>("idf.toolsPath" + winFlag)
+      .replace("${env:IDF_TOOLS_PATH}", process.env.IDF_TOOLS_PATH),
+    conf.get<string>("idf.pythonInstallPath")
   );
 
   console.log(

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -17,7 +17,10 @@
  */
 import { join } from "path";
 import { IdfToolsManager } from "../idfToolsManager";
-import { getEnvVarsFromIdfTools, getPythonEnvPath } from "../pythonManager";
+import {
+  getEnvVarsFromIdfTools,
+  getVirtualEnvPythonPath,
+} from "../pythonManager";
 import { reportObj } from "./types";
 import { Uri, workspace } from "vscode";
 
@@ -30,11 +33,7 @@ export async function getConfigurationSettings(
   reportedResult.workspaceFolder = scope
     ? scope.fsPath
     : "No workspace folder is open";
-  const pythonVenvPath = await getPythonEnvPath(
-    conf.get("idf.espIdfPath" + winFlag),
-    conf.get("idf.toolsPath" + winFlag),
-    conf.get("idf.pythonInstallPath")
-  );
+  const pythonVenvPath = await getVirtualEnvPythonPath(scope);
   const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
     conf.get("idf.espIdfPath" + winFlag)
   );
@@ -47,8 +46,12 @@ export async function getConfigurationSettings(
   );
 
   const idfToolsExportVars = await getEnvVarsFromIdfTools(
-    conf.get("idf.espIdfPath" + winFlag),
-    conf.get("idf.toolsPath" + winFlag),
+    conf
+      .get<string>("idf.espIdfPath" + winFlag)
+      .replace("${env:IDF_PATH}", process.env.IDF_PATH),
+    conf
+      .get<string>("idf.toolsPath" + winFlag)
+      .replace("${env:IDF_TOOLS_PATH}", process.env.IDF_TOOLS_PATH),
     pythonVenvPath
   );
 

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -30,7 +30,6 @@ export async function getConfigurationSettings(
   reportedResult.workspaceFolder = scope
     ? scope.fsPath
     : "No workspace folder is open";
-  // const pythonVenvPath = await getVirtualEnvPythonPath(scope);
   const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
     conf.get("idf.espIdfPath" + winFlag)
   );
@@ -51,18 +50,6 @@ export async function getConfigurationSettings(
       .replace("${env:IDF_TOOLS_PATH}", process.env.IDF_TOOLS_PATH),
     conf.get<string>("idf.pythonInstallPath")
   );
-
-  console.log(
-    `IDF_PATH is ${conf
-      .get<string>("idf.espIdfPath" + winFlag)
-      .replace("${env:IDF_PATH}", process.env.IDF_PATH)}`
-  );
-  console.log(
-    `IDF_TOOLS_PATH is ${conf
-      .get<string>("idf.toolsPath" + winFlag)
-      .replace("${env:IDF_TOOLS_PATH}", process.env.IDF_TOOLS_PATH)}`
-  );
-  console.log(`Python path is ${pythonVenvPath}`);
 
   const idfToolsExportVars = await getEnvVarsFromIdfTools(
     conf

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -17,10 +17,7 @@
  */
 import { join } from "path";
 import { IdfToolsManager } from "../idfToolsManager";
-import {
-  getEnvVarsFromIdfTools,
-  getVirtualEnvPythonPath,
-} from "../pythonManager";
+import { getEnvVarsFromIdfTools, getPythonEnvPath } from "../pythonManager";
 import { reportObj } from "./types";
 import { Uri, workspace } from "vscode";
 
@@ -33,7 +30,11 @@ export async function getConfigurationSettings(
   reportedResult.workspaceFolder = scope
     ? scope.fsPath
     : "No workspace folder is open";
-  const pythonVenvPath = await getVirtualEnvPythonPath(scope);
+  const pythonVenvPath = await getPythonEnvPath(
+    conf.get("idf.espIdfPath" + winFlag),
+    conf.get("idf.toolsPath" + winFlag),
+    conf.get("idf.pythonInstallPath")
+  );
   const idfToolsManager = await IdfToolsManager.createIdfToolsManager(
     conf.get("idf.espIdfPath" + winFlag)
   );

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -45,6 +45,18 @@ export async function getConfigurationSettings(
     join(conf.get("idf.toolsPath" + winFlag), "tools")
   );
 
+  console.log(
+    `IDF_PATH is ${conf
+      .get<string>("idf.espIdfPath" + winFlag)
+      .replace("${env:IDF_PATH}", process.env.IDF_PATH)}`
+  );
+  console.log(
+    `IDF_TOOLS_PATH is ${conf
+      .get<string>("idf.toolsPath" + winFlag)
+      .replace("${env:IDF_TOOLS_PATH}", process.env.IDF_TOOLS_PATH)}`
+  );
+  console.log(`Python path is ${pythonVenvPath}`);
+
   const idfToolsExportVars = await getEnvVarsFromIdfTools(
     conf
       .get<string>("idf.espIdfPath" + winFlag)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,11 @@ import { getIdfTargetFromSdkconfig, getProjectName } from "./workspaceConfig";
 import { OutputChannel } from "./logger/outputChannel";
 import { ESP } from "./config";
 import * as sanitizedHtml from "sanitize-html";
-import { getPythonPath, getVirtualEnvPythonPath } from "./pythonManager";
+import {
+  getEnvVarsFromIdfTools,
+  getPythonPath,
+  getVirtualEnvPythonPath,
+} from "./pythonManager";
 import { IdfToolsManager } from "./idfToolsManager";
 
 const currentFolderMsg = vscode.l10n.t("ESP-IDF: Current Project");
@@ -1140,6 +1144,37 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   let pathNameInEnv: string = Object.keys(process.env).find(
     (k) => k.toUpperCase() == "PATH"
   );
+
+  const pythonBinPathExists = await pathExists(pythonBinPath);
+
+  if (pythonBinPathExists) {
+    const idfToolsExportVars = await getEnvVarsFromIdfTools(
+      modifiedEnv.IDF_PATH,
+      modifiedEnv.IDF_TOOLS_PATH,
+      pythonBinPath
+    );
+
+    if (idfToolsExportVars) {
+      try {
+        for (const envVar in idfToolsExportVars) {
+          if (envVar === pathNameInEnv) {
+            modifiedEnv[pathNameInEnv] = idfToolsExportVars[pathNameInEnv]
+              .replace("%PATH%", modifiedEnv[pathNameInEnv])
+              .replace("$PATH", modifiedEnv[pathNameInEnv]);
+          } else {
+            modifiedEnv[envVar] = idfToolsExportVars[envVar];
+          }
+        }
+      } catch (error) {
+        Logger.errorNotify(
+          "Invalid ESP-IDF idf_tools.py export environment variables format",
+          error,
+          "appendIdfAndToolsToPath idf_tools export env vars"
+        );
+      }
+    }
+  }
+
   if (pathToGitDir) {
     modifiedEnv[pathNameInEnv] =
       pathToGitDir + path.delimiter + modifiedEnv[pathNameInEnv];
@@ -1155,13 +1190,17 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     path.delimiter +
     modifiedEnv[pathNameInEnv];
 
-  if (
-    modifiedEnv[pathNameInEnv] &&
-    !modifiedEnv[pathNameInEnv].includes(extraPaths)
-  ) {
-    modifiedEnv[pathNameInEnv] =
-      extraPaths + path.delimiter + modifiedEnv[pathNameInEnv];
+  const extraPathsArray = extraPaths.split(path.delimiter);
+  for (let extraPath of extraPathsArray) {
+    if (
+      modifiedEnv[pathNameInEnv] &&
+      !modifiedEnv[pathNameInEnv].includes(extraPath)
+    ) {
+      modifiedEnv[pathNameInEnv] =
+        extraPath + path.delimiter + modifiedEnv[pathNameInEnv];
+    }
   }
+
   modifiedEnv[
     pathNameInEnv
   ] = `${IDF_ADD_PATHS_EXTRAS}${path.delimiter}${modifiedEnv[pathNameInEnv]}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1157,8 +1157,8 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     if (idfToolsExportVars) {
       try {
         for (const envVar in idfToolsExportVars) {
-          if (envVar === pathNameInEnv) {
-            modifiedEnv[pathNameInEnv] = idfToolsExportVars[pathNameInEnv]
+          if (envVar.toUpperCase() === pathNameInEnv.toUpperCase()) {
+            modifiedEnv[pathNameInEnv] = idfToolsExportVars[envVar]
               .replace("%PATH%", modifiedEnv[pathNameInEnv])
               .replace("$PATH", modifiedEnv[pathNameInEnv]);
           } else {

--- a/testFiles/testWorkspace/.vscode/settings.json
+++ b/testFiles/testWorkspace/.vscode/settings.json
@@ -12,5 +12,5 @@
   "window.dialogStyle": "custom",
   "idf.notificationMode": "Output",
   "idf.showOnboardingOnInit": false,
-  "idf.pythonInstallPath": "python"
+  "idf.pythonInstallPath": "/usr/bin/python"
 }

--- a/testFiles/testWorkspace/.vscode/settings.json
+++ b/testFiles/testWorkspace/.vscode/settings.json
@@ -12,5 +12,5 @@
   "window.dialogStyle": "custom",
   "idf.notificationMode": "Output",
   "idf.showOnboardingOnInit": false,
-  "idf.pythonInstallPath": "/usr/bin/python"
+  "idf.pythonInstallPath": "python"
 }


### PR DESCRIPTION
## Description

Use `idf_tools.py export --format key-value` to get ESP-IDF variables required in environment variables.

This should fix missing `ESP_IDF_VERSION` from extension tasks and use PATH from idf_tools.py (which is already done but could replace extension implementation.)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Probably the best way to verify that variables are present is to open `ESP-IDF: Open ESP-IDF Terminal` and do `echo $ESP_IDF_VERSION` or other environment variable from `idf_tools.py export` output.  

You can also test with any command like `ESP-IDF: Build your project` but harder to see if variables are available.

- Expected behaviour:

All variables from `idf_tools.py export --format key-value` should be available in extension commands like `ESP-IDF: Open ESP-IDF Terminal`

**Test Configuration**:
* ESP-IDF Version: 4.4 , 4.4.8, 5.0.4 5.4
* OS (Windows,Linux and macOS): macOS Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
