### PR TITLE
[VSC-1537] use IDF_TARGET in customExtraVars if no sdkconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,8 +555,9 @@ We have implemented some utilities commands that can be used in `tasks.json` and
 - `espIdf.getOpenOcdScriptValue`: Return the value of OPENOCD_SCRIPTS computed from ESP-IDF Tools path, `idf.customExtraVars`, or the system's OPENOCD_SCRIPTS environment variable.
 - `espIdf.getOpenOcdConfig`: Return the openOCD configuration files as string. Example `-f interface/ftdi/esp32_devkitj_v1.cfg -f board/esp32-wrover.cfg`.
 - `espIdf.getProjectName`: Return the project name from current workspace folder `build/project_description.json`.
-- `espIdf.getToolchainGcc`: Return the absolute path of the toolchain GCC for the ESP-IDF target given by current IDF_TARGET in sdkconfig.
-- `espIdf.getToolchainGdb`: Return the absolute path of the toolchain gdb for the ESP-IDF target given by current IDF_TARGET in sdkconfig.
+- `espIdf.getToolchainGcc`: Return the absolute path of the toolchain GCC for the ESP-IDF target given by current IDF_TARGET in sdkconfig or `idf.customExtraVars`["IDF_TARGET"] configuration setting.
+- `espIdf.getToolchainGdb`: Return the absolute path of the toolchain gdb for the ESP-IDF target given by current IDF_TARGET in sdkconfig or `idf.customExtraVars`["IDF_TARGET"] configuration setting.
+- `espIdf.getIDFTarget`: Return the current IDF_TARGET from sdkconfig or `idf.customExtraVars`["IDF_TARGET"] configuration setting.
 
 See an example in the [debugging](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/debugproject.html) documentation.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -555,8 +555,9 @@ ESP-IDF 扩展在 VS Code 底部蓝色窗口的状态栏中提供了一系列命
 - `espIdf.getOpenOcdScriptValue`：返回从 ESP-IDF 工具路径、`idf.customExtraVars` 或系统 OPENOCD_SCRIPTS 环境变量中计算出的 OPENOCD_SCRIPTS 的值。
 - `espIdf.getOpenOcdConfig`：以字符串形式返回 openOCD 配置文件。例如 `-f interface/ftdi/esp32_devkitj_v1.cfg -f board/esp32-wrover.cfg`。
 - `espIdf.getProjectName`：从当前工作区文件夹的 `build/project_description.json` 文件中提取项目名称。
-- `espIdf.getToolchainGcc`：根据 sdkconfig 文件中指定的 IDF_TARGET，该命令将返回相应 GCC 工具链的绝对路径。
-- `espIdf.getToolchainGdb`：根据 sdkconfig 文件中指定的 IDF_TARGET，该命令将返回相应 GDB 工具链的绝对路径。
+- `espIdf.getToolchainGcc`：根据 sdkconfig 或 `idf.customExtraVars`[“IDF_TARGET”] 文件中指定的 IDF_TARGET，该命令将返回相应 GCC 工具链的绝对路径。
+- `espIdf.getToolchainGdb`：根据 sdkconfig 或 `idf.customExtraVars`[“IDF_TARGET”] 文件中指定的 IDF_TARGET，该命令将返回相应 GDB 工具链的绝对路径。
+- `espIdf.getIDFTarget`: 根据 sdkconfig 或 `idf.customExtraVars`[“IDF_TARGET”] 该命令将返回相应 IDF_TARGET。
 
 在[调试](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/debugproject.html)文档中查看示例。
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "onCommand:espIdf.apptrace.archive.showReport",
     "onCommand:espIdf.apptrace.customize",
     "onCommand:espIdf.getExtensionPath",
+    "onCommand:espIdf.getIDFTarget",
     "onCommand:espIdf.getOpenOcdConfigs",
     "onCommand:espIdf.genCoverage",
     "onCommand:espIdf.partition.table.refresh",

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -66,6 +66,17 @@ export async function setIdfTarget(
         if (!selectedTarget) {
           return;
         }
+        const customExtraVars = readParameter(
+          "idf.customExtraVars",
+          workspaceFolder
+        ) as { [key: string]: string };
+        customExtraVars["IDF_TARGET"] = selectedTarget.target;
+        await writeParameter(
+          "idf.customExtraVars",
+          customExtraVars,
+          configurationTarget,
+          workspaceFolder.uri
+        );
         const openOcdScriptsPath = await getOpenOcdScripts(workspaceFolder.uri);
         const boards = await getBoards(
           openOcdScriptsPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -508,6 +508,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(sdkWatchDisposable);
   const sdkDeleteWatchDisposable = sdkconfigWatcher.onDidDelete(async () => {
     ConfserverProcess.dispose();
+    await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
   });
   context.subscriptions.push(sdkDeleteWatchDisposable);
 
@@ -1234,6 +1235,8 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     } else if (e.affectsConfiguration("idf.buildPath")) {
       updateIdfComponentsTree(workspaceRoot);
+    } else if (e.affectsConfiguration("idf.customExtraVars")) {
+      await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
     }
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2155,6 +2155,10 @@ export async function activate(context: vscode.ExtensionContext) {
     return context.extensionPath;
   });
 
+  registerIDFCommand("espIdf.getIDFTarget", async () => {
+    return await getIdfTargetFromSdkconfig(workspaceRoot);
+  });
+
   registerIDFCommand("espIdf.getOpenOcdConfigs", () => {
     const openOcfConfigs = idfConf.readParameter(
       "idf.openOcdConfigs",

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -259,6 +259,10 @@ export function resolveVariables(
     }
     if (match.indexOf("env:") > 0) {
       const envVariable = name.substring(name.indexOf("env:") + "env:".length);
+      const customExtraVars = readParameter("idf.customExtraVars", scope);
+      if (Object.keys(customExtraVars).indexOf(envVariable) !== -1) {
+        return customExtraVars[envVariable];
+      }
       if (Object.keys(process.env).indexOf(envVariable) === -1) {
         return "";
       }

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 import * as fs from "fs";
-import { pathExists } from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
 import { IdfTreeDataProvider } from "./idfComponentsDataProvider";
 import { Logger } from "./logger/logger";
 import * as utils from "./utils";
-import { getSDKConfigFilePath } from "./utils";
+import { readParameter } from "./idfConfiguration";
 
 export function initSelectedWorkspace(status?: vscode.StatusBarItem) {
   const workspaceRoot = vscode.workspace.workspaceFolders[0].uri;
@@ -93,6 +92,13 @@ export async function getIdfTargetFromSdkconfig(
     );
     let idfTarget = configIdfTarget.replace(/\"/g, "");
     if (!idfTarget) {
+      const customExtraVars = readParameter(
+        "idf.customExtraVars",
+        workspacePath
+      ) as { [key: string]: string };
+      idfTarget = customExtraVars["IDF_TARGET"];
+    }
+    if (!idfTarget) {
       idfTarget = "esp32";
     }
     if (statusItem) {
@@ -100,9 +106,14 @@ export async function getIdfTargetFromSdkconfig(
     }
     return idfTarget;
   } catch (error) {
+    const customExtraVars = readParameter(
+      "idf.customExtraVars",
+      workspacePath
+    ) as { [key: string]: string };
+    let idfTarget = customExtraVars["IDF_TARGET"] || "esp32";
     if (statusItem) {
-      statusItem.text = "$(chip) esp32";
+      statusItem.text = `$(chip) ${idfTarget}`;
     }
-    return "esp32";
+    return idfTarget;
   }
 }


### PR DESCRIPTION
## Description

To find the current IDF_TARGET the extension reads the sdkconfig in v1.9.0 but before there was a `idf.adapterTargetName` configuration setting which was used to resolve IDF_TARGET. The previous logic would fail if the current project is configure for a target (say esp32) but the configuration setting is set to (say esp32c3).

Reading from sdkconfig seems like a better approach, but what happens when you want to define a IDF_TARGET but no sdkconfig exists ? For this case we still need to persist this somehow. Now we would use `idf.customExtraVars` configuration setting and add `IDF_TARGET` when running the `ESP-IDF: Set Espressif Device Target` command. The extension will use this value when sdkconfig IDF_TARGET value doesn't exist.

Also add `idf.customExtraVars` to idfConfiguration.ts readParameter. When a user has a setting with value ${env:VARNAME} now it will also use `idf.customExtraVars` to resolve it. For example `"idf.svdFilePath": "${workspaceFolder}/${env:IDF_TARGET}.svd"`

Fixes #1363 
Fixes #1386

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request


1. Run the `ESP-IDF: Set Espressif Device Target` on a ESP-IDF project. This will create an sdkconfig file and build project.
2. Delete the build directory and sdkconfig file.
3. Run the `ESP-IDF: Build your project` command. The project should build with the target defined before instead of previously default esp32.

- Expected behaviour:

The IDF_TARGET that was set in 1 is still used when sdkconfig has been deleted for other extension commands like `ESP-IDF: Build your project`.

- Expected output:

The IDF_TARGET that was set in 1 is still used when sdkconfig has been deleted for other extension commands like `ESP-IDF: Build your project`.

## How has this been tested?

Manual test by following steps above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
