### PR TITLE
[VSC-1575] Remove port validation for Jtag; Fix timing bug

### DIFF
--- a/src/espIdf/openOcd/tcl/tclClient.ts
+++ b/src/espIdf/openOcd/tcl/tclClient.ts
@@ -62,6 +62,24 @@ export class TCLClient extends EventEmitter {
     });
   }
 
+  // Verify if OpenOCD is ready to receive commands
+  public async verifyOpenOCDReady(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.removeAllListeners("response");
+        resolve(false);
+      }, 5000);
+
+      this.once("response", (data) => {
+        clearTimeout(timeout);
+        this.removeAllListeners("response");
+        resolve(true);
+      });
+
+      this.sendCommand("echo ready");
+    });
+  }
+
   public sendCommandWithCapture(command: string) {
     setTimeout(() => {
       return this.sendCommand(`capture "${command}"`);

--- a/src/espIdf/unitTest/configure.ts
+++ b/src/espIdf/unitTest/configure.ts
@@ -155,11 +155,18 @@ export async function buildFlashTestApp(
   unitTestAppDirPath: Uri,
   cancelToken: CancellationToken
 ) {
-  let flashType = readParameter("idf.flashType", unitTestAppDirPath) as ESP.FlashType;
+  let flashType = readParameter(
+    "idf.flashType",
+    unitTestAppDirPath
+  ) as ESP.FlashType;
   if (!flashType) {
     flashType = ESP.FlashType.UART;
   }
-  let canContinue = await buildCommand(unitTestAppDirPath, cancelToken, flashType);
+  let canContinue = await buildCommand(
+    unitTestAppDirPath,
+    cancelToken,
+    flashType
+  );
   if (!canContinue) {
     return;
   }
@@ -169,8 +176,16 @@ export async function buildFlashTestApp(
     return;
   }
   const flashBaudRate = readParameter("idf.flashBaudRate", unitTestAppDirPath);
-  const idfPathDir = readParameter("idf.espIdfPath", unitTestAppDirPath) as string;
-  const canFlash = await verifyCanFlash(flashBaudRate, port, unitTestAppDirPath);
+  const idfPathDir = readParameter(
+    "idf.espIdfPath",
+    unitTestAppDirPath
+  ) as string;
+  const canFlash = await verifyCanFlash(
+    flashBaudRate,
+    port,
+    flashType,
+    unitTestAppDirPath
+  );
   if (!canFlash) {
     return;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4214,7 +4214,12 @@ async function startFlashing(
   if (IDFMonitor.terminal) {
     IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
   }
-  const canFlash = await verifyCanFlash(flashBaudRate, port, workspaceRoot);
+  const canFlash = await verifyCanFlash(
+    flashBaudRate,
+    port,
+    flashType,
+    workspaceRoot
+  );
   if (!canFlash) {
     return;
   }

--- a/src/flash/flashCmd.ts
+++ b/src/flash/flashCmd.ts
@@ -31,6 +31,7 @@ import { OutputChannel } from "../logger/outputChannel";
 export async function verifyCanFlash(
   flashBaudRate: string,
   port: string,
+  flashType: ESP.FlashType,
   workspace: vscode.Uri
 ) {
   let continueFlag = true;
@@ -69,20 +70,22 @@ export async function verifyCanFlash(
     OutputChannel.appendLineAndShow(errStr, "Flash");
     return Logger.warnNotify(errStr);
   }
-  if (!port) {
-    try {
-      await vscode.commands.executeCommand("espIdf.selectPort");
-    } catch (error) {
-      const errStr = "Unable to execute the command: espIdf.selectPort";
+  if(flashType !== "JTAG") {
+    if (!port) {
+      try {
+        await vscode.commands.executeCommand("espIdf.selectPort");
+      } catch (error) {
+        const errStr = "Unable to execute the command: espIdf.selectPort";
+        OutputChannel.show();
+        OutputChannel.appendLineAndShow(errStr, "Flash");
+        Logger.error(errStr, error, "verifyCanFlash selectPort");
+      }
+      const errStr = "Select a port before flashing";
       OutputChannel.show();
       OutputChannel.appendLineAndShow(errStr, "Flash");
-      Logger.error(errStr, error, "verifyCanFlash selectPort");
+      return Logger.errorNotify(errStr, new Error("NOT_SELECTED_PORT"),
+      "flashCmd verifyCanFlash select port");
     }
-    const errStr = "Select a port before flashing";
-    OutputChannel.show();
-    OutputChannel.appendLineAndShow(errStr, "Flash");
-    return Logger.errorNotify(errStr, new Error("NOT_SELECTED_PORT"),
-    "flashCmd verifyCanFlash select port");
   }
   if (!flashBaudRate) {
     const errStr = "Select a baud rate before flashing";


### PR DESCRIPTION


## Description

- Remove serial port validation when flashing with JTAG
- Add validation to make sure OpenOCD accepts commands before we try flashing

Fixes [#1411](https://github.com/espressif/vscode-esp-idf-extension/issues/1411)

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

- Try to flash a project using JTAG, without selecting a port

There should not be any issues for not selecting a port and there should not be any timing issues between OpenOCD and JTAG Flashing.
**Example of timing issue:**
```
Open On-Chip Debugger v0.12.0-esp32-20241016 (2024-10-16-14:17)
Licensed under GNU GPL v2
For bug reports, read
    http://openocd.org/doc/doxygen/bugs.html

debug_level: 2

Info : only one transport 
option; autoselecting 'jtag'
Info : esp_usb_jtag: VID set to 0x303a and PID to 0x1001
Info : esp_usb_jtag: capabilities descriptor set to 0x2000

Info : Listening on port 6666 for tcl connections

Info : Listening on port 4444 for telnet connections

[/OpenOCD]
[Flash]
Failed to flash (via JTag), due to some unknown error in tcl, please try to relaunch open-ocd
[/Flash]
[OpenOCD]
Info : esp_usb_jtag: serial (40:4C:CA:51:3
5:A8)

Info : esp_usb_jtag: Device found. Base speed 24000KHz, div range 1 to 255

Info : clock speed 24000 kHz

Info : JTAG tap: esp32c6.tap
0 tap/device found: 0x0000dc25 (mfg: 0x612 (Espressif Systems), part: 0x000d, ver: 0x0)

Info : [esp32c6] datacoun
t=2 progbufsize=16

Info : [esp32c6] Examined RISC-V core; found 
2 harts
Info : [esp32c6]  XLEN=32, misa=0x40903105
Info : [esp32c6] Examination succeed
Info : [esp32c6] starting gdb server 
on 3333
Info : Listening on port 3333 for gdb connections

Info : accepting 'tcl' connection on tcp/6666
Info : dropped 'tcl' connection
```

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
