### PR TITLE
[VSC-1597] preBuild wrongly used in project conf idf.preFlashTask

### DIFF
--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -86,7 +86,7 @@ export function parameterToProjectConfigMap(param: string) {
     case "idf.postBuildTask":
       return currentProjectConf.tasks.postBuild;
     case "idf.preFlashTask":
-      return currentProjectConf.tasks.preBuild;
+      return currentProjectConf.tasks.preFlash;
     case "idf.postFlashTask":
       return currentProjectConf.tasks.postFlash;
     case "idf.sdkconfigFilePath":


### PR DESCRIPTION
## Description

Prebuild Task being used in flash task as pre flash task in Project Configuration Editor

Fixes #1438

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on `ESP-IDF: Project Configuration Editor` and add a profile with `"preBuild": "idf.py set-target esp32p4"`. Save it
2. Execute `ESP-IDF: Select Project Configuration` to select previously defined profile.
3. Execute `ESP-IDF: Flash Your Project`. Previously you would see the prebuilt task being executed. In This PR, it should NOT be executed. Instead if you define  `"preFlash": "idf.py set-target esp32p4"` in `ESP-IDF: Project Configuration Editor` it should run before flash as intended.

- Expected behaviour:
PreBuild tasks should NOT execute before flashing

- Expected output:
PreFlash task SHOULD execute before flashing.

## How has this been tested?

Manual testing with steps above.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
