### PR TITLE
[VSC-1551] rm powershell no profile arg idf terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4272,7 +4272,7 @@ function createIdfTerminal(extensionPath: string) {
         vscode.env.shell.indexOf("powershell") !== -1 ||
         vscode.env.shell.indexOf("pwsh") !== -1
       ) {
-        shellArgs = ["-ExecutionPolicy", "Bypass", "-NoProfile"];
+        shellArgs = ["-ExecutionPolicy", "Bypass"];
       }
     }
     const espIdfTerminal = vscode.window.createTerminal({


### PR DESCRIPTION
## Description

Remove `-NoProfile` argument in `ESP-IDF: Open ESP-IDF Terminal` to avoid user restriction of profiles. Was added due to script need to run in Powershell to ByPass execution policy in order to add command shortcuts.

Fixes #1387

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Open ESP-IDF Terminal`". The Terminal should allow user to apply a Powershell profile now.
2. Execute action.
3. Observe results.

## How has this been tested?

Manual testing on Windows.

**Test Configuration**:
* ESP-IDF Version: 5.3.2
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
