### PR TITLE
[VSC-1539] Fix scenario for partial encryption

### DIFF
--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -210,22 +210,44 @@ export class FlashTask {
         this.model.flashSections &&
         this.model.flashSections.length === encryptedFlashSections.length
       ) {
+        // If all files need encryption, then use --encrypt flag
         flasherArgs.push("--encrypt");
+        // Add all files
+        for (const flashFile of this.model.flashSections) {
+          let binPath = replacePathSep
+            ? flashFile.binFilePath.replace(/\//g, "\\")
+            : flashFile.binFilePath;
+          flasherArgs.push(flashFile.address, binPath);
+        }
       } else {
+        // If only some files need encryption, then use --encrypt-files flag
         flasherArgs.push("--encrypt-files");
+        // First add encrypted files
         for (const flashFile of encryptedFlashSections) {
           let binPath = replacePathSep
             ? flashFile.binFilePath.replace(/\//g, "\\")
             : flashFile.binFilePath;
           flasherArgs.push(flashFile.address, binPath);
         }
+        // Then add unencrypted files
+
+        const unencryptedSections = this.model.flashSections.filter(
+          (section) => !section.encrypted
+        );
+        for (const flashFile of unencryptedSections) {
+          let binPath = replacePathSep
+            ? flashFile.binFilePath.replace(/\//g, "\\")
+            : flashFile.binFilePath;
+          flasherArgs.push(flashFile.address, binPath);
+        }
       }
-    }
-    for (const flashFile of this.model.flashSections) {
-      let binPath = replacePathSep
-        ? flashFile.binFilePath.replace(/\//g, "\\")
-        : flashFile.binFilePath;
-      flasherArgs.push(flashFile.address, binPath);
+    } else {
+      for (const flashFile of this.model.flashSections) {
+        let binPath = replacePathSep
+          ? flashFile.binFilePath.replace(/\//g, "\\")
+          : flashFile.binFilePath;
+        flasherArgs.push(flashFile.address, binPath);
+      }
     }
 
     return flasherArgs;

--- a/src/flash/flashTask.ts
+++ b/src/flash/flashTask.ts
@@ -220,17 +220,8 @@ export class FlashTask {
           flasherArgs.push(flashFile.address, binPath);
         }
       } else {
-        // If only some files need encryption, then use --encrypt-files flag
-        flasherArgs.push("--encrypt-files");
-        // First add encrypted files
-        for (const flashFile of encryptedFlashSections) {
-          let binPath = replacePathSep
-            ? flashFile.binFilePath.replace(/\//g, "\\")
-            : flashFile.binFilePath;
-          flasherArgs.push(flashFile.address, binPath);
-        }
-        // Then add unencrypted files
-
+        // If only some files need encryption, handle them separately
+        // First add all unencrypted files normally
         const unencryptedSections = this.model.flashSections.filter(
           (section) => !section.encrypted
         );
@@ -240,8 +231,17 @@ export class FlashTask {
             : flashFile.binFilePath;
           flasherArgs.push(flashFile.address, binPath);
         }
+        // Then add encrypted files after the --encrypt-files flag
+        flasherArgs.push("--encrypt-files");
+        for (const flashFile of encryptedFlashSections) {
+          let binPath = replacePathSep
+            ? flashFile.binFilePath.replace(/\//g, "\\")
+            : flashFile.binFilePath;
+          flasherArgs.push(flashFile.address, binPath);
+        }
       }
     } else {
+      // No encryption needed, just add all files
       for (const flashFile of this.model.flashSections) {
         let binPath = replacePathSep
           ? flashFile.binFilePath.replace(/\//g, "\\")


### PR DESCRIPTION
## Description

**Work in progress:**
From the output received from the user, it seems there are some duplicated arguments if we are using "--encrypted-files" flag.
When the flash command tries to write to 0x0 twice, it might be corrupting the encrypted bootloader

Fixes [#1366](https://github.com/espressif/vscode-esp-idf-extension/issues/1366)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
