### PR TITLE
add missing espressif doc link

### DIFF
--- a/docs/tutorial/install.md
+++ b/docs/tutorial/install.md
@@ -1,0 +1,7 @@
+# Documentation has moved to:
+
+# [English](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/)
+
+# 文档已移至
+
+# [中文](https://docs.espressif.com/projects/vscode-esp-idf-extension/zh_CN/latest/index.html)


### PR DESCRIPTION
## Description

Current stable [ESP-IDF v5.3.2 documentation](https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/get-started/index.html) has a link to `docs/tutorial/install.md` which can't be updated. This PR add the missing file with links to new documentation.

## Type of change

- This change requires a documentation update

## Steps to test this pull request

Click the VSCode Extension link in https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/get-started/index.html After this PR is merged this is fixed.

## How has this been tested?

No test need.

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS
