### PR TITLE
[VSC-1568] get supported qemu targets from tools json

### DIFF
--- a/src/IPackage.ts
+++ b/src/IPackage.ts
@@ -64,4 +64,6 @@ export interface IPackage {
   versions: IVersion[];
 
   strip_container_dirs: number;
+
+  supported_targets: string[];
 }


### PR DESCRIPTION
## Description

Use `$IDF_PATH/tools/tools.json` to obtain QEMU forks supported targets. From now any IDF_TARGET is mapped to them and fallback to esp32 and esp32c3 forks.

Fixes #1404

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "[QEMU Server]" on the status bar and run either QEMU Debug or Monitor. It should select the new esp32s3 (when available in ESP-IDF tools.json) target.
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual testing running any QEMU command (Debug, Monitor) to make sure IDF_TARGET is used to get the QEMU fork to use (xtensa or risc-v)

**Test Configuration**:
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
