### PR TITLE
add support for idf.qemuExtraArgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -980,6 +980,15 @@
             "scope": "window",
             "default": true
           },
+          "idf.qemuExtraArgs": {
+            "type": "array",
+            "default": [],
+            "description": "%param.qemuExtraArgs%",
+            "scope": "resource",
+            "items": {
+              "type": "string"
+            }
+          },
           "idf.qemuTcpPort": {
             "type": "number",
             "description": "%param.qemuTcpPort%",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -148,6 +148,7 @@
 	"param.preBuildTask": "Tarea personalizada previa a la construcción",
 	"param.preFlashTask": "Tarea personalizada previa al flasheo",
 	"param.pythonBinPath": "Ruta absoluta del binario Python utilizado para ejecutar Scripts de Python de ESP-IDF",
+	"param.qemuExtraArgs": "Argumentos adicionales pasados a QEMU",
 	"param.qemuTcpPort": "Puerto tcp de QEMU para comunicación serial",
 	"param.rainmaker.api.server_url": "URL del servidor en la nube de ESP-Rainmaker",
 	"param.saveBeforeBuildDescription": "Guardar todos los archivos editados en el espacio de trabajo antes de proceder con la construcción, aunque si no se pueden guardar los archivos, se construirá de todos modos",

--- a/package.nls.json
+++ b/package.nls.json
@@ -148,6 +148,7 @@
   "param.preBuildTask": "Pre build custom task",
   "param.preFlashTask": "Pre flash custom task",
   "param.pythonBinPath": "Python absolute binary path used to execute ESP-IDF Python scripts",
+  "param.qemuExtraArgs": "Additional arguments passed to QEMU",
   "param.qemuTcpPort": "QEMU TCP port for serial communication",
   "param.rainmaker.api.server_url": "ESP-Rainmaker cloud server URL",
   "param.saveBeforeBuildDescription": "Save all edited files in the workspace before proceeding with the build. If saving fails, the build will proceed regardless",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -148,6 +148,7 @@
 	"param.preBuildTask": "Tarefa personalizada de pré-construção",
 	"param.preFlashTask": "Tarefa personalizada pré-flash",
 	"param.pythonBinPath": "Caminho binário absoluto do Python usado para executar scripts Python ESP-IDF",
+	"param.qemuExtraArgs": "Argumentos adicionais passados para o QEMU",
 	"param.qemuTcpPort": "Porta tcp QEMU para comunicação serial",
 	"param.rainmaker.api.server_url": "URL do servidor em nuvem ESP-Rainmaker",
 	"param.saveBeforeBuildDescription": "Salve todos os arquivos editados na área de trabalho antes de prosseguir com a compilação, embora se não conseguir salvar os arquivos, a compilação será de qualquer maneira",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -148,6 +148,7 @@
 	"param.preBuildTask": "Пользовательская задача перед сборкой",
 	"param.preFlashTask": "Пользовательская задача перед прошивкой",
 	"param.pythonBinPath": "Абсолютный путь до бинарника Python, используемый для выполнения скриптов Python ESP-IDF",
+	"param.qemuExtraArgs": "Дополнительные аргументы, передаваемые в QEMU",
 	"param.qemuTcpPort": "TCP-порт QEMU для последовательной связи",
 	"param.rainmaker.api.server_url": "URL-адрес облачного сервера ESP-Rainmaker",
 	"param.saveBeforeBuildDescription": "Сохранять все изменённые файлы в рабочей области перед сборкой. Если файлы не удастся сохранить, сборка все равно будет выполнена",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -148,6 +148,7 @@
 	"param.preBuildTask": "构建前的自定义任务",
 	"param.preFlashTask": "烧录前的自定义任务",
 	"param.pythonBinPath": "用于执行 ESP-IDF Python 脚本的 Python 绝对路径",
+	"param.qemuExtraArgs": "传递给 QEMU 的附加参数",
 	"param.qemuTcpPort": "QEMU 用于串行通信的 TCP 端口",
 	"param.rainmaker.api.server_url": "ESP-Rainmaker 云服务器 URL",
 	"param.saveBeforeBuildDescription": "在继续构建之前保存工作区中的所有编辑文件（若未能保存文件，构建仍将继续）",

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -115,6 +115,11 @@ export class QemuManager extends EventEmitter {
       "idf.qemuTcpPort",
       workspaceFolder
     ) as string;
+    const rawExtraArgs = readParameter("idf.qemuExtraArgs", workspaceFolder) as string[];
+
+    let extraArgs: string[] = [];
+    
+    if (Array.isArray(rawExtraArgs)) extraArgs = rawExtraArgs;
 
     if (mode === QemuLaunchMode.Debug) {
       return [
@@ -125,6 +130,7 @@ export class QemuManager extends EventEmitter {
         idfTarget,
         "-drive",
         `file='${qemuFile.fsPath}',if=mtd,format=raw`,
+        ...extraArgs,
       ];
     } else {
       return [
@@ -135,6 +141,7 @@ export class QemuManager extends EventEmitter {
         `file='${qemuFile.fsPath}',if=mtd,format=raw`,
         "-monitor stdio",
         `-serial tcp::${qemuTcpPort},server,nowait`,
+        ...extraArgs,
       ];
     }
   }


### PR DESCRIPTION
## Description

QEMU arguments are currently hardcoded. This adds a setting "idf.qemuExtraArgs" as an array of strings that allows passing additional arguments to QEMU.

This is useful for example to increase the memory size of the emulator to support PSRAM. This would be accomplished in .vscode/settings.json by adding:

"idf.qemuExtraArgs": ["-m", "4M"],

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Edit the workspace's .vscode/settings.json file and add:

"idf.qemuExtraArgs": ["-m", "4M"],

2. Launch of of the ESP-IDF Extension's QEMU commands, e.g. ESP-IDF: Monitor QEMU Device

- Expected behaviour:

QEMU will launch with the extra args appended.

- Expected output:

No additional output

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I added the extra setting as described above, then ran ESP-IDF: Monitor QEMU Device.

I verified the arguments were passed successfully by running `ps ajx | grep qemu` at the command line and verifying the extra args were passed (my arguments are macOS specific ps, use appropriate args for your test OS).

$ ps ajx | grep qemu
brian             6105  5835  6105      0    1 R+   s012    0:16.70 qemu-system-xtensa -nographic -machine esp32 -drive file=/Users/brian/code/fertigator/esp32/build/merged_qemu.bin,if=mtd,format=raw -monitor stdio -serial tcp::5555,server,nowait -m 4M

**Test Configuration**:
* ESP-IDF Version: 1.9.1
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

n/a

## Checklist
- [ x] PR Self Reviewed
- [ x] Applied Code formatting
- [ x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
