### PR TITLE
[VSC-1538] rm use of wmic in favor of Get WmiObject

### DIFF
--- a/src/PlatformInformation.ts
+++ b/src/PlatformInformation.ts
@@ -92,8 +92,12 @@ export class PlatformInformation {
   }
 
   private static GetWindowsArchitecture(): Promise<string> {
-    const command = "wmic";
-    const args = ["os", "get", "osarchitecture"];
+    const command = "powershell";
+    const args = [
+      "-executionPolicy",
+      "bypass",
+      "(Get-WmiObject Win32_OperatingSystem).OSArchitecture",
+    ];
     return utils
       .execChildProcess(command, args, utils.extensionContext.extensionPath)
       .then((architecture) => {


### PR DESCRIPTION
## Description

Remove deprecated `wmic` in favor of calling `Get-WmiObject Win32_OperatingSystem` from powershell.

Fixes #1364

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Configure ESP-IDF Extension"
2. Execute action. Setup should work normally in Windows regardless of current terminal defaults shell. Check ESP-IDF: Doctor Command.
3. Observe results. 

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
