### PR TITLE
[VSC-1544] update test case regex

### DIFF
--- a/src/espIdf/unitTest/adapter.ts
+++ b/src/espIdf/unitTest/adapter.ts
@@ -202,7 +202,7 @@ export class UnitTest {
       children: [],
       testName: "TEST_ALL",
     };
-    const testRegex = new RegExp('TEST_CASE\\("(.*)",\\s*"(.*)"\\)', "gm");
+    const testRegex = new RegExp('TEST_CASE\\(\\s*"(.*)"\\s*,\\s*"(.*)"\\s*\\)', "gm");
     const fileText = await readFile(file.fsPath, "utf8");
     let match = testRegex.exec(fileText);
     while (match != null) {


### PR DESCRIPTION
## Description

Update TEST_CASE regex to support spaces between ( and " such as:

`TEST_CASE( "New test i just made" , "[mean][fails]" )` and `TEST_CASE("New test d i just made","[mean][fails]")`

this happens when clang auto format on test_*.c files.

Fixes #1371

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open a ESP-IDF projects with unit tests like the [unity_test]() example.
2. Click on `Testing` tab in the side panel activity bar. Test should be autodiscovered.
3. Update test name to include spaces like the ones shown in description. Click refresh button. Test should be still visible.
4. Observe results.

- Expected behaviour:
Test with spaces between ( and " should be shown in Testing tab

## How has this been tested?

Manual testing.

**Test Configuration**:
* ESP-IDF Version: 5.3.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
