### PR TITLE
[VSC-1552] Resolve folder when using launch config from code-workspace

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -21,6 +21,7 @@ import {
   DebugConfiguration,
   DebugConfigurationProvider,
   WorkspaceFolder,
+  window
 } from "vscode";
 import { readParameter } from "../idfConfiguration";
 import { getIdfTargetFromSdkconfig, getProjectName } from "../workspaceConfig";
@@ -40,6 +41,14 @@ export class CDTDebugConfigurationProvider
     token?: CancellationToken
   ): Promise<DebugConfiguration> {
     try {
+      if (!folder) {
+        folder = await window.showWorkspaceFolderPick({
+          placeHolder: "Pick a workspace folder to start a debug session.",
+        });
+        if (!folder) {
+          throw new Error("No folder was selected to start debug session");
+        }
+      }
       if (!config.program) {
         const buildDirPath = readParameter("idf.buildPath", folder) as string;
         const projectName = await getProjectName(buildDirPath);

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,7 @@ export namespace ESP {
   export namespace GlobalConfiguration {
     export let store: ExtensionConfigStore;
     export const IDF_SETUPS = "IDF_SETUPS";
+    export const SELECTED_WORKSPACE_FOLDER = "SELECTED_WORKSPACE_FOLDER";
   }
 
   export const platformDepConfigurations: string[] = [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -324,6 +324,10 @@ export async function activate(context: vscode.ExtensionContext) {
   if (PreCheck.isWorkspaceFolderOpen()) {
     await createCmdsStatusBarItems(vscode.workspace.workspaceFolders[0].uri);
     workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+    ESP.GlobalConfiguration.store.set(
+      ESP.GlobalConfiguration.SELECTED_WORKSPACE_FOLDER,
+      workspaceRoot
+    );
     await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
     if (statusBarItems && statusBarItems["port"]) {
       statusBarItems["port"].text =
@@ -409,6 +413,10 @@ export async function activate(context: vscode.ExtensionContext) {
         for (const ws of e.removed) {
           if (workspaceRoot && ws.uri === workspaceRoot) {
             workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+            ESP.GlobalConfiguration.store.set(
+              ESP.GlobalConfiguration.SELECTED_WORKSPACE_FOLDER,
+              workspaceRoot
+            );
             await getIdfTargetFromSdkconfig(
               workspaceRoot,
               statusBarItems["target"]
@@ -452,6 +460,10 @@ export async function activate(context: vscode.ExtensionContext) {
         }
         if (typeof workspaceRoot === undefined) {
           workspaceRoot = initSelectedWorkspace(statusBarItems["workspace"]);
+          ESP.GlobalConfiguration.store.set(
+            ESP.GlobalConfiguration.SELECTED_WORKSPACE_FOLDER,
+            workspaceRoot
+          );
           await getIdfTargetFromSdkconfig(
             workspaceRoot,
             statusBarItems["target"]
@@ -966,6 +978,10 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
         workspaceRoot = option.uri;
+        ESP.GlobalConfiguration.store.set(
+          ESP.GlobalConfiguration.SELECTED_WORKSPACE_FOLDER,
+          workspaceRoot
+        );
         await getIdfTargetFromSdkconfig(
           workspaceRoot,
           statusBarItems["target"]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1208,15 +1208,6 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     pathNameInEnv
   ] = `${IDF_ADD_PATHS_EXTRAS}${path.delimiter}${modifiedEnv[pathNameInEnv]}`;
 
-  extensionContext.environmentVariableCollection.replace(
-    pathNameInEnv,
-    modifiedEnv[pathNameInEnv],
-    {
-      applyAtShellIntegration: true,
-      applyAtProcessCreation: true,
-    }
-  );
-
   let idfTarget = await getIdfTargetFromSdkconfig(curWorkspace);
   if (idfTarget) {
     modifiedEnv.IDF_TARGET = idfTarget || process.env.IDF_TARGET;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1208,6 +1208,15 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     pathNameInEnv
   ] = `${IDF_ADD_PATHS_EXTRAS}${path.delimiter}${modifiedEnv[pathNameInEnv]}`;
 
+  extensionContext.environmentVariableCollection.replace(
+    pathNameInEnv,
+    modifiedEnv[pathNameInEnv],
+    {
+      applyAtShellIntegration: true,
+      applyAtProcessCreation: true,
+    }
+  );
+
   let idfTarget = await getIdfTargetFromSdkconfig(curWorkspace);
   if (idfTarget) {
     modifiedEnv.IDF_TARGET = idfTarget || process.env.IDF_TARGET;


### PR DESCRIPTION
## Description

Use currently selected workspace folder when using `ESP-IDF: Pick a Workspace Folder` for workspace launch configuration.

Override env PATH  in extension context environment variables collection.

Fixes #1394 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Create a workspace `.code-workspace` file like this:

```
{
	"folders": [
		{
			"path": "."
		}
	],
	"settings": {
		"idf.port": "/dev/ttyACM1",
		"idf.flashType": "UART",
		"idf.openOcdDebugLevel": 2,
		"idf.openOcdLaunchArgs": [
			"-c adapter serial 40:4C:CA:43:1C:AC"
		],
		"idf.openOcdConfigs": [
			"board/esp32c6-builtin.cfg"
		],
	},
	"launch": {
		"version": "0.2.0",
		"configurations": [
			{
			  "type": "gdbtarget",
			  "request": "attach",
			  "name": "Eclipse CDT GDB Adapter"
			},
			{
			  "type": "espidf",
			  "name": "Launch",
			  "request": "launch"
			}
		],
	},
}
```

2. In vscode select menu File -> `Open workspace from file...` and select the previous created file.
3. In the created workspace select the  `Eclipse CDT GDB Adapter (workspace)` debug configuration and start debug.
4. A dropdown should be shown to select a workspace folder.
5. If there is a `/usr/bin/openocd` in env PATH, the extension should use the one from $IDF_TOOLS_PATH.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual test as described above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Linux and MacOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
