### PR TITLE
escape quotes idf terminal export scripts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4292,12 +4292,14 @@ function createIdfTerminal(extensionPath: string) {
     });
     if (process.platform === "win32") {
       if (vscode.env.shell.indexOf("cmd.exe") !== -1) {
-        espIdfTerminal.sendText(path.join(extensionPath, "export.bat"));
+        espIdfTerminal.sendText(`"${path.join(extensionPath, "export.bat")}"`);
       } else if (
         vscode.env.shell.indexOf("powershell") !== -1 ||
         vscode.env.shell.indexOf("pwsh") !== -1
       ) {
-        espIdfTerminal.sendText(path.join(extensionPath, "export.ps1"));
+        espIdfTerminal.sendText(
+          `${path.join(extensionPath, "export.ps1").replace(/'/g, "''")}`
+        );
       }
     }
     espIdfTerminal.show();


### PR DESCRIPTION
## Description

Fix running extension export.{ps1,bat} scripts on `ESP-IDF: Open ESP-IDF Terminal` when the user profile path has spaces.

Fixes #1424

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on `ESP-IDF: Open ESP-IDF Terminal` command on vscode extension with a user that has spaces in. Something like `C:\Users\John Doe\.vscode\extensions\...`.
2. Execute action. Make sure that the ESP-IDF terminal does work and idf commands like `idf.py build` works.
3. Observe results.

- Expected behaviour:

ESP-IDF Terminal works correctly even if users has spaces in `%USERPROFILE%`

- Expected output:

## How has this been tested?

Manual testing by adding spaces in `%USERPROFILE%`

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
