### PR TITLE
[VSC-1534] Fix Install Extension Python Requirements

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -182,7 +182,12 @@ export async function installExtensionPyReqs(
     OutputChannel.appendLine(debugAdapterRequirements + reqDoesNotExists);
     return;
   }
-  const espIdfVersion = await utils.getEspIdfFromCMake(espDir);
+  const fullEspIdfVersion = await utils.getEspIdfFromCMake(espDir);
+  const majorMinorMatches = fullEspIdfVersion.match(/([0-9]+\.[0-9]+).*/);
+  const espIdfVersion =
+    majorMinorMatches && majorMinorMatches.length > 0
+      ? majorMinorMatches[1]
+      : "x.x";
   const constrainsFile = join(
     idfToolsDir,
     `espidf.constraints.v${espIdfVersion}.txt`


### PR DESCRIPTION
## Description

Bug: Constraints File Path Mismatch

The extension currently searches for ESP-IDF constraint files using the full version number (including patch version), but ESP-IDF only uses major.minor versions in the filename.

Example:
- Current code looks for: `espidf.constraints.v5.3.1`
- Actual ESP-IDF filename: `espidf.constraints.v5.3`

This PR fixes the version parsing to correctly match ESP-IDF's constraint file naming convention.

This PR changes this behavior.
## Type of change

- Bug fix (non-breaking change which fixes an issue)
## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1) Have a project created with v5.3.1 of esp-idf.
2) Build + select device target
3) Use the command from ESP-IDF Explorer: Advanced > Install Extension Python Requirements
4) Try to change device target (it should work)

Before this bugfix, changing the device target would not work because of the error in the logs: `The following Python requirements are not satisfied`

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
