### PR TITLE
[VSC-1434] add prefix_map_gdbinit initCommands if reproducible build

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -32,7 +32,7 @@ import { pathExists } from "fs-extra";
 import { verifyAppBinary } from "../espIdf/debugAdapter/verifyApp";
 import { OpenOCDManager } from "../espIdf/openOcd/openOcdManager";
 import { Logger } from "../logger/logger";
-import { getToolchainPath } from "../utils";
+import { getConfigValueFromSDKConfig, getToolchainPath } from "../utils";
 import { createNewIdfMonitor } from "../espIdf/monitor/command";
 import { ESP } from "../config";
 
@@ -83,6 +83,14 @@ export class CDTDebugConfigurationProvider
           "mon reset halt",
           "maintenance flush register-cache",
         ];
+        const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
+          "CONFIG_APP_REPRODUCIBLE_BUILD",
+          folder.uri
+        );
+        if (isAppReproducibleBuildEnabled === "y") {
+          const buildDirPath = readParameter("idf.buildPath", folder) as string;
+          config.initCommands.push(`source ${join(buildDirPath, "prefix_map_gdbinit")}`);
+        }
         if (typeof config.initialBreakpoint === "undefined") {
           config.initCommands.push(`thb app_main`);
         } else if (config.initialBreakpoint) {


### PR DESCRIPTION
## Description

Add source `${buildPath}/prefix_map_gdbinit` in CDT debug configuration provider initCommands if `CONFIG_APP_REPRODUCIBLE_BUILD` is enabled.

Fixes #1250

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Enable `CONFIG_APP_REPRODUCIBLE_BUILD` in `SDK Configuration Editor`.
2. Build flash and start debugging.
3. Observe results. Check in the debug console that `source ${buildPath}/prefix_map_gdbinit` was executed in gdb and that the debug session works correctly.

- Expected behaviour:

Debug session works correctly when CONFIG_APP_REPRODUCIBLE_BUILD is enabled.

- Expected output:

`source ${buildPath}/prefix_map_gdbinit` was executed in gdb

## How has this been tested?

Manual testing as described above.

**Test Configuration**:
* ESP-IDF Version: 5.3.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
