### PR TITLE
Enhance/uninstall improvement

### DIFF
--- a/docs_espressif/en/installation.rst
+++ b/docs_espressif/en/installation.rst
@@ -59,3 +59,26 @@ After installing Visual Studio Code you need to install the ESP-IDF extension fo
 
 .. warning::
   Check the :ref:`Troubleshooting <troubleshooting>` section if you have any issues during installation.
+
+Uninstall ESP-IDF VS Code Extension
+===========================
+
+To uninstall the ESP-IDF VS Code extension, follow these steps:
+
+1. Open Command Palette (F1) and type **ESP-IDF: Remove All ESP-IDF Settings** and select the command to remove all ESP-IDF settings.
+
+2. Navigate to **View** > **Extensions** or use the keyboard shortcut :kbd:`Ctrl+Shift+X` in Windows/Linux or :kbd:`Shift+⌘+X` in MacOS.
+
+3. Search for `ESP-IDF` and click on the **Uninstall** button.
+
+4. Ensure you remove the following folders:
+
+   - Go to your `${VSCODE_EXTENSION_DIR}` and delete the ESP-IDF plugin folder.
+   
+   - `${VSCODE_EXTENSION_DIR}` is the location of the extension:
+     - **Windows**: `%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\`
+     - **MacOS/Linux**: `$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/`
+
+.. note::
+
+  Make sure to replace `VERSION` with the actual version number of the ESP-IDF extension installed.

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -196,5 +196,18 @@
   "JTAG is soft-disabled ({0} is set to an odd value: {1}).": "JTAG está deshabilitado por software ({0} se ha establecido con un valor impar: {1}).",
   "JTAG selection may be affected by strapping configuration ({0} is set).": "La selección de JTAG puede verse afectada por la configuración de strapping (se ha establecido {0}).",
   "JTAG is not disabled.": "JTAG no está deshabilitado.",
-  "IDF Version >= 4.3.x required to have e-fuse view": "Se requiere IDF Versión >= 4.3.x para tener vista de e-fuse"
+  "IDF Version >= 4.3.x required to have e-fuse view": "Se requiere IDF Versión >= 4.3.x para tener vista de e-fuse",
+  "No ESP-IDF settings found to remove.": "No se encontró ninguna configuración de ESP-IDF para eliminar.",
+  "Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.": "¿Está seguro de que desea eliminar todas las configuraciones de ESP-IDF? Esto eliminará todas las configuraciones idf.*.",
+  "{0} settings will be removed.": "{0} configuraciones serán eliminadas.",
+  "Yes": "Sí",
+  "No": "No",
+  "Starting ESP-IDF settings cleanup...": "Iniciando limpieza de configuraciones ESP-IDF...",
+  "Removed global setting: {0}": "Configuración global eliminada: {0}",
+  "Removed workspace setting: {0}": "Configuración del espacio de trabajo eliminada: {0}",
+  "Removed workspace folder setting: {0}": "Configuración de la carpeta del espacio de trabajo eliminada: {0}",
+  "Warning: Could not fully remove setting {0}: {1}": "Advertencia: No se pudo eliminar completamente la configuración {0}: {1}",
+  "ESP-IDF settings removed successfully.": "Configuraciones de ESP-IDF eliminadas exitosamente.",
+  "Failed to remove settings: {0}": "Error al eliminar las configuraciones: {0}",
+  "Error: {0}": "Error: {0}"
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -196,5 +196,18 @@
   "JTAG is soft-disabled ({0} is set to an odd value: {1}).": "JTAG está desativado por software ({0} está definido com um valor ímpar: {1}).",
   "JTAG selection may be affected by strapping configuration ({0} is set).": "A seleção JTAG pode ser afetada pela configuração de strapping ({0} está definido).",
   "JTAG is not disabled.": "JTAG não está desativado.",
-  "IDF Version >= 4.3.x required to have e-fuse view": "IDF Versão >= 4.3.x necessária para ter visualização de e-fuse"
+  "IDF Version >= 4.3.x required to have e-fuse view": "IDF Versão >= 4.3.x necessária para ter visualização de e-fuse",
+  "No ESP-IDF settings found to remove.": "Nenhuma configuração do ESP-IDF encontrada para remover.",
+  "Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.": "Tem certeza que deseja remover todas as configurações do ESP-IDF? Isso excluirá todas as configurações idf.*.",
+  "{0} settings will be removed.": "{0} configurações serão removidas.",
+  "Yes": "Sim",
+  "No": "Não",
+  "Starting ESP-IDF settings cleanup...": "Iniciando limpeza das configurações ESP-IDF...",
+  "Removed global setting: {0}": "Configuração global removida: {0}",
+  "Removed workspace setting: {0}": "Configuração do espaço de trabalho removida: {0}",
+  "Removed workspace folder setting: {0}": "Configuração da pasta do espaço de trabalho removida: {0}",
+  "Warning: Could not fully remove setting {0}: {1}": "Aviso: Não foi possível remover completamente a configuração {0}: {1}",
+  "ESP-IDF settings removed successfully.": "Configurações ESP-IDF removidas com sucesso.",
+  "Failed to remove settings: {0}": "Falha ao remover configurações: {0}",
+  "Error: {0}": "Erro: {0}"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -196,5 +196,18 @@
   "JTAG is soft-disabled ({0} is set to an odd value: {1}).": "JTAG программно отключен ({0} установлен на нечетное значение: {1}).",
   "JTAG selection may be affected by strapping configuration ({0} is set).": "Выбор JTAG может зависеть от конфигурации стрэппинга (установлен {0}).",
   "JTAG is not disabled.": "JTAG не отключен.",
-  "IDF Version >= 4.3.x required to have e-fuse view": "Требуется IDF версии >= 4.3.x для просмотра e-fuse"
+  "IDF Version >= 4.3.x required to have e-fuse view": "Требуется IDF версии >= 4.3.x для просмотра e-fuse",
+  "No ESP-IDF settings found to remove.": "Настройки ESP-IDF для удаления не найдены.",
+  "Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.": "Вы уверены, что хотите удалить все настройки ESP-IDF? Это удалит все конфигурации idf.*.",
+  "{0} settings will be removed.": "{0} настроек будет удалено.",
+  "Yes": "Да",
+  "No": "Нет",
+  "Starting ESP-IDF settings cleanup...": "Начинается очистка настроек ESP-IDF...",
+  "Removed global setting: {0}": "Удалена глобальная настройка: {0}",
+  "Removed workspace setting: {0}": "Удалена настройка рабочего пространства: {0}",
+  "Removed workspace folder setting: {0}": "Удалена настройка папки рабочего пространства: {0}",
+  "Warning: Could not fully remove setting {0}: {1}": "Предупреждение: Не удалось полностью удалить настройку {0}: {1}",
+  "ESP-IDF settings removed successfully.": "Настройки ESP-IDF успешно удалены.",
+  "Failed to remove settings: {0}": "Не удалось удалить настройки: {0}",
+  "Error: {0}": "Ошибка: {0}"
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -196,5 +196,18 @@
   "JTAG is soft-disabled ({0} is set to an odd value: {1}).": "JTAG已软禁用（{0}设置为奇数值：{1}）。",
   "JTAG selection may be affected by strapping configuration ({0} is set).": "JTAG选择可能受到硬件配置的影响（已设置{0}）。",
   "JTAG is not disabled.": "JTAG未被禁用。",
-  "IDF Version >= 4.3.x required to have e-fuse view": "需要 IDF 版本 >= 4.3.x 才能查看 e-fuse"
+  "IDF Version >= 4.3.x required to have e-fuse view": "需要 IDF 版本 >= 4.3.x 才能查看 e-fuse",
+  "No ESP-IDF settings found to remove.": "未找到要删除的ESP-IDF设置。",
+  "Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.": "您确定要删除所有ESP-IDF设置吗？这将删除所有idf.*配置。",
+  "{0} settings will be removed.": "{0}个设置将被删除。",
+  "Yes": "是",
+  "No": "否",
+  "Starting ESP-IDF settings cleanup...": "正在开始清理ESP-IDF设置...",
+  "Removed global setting: {0}": "已删除全局设置：{0}",
+  "Removed workspace setting: {0}": "已删除工作区设置：{0}",
+  "Removed workspace folder setting: {0}": "已删除工作区文件夹设置：{0}",
+  "Warning: Could not fully remove setting {0}: {1}": "警告：无法完全删除设置 {0}：{1}",
+  "ESP-IDF settings removed successfully.": "ESP-IDF设置已成功删除。",
+  "Failed to remove settings: {0}": "删除设置失败：{0}",
+  "Error: {0}": "错误：{0}"
 }

--- a/package.json
+++ b/package.json
@@ -1191,6 +1191,11 @@
     ],
     "commands": [
       {
+        "command": "espIdf.removeEspIdfSettings",
+        "title": "espIdf.removeEspIdfSettings.title",
+        "category": "ESP-IDF"
+      },
+      {
         "command": "espIdf.openWalkthrough",
         "title": "ESP-IDF: Open Get Started Walkthrough"
       },

--- a/package.json
+++ b/package.json
@@ -1192,7 +1192,7 @@
     "commands": [
       {
         "command": "espIdf.removeEspIdfSettings",
-        "title": "espIdf.removeEspIdfSettings.title",
+        "title": "%espIdf.removeEspIdfSettings.title%",
         "category": "ESP-IDF"
       },
       {

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -94,6 +94,7 @@
 	"esp_idf.tmoScaleFactor.description": "Factor de escala para el tiempo de espera de gdb [predeterminado:1]",
 	"esp_idf.verifyAppBinBeforeDebug.description": "Verificar binarios de la aplicación antes de depurar",
 	"espIdf.searchError.title": "ESP-IDF: Sugerencia de error de búsqueda",
+	"espIdf.removeEspIdfSettings.title": "Eliminar configuración de ESP-IDF",
 	"idf.flashType.description": "Método de flasheo del dispositivo, UART o JTag",
 	"idf.wssPort.description": "Puerto del servidor de socket web para Core Dump o GDB Stub",
 	"openocd.tcl.host.description": "Host para conexión tcl de Openocd",

--- a/package.nls.json
+++ b/package.nls.json
@@ -94,6 +94,7 @@
   "esp_idf.tmoScaleFactor.description": "Scale factor for gdb timeout [default:1]",
   "esp_idf.verifyAppBinBeforeDebug.description": "Verify app binaries before debug",
   "espIdf.searchError.title": "ESP-IDF: Search Error Hint",
+  "espIdf.removeEspIdfSettings.title": "Remove ESP-IDF Settings",
   "idf.flashType.description": "Device flash method, UART or JTag",
   "idf.wssPort.description": "Web Socket Server Port for Core Dump or GDB Stub",
   "openocd.tcl.host.description": "Host for OpenOCD tcl connection",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -93,6 +93,8 @@
 	"esp_idf.initGdbCommands.description": "Um ou mais comandos GDB a serem executados para configurar o depurador subjacente. ",
 	"esp_idf.tmoScaleFactor.description": "Fator de escala para tempo limite do gdb [padrão: 1]",
 	"esp_idf.verifyAppBinBeforeDebug.description": "Verifique os binários do aplicativo antes da depuração",
+	"espIdf.searchError.title": "ESP-IDF: Buscar Dica de Erro",
+	"espIdf.removeEspIdfSettings.title": "Remover Configurações ESP-IDF",
 	"idf.flashType.description": "Método flash do dispositivo, UART ou JTag",
 	"idf.wssPort.description": "Porta do servidor Web Socket para Core Dump ou GDB Stub",
 	"openocd.tcl.host.description": "Host para conexão OpenOCD tcl",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -94,6 +94,7 @@
 	"esp_idf.tmoScaleFactor.description": "Масштабный коэффициент для тайм-аута GDB [по умолчанию: 1]",
 	"esp_idf.verifyAppBinBeforeDebug.description": "Проверьте двоичные файлы приложения перед отладкой",
 	"espIdf.searchError.title": "ESP-IDF: Подсказка об ошибке поиска",
+	"espIdf.removeEspIdfSettings.title": "Удалить настройки ESP-IDF",
 	"idf.flashType.description": "Метод прошивки устройства, UART или JTag",
 	"idf.wssPort.description": "Порт веб-сокет-сервера для дампа ядра или заглушки GDB",
 	"openocd.tcl.host.description": "Хост для подключения openocd tcl",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -94,6 +94,7 @@
 	"esp_idf.tmoScaleFactor.description": "GDB 超时的缩放因子 [默认值：1]",
 	"esp_idf.verifyAppBinBeforeDebug.description": "在调试前验证应用程序二进制文件",
 	"espIdf.searchError.title": "ESP-IDF： 搜索错误提示",
+	"espIdf.removeEspIdfSettings.title": "删除 ESP-IDF 设置",
 	"idf.flashType.description": "设备烧录方法，UART 或 JTag",
 	"idf.wssPort.description": "用于 Core Dump 或 GDB Stub 的 Web Socket 服务器端口",
 	"openocd.tcl.host.description": "用于 OpenOCD tcl 连接的主机",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3726,7 +3726,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Remove ESP-IDF settings
   context.subscriptions.push(
-    vscode.commands.registerCommand('espIdf.removeEspIdfSettings', removeEspIdfSettings)
+    vscode.commands.registerCommand(
+      "espIdf.removeEspIdfSettings",
+      removeEspIdfSettings
+    )
   );
 }
 
@@ -3735,11 +3738,11 @@ async function removeEspIdfSettings() {
   const settingsToDelete: string[] = [];
 
   // Helper function to recursively find idf settings
-  function findIdfSettings(obj: any, prefix: string = '') {
-    if (typeof obj === 'object' && obj !== null) {
-      Object.keys(obj).forEach(key => {
+  function findIdfSettings(obj: any, prefix: string = "") {
+    if (typeof obj === "object" && obj !== null) {
+      Object.keys(obj).forEach((key) => {
         const fullPath = prefix ? `${prefix}.${key}` : key;
-        if (fullPath.startsWith('idf.') || fullPath.startsWith('esp.')) {
+        if (fullPath.startsWith("idf.") || fullPath.startsWith("esp.")) {
           settingsToDelete.push(fullPath);
         }
         findIdfSettings(obj[key], fullPath);
@@ -3748,7 +3751,7 @@ async function removeEspIdfSettings() {
   }
 
   // Get all settings directly from configuration
-  const allSettings = config.inspect('');
+  const allSettings = config.inspect("");
   // Check values saved in each scope
   if (allSettings?.globalValue) {
     findIdfSettings(allSettings.globalValue);
@@ -3761,32 +3764,39 @@ async function removeEspIdfSettings() {
     findIdfSettings(allSettings.workspaceFolderValue);
   }
 
-  if(settingsToDelete.length === 0) {
-    vscode.window.showInformationMessage("No ESP-IDF settings found to remove.");
-    return ;
+  if (settingsToDelete.length === 0) {
+    vscode.window.showInformationMessage(
+      vscode.l10n.t("No ESP-IDF settings found to remove.")
+    );
+    return;
   }
 
   // Filter out any duplicate paths
   const uniqueSettingsToDelete = [...new Set(settingsToDelete)];
 
   // Ask user for confirmation
-  const message = 'Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.';
+  const message = vscode.l10n.t(
+    "Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations."
+  );
   const result = await vscode.window.showWarningMessage(
     message,
     {
       modal: true,
-      detail: `${uniqueSettingsToDelete.length} settings will be removed.`
+      detail: vscode.l10n.t(
+        "{0} settings will be removed.",
+        uniqueSettingsToDelete.length
+      ),
     },
-    'Yes',
-    'No'
+    vscode.l10n.t("Yes"),
+    vscode.l10n.t("No")
   );
 
-  if (result !== 'Yes') {
+  if (result !== vscode.l10n.t("Yes")) {
     return;
   }
 
   try {
-    const message = 'Starting ESP-IDF settings cleanup...';
+    const message = vscode.l10n.t("Starting ESP-IDF settings cleanup...");
     OutputChannel.appendLineAndShow(message);
     Logger.info(message);
 
@@ -3798,8 +3808,14 @@ async function removeEspIdfSettings() {
         try {
           const inspection = config.inspect(setting);
           if (inspection?.globalValue !== undefined) {
-            await config.update(setting, undefined, vscode.ConfigurationTarget.Global);
-            OutputChannel.appendLine(`Removed global setting: ${setting}`);
+            await config.update(
+              setting,
+              undefined,
+              vscode.ConfigurationTarget.Global
+            );
+            OutputChannel.appendLine(
+              vscode.l10n.t("Removed global setting: {0}", setting)
+            );
           }
         } catch (e) {
           // Silently continue if we can't modify global settings
@@ -3809,8 +3825,14 @@ async function removeEspIdfSettings() {
         try {
           const inspection = config.inspect(setting);
           if (inspection?.workspaceValue !== undefined) {
-            await config.update(setting, undefined, vscode.ConfigurationTarget.Workspace);
-            OutputChannel.appendLine(`Removed workspace setting: ${setting}`);
+            await config.update(
+              setting,
+              undefined,
+              vscode.ConfigurationTarget.Workspace
+            );
+            OutputChannel.appendLine(
+              vscode.l10n.t("Removed workspace setting: {0}", setting)
+            );
           }
         } catch (e) {
           // Silently continue if we can't modify workspace settings
@@ -3820,23 +3842,40 @@ async function removeEspIdfSettings() {
         try {
           const inspection = config.inspect(setting);
           if (inspection?.workspaceFolderValue !== undefined) {
-            await config.update(setting, undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-            OutputChannel.appendLine(`Removed workspace folder setting: ${setting}`);
+            await config.update(
+              setting,
+              undefined,
+              vscode.ConfigurationTarget.WorkspaceFolder
+            );
+            OutputChannel.appendLine(
+              vscode.l10n.t("Removed workspace folder setting: {0}", setting)
+            );
           }
         } catch (e) {
           // Silently continue if we can't modify workspace folder settings
         }
       } catch (settingError) {
-        OutputChannel.appendLine(`Warning: Could not fully remove setting ${setting}: ${settingError.message}`);
+        OutputChannel.appendLine(
+          vscode.l10n.t(
+            "Warning: Could not fully remove setting {0}: {1}",
+            setting,
+            settingError.message
+          )
+        );
       }
     }
 
-    OutputChannel.appendLineAndShow('ESP-IDF settings removed successfully.');
+    OutputChannel.appendLineAndShow(
+      vscode.l10n.t("ESP-IDF settings removed successfully.")
+    );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to remove settings: ${errorMessage}`);
-    OutputChannel.appendLineAndShow(`Error: ${errorMessage}`);
-    Logger.error(errorMessage, error, 'extension removeEspIdfSettings');
+    vscode.window.showErrorMessage(
+      vscode.l10n.t("Failed to remove settings: {0}"),
+      errorMessage
+    );
+    OutputChannel.appendLineAndShow(vscode.l10n.t("Error: {0}"), errorMessage);
+    Logger.error(errorMessage, error, "extension removeEspIdfSettings");
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3723,6 +3723,121 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   checkAndNotifyMissingCompileCommands();
+
+  // Remove ESP-IDF settings
+  context.subscriptions.push(
+    vscode.commands.registerCommand('espIdf.removeEspIdfSettings', removeEspIdfSettings)
+  );
+}
+
+async function removeEspIdfSettings() {
+  const config = vscode.workspace.getConfiguration();
+  const settingsToDelete: string[] = [];
+
+  // Helper function to recursively find idf settings
+  function findIdfSettings(obj: any, prefix: string = '') {
+    if (typeof obj === 'object' && obj !== null) {
+      Object.keys(obj).forEach(key => {
+        const fullPath = prefix ? `${prefix}.${key}` : key;
+        if (fullPath.startsWith('idf.') || fullPath.startsWith('esp.')) {
+          settingsToDelete.push(fullPath);
+        }
+        findIdfSettings(obj[key], fullPath);
+      });
+    }
+  }
+
+  // Get all settings directly from configuration
+  const allSettings = config.inspect('');
+  // Check values saved in each scope
+  if (allSettings?.globalValue) {
+    findIdfSettings(allSettings.globalValue);
+  }
+  if (allSettings?.workspaceValue) {
+    findIdfSettings(allSettings.workspaceValue);
+  }
+
+  if (allSettings?.workspaceFolderValue) {
+    findIdfSettings(allSettings.workspaceFolderValue);
+  }
+
+  if(settingsToDelete.length === 0) {
+    vscode.window.showInformationMessage("No ESP-IDF settings found to remove.");
+    return ;
+  }
+
+  // Filter out any duplicate paths
+  const uniqueSettingsToDelete = [...new Set(settingsToDelete)];
+
+  // Ask user for confirmation
+  const message = 'Are you sure you want to remove all ESP-IDF settings? This will delete all idf.* configurations.';
+  const result = await vscode.window.showWarningMessage(
+    message,
+    {
+      modal: true,
+      detail: `${uniqueSettingsToDelete.length} settings will be removed.`
+    },
+    'Yes',
+    'No'
+  );
+
+  if (result !== 'Yes') {
+    return;
+  }
+
+  try {
+    const message = 'Starting ESP-IDF settings cleanup...';
+    OutputChannel.appendLineAndShow(message);
+    Logger.info(message);
+
+    // Delete each setting
+    for (const setting of uniqueSettingsToDelete) {
+      try {
+        // Try to remove from each scope, but handle errors silently
+        // Global settings
+        try {
+          const inspection = config.inspect(setting);
+          if (inspection?.globalValue !== undefined) {
+            await config.update(setting, undefined, vscode.ConfigurationTarget.Global);
+            OutputChannel.appendLine(`Removed global setting: ${setting}`);
+          }
+        } catch (e) {
+          // Silently continue if we can't modify global settings
+        }
+
+        // Workspace settings
+        try {
+          const inspection = config.inspect(setting);
+          if (inspection?.workspaceValue !== undefined) {
+            await config.update(setting, undefined, vscode.ConfigurationTarget.Workspace);
+            OutputChannel.appendLine(`Removed workspace setting: ${setting}`);
+          }
+        } catch (e) {
+          // Silently continue if we can't modify workspace settings
+        }
+
+        // WorkspaceFolder settings
+        try {
+          const inspection = config.inspect(setting);
+          if (inspection?.workspaceFolderValue !== undefined) {
+            await config.update(setting, undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+            OutputChannel.appendLine(`Removed workspace folder setting: ${setting}`);
+          }
+        } catch (e) {
+          // Silently continue if we can't modify workspace folder settings
+        }
+      } catch (settingError) {
+        OutputChannel.appendLine(`Warning: Could not fully remove setting ${setting}: ${settingError.message}`);
+      }
+    }
+
+    OutputChannel.appendLineAndShow('ESP-IDF settings removed successfully.');
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to remove settings: ${errorMessage}`);
+    OutputChannel.appendLineAndShow(`Error: ${errorMessage}`);
+    Logger.error(errorMessage, error, 'extension removeEspIdfSettings');
+  }
 }
 
 function checkAndNotifyMissingCompileCommands() {


### PR DESCRIPTION
## Description

Added command for the user to remove all esp-idf settings from the settings.json files that can be opened with:
```
Preferences: Open Workspace Settings (JSON) (workspace Folder)
Preferences: Open User Settings (JSON) (global settings)
```
And also the settings from .code-workspace (multi-project)

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Steps to test this pull request

Remove all settings using the command **ESP-IDF: Remove ESP-IDF Settings**

## How has this been tested?

Used the command and saw all the settings were removed as expected.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows 

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
