### PR TITLE
[VSC-1596] add idf.jtagFlashCommandExtraArgs to modify jtag flash behaviour

### DIFF
--- a/docs_espressif/en/settings.rst
+++ b/docs_espressif/en/settings.rst
@@ -112,6 +112,8 @@ These settings are specific to the ESP32 Chip/Board.
       - Forced to use ``/`` instead of ``\\`` as path separator for Win32 based OS
     * - **idf.svdFilePath**
       - SVD file absolute path to resolve chip debug peripheral tree view
+    * - **idf.jtagFlashCommandExtraArgs**
+      - OpenOCD JTAG flash extra arguments. Default is ["verify", "reset"].
 
 This is how the extension uses them:
 
@@ -121,6 +123,7 @@ This is how the extension uses them:
 4. **idf.port** (or **idf.portWin** in Windows) is used as the serial port value for the extension commands.
 5. **idf.openOcdDebugLevel** is the log level for OpenOCD server output from 0 to 4.
 6. **idf.openOcdLaunchArgs** is the launch arguments string array for OpenOCD. The resulting OpenOCD launch command looks like this: ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}``.
+7. **idf.jtagFlashCommandExtraArgs** is used for OpenOCD JTAG flash task. Please review `Upload application for debugging <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html#upload-application-for-debugging>`.
 
 .. note::
 

--- a/docs_espressif/zh_CN/settings.rst
+++ b/docs_espressif/zh_CN/settings.rst
@@ -112,6 +112,8 @@ ESP-IDF 相关设置
       - 强制在 Windows 操作系统中使用 ``/`` 作为路径分隔符，而不是 ``\\``
     * - **idf.svdFilePath**
       - SVD 文件的绝对路径，用于解析芯片在调试器中的外设树视图
+    * - **idf.jtagFlashCommandExtraArgs**
+      - OpenOCD JTAG 闪存额外参数。默认值为 ["verify", "reset"]
 
 扩展将按照以下方式使用上述设置：
 
@@ -121,6 +123,7 @@ ESP-IDF 相关设置
 4. **idf.port** （Windows 系统中为 **idf.portWin**）用作扩展命令的串口值。
 5. **idf.openOcdDebugLevel** 是 OpenOCD 服务器输出的日志级别，范围为 0 到 4。
 6. **idf.openOcdLaunchArgs** 是用于配置 OpenOCD 启动的参数字符串数组。生成的 OpenOCD 启动命令格式如下：``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}``。
+7. **idf.jtagFlashCommandExtraArgs** 用于OpenCD JTAG闪存任务。请查看 `上传待调试的应用程序 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/jtag-debugging/index.html#jtag-upload-app-debug>`.
 
 .. note::
 

--- a/package.json
+++ b/package.json
@@ -1194,6 +1194,18 @@
                 "productId": "0x6001"
               }
             }
+          },
+          "idf.jtagFlashCommandExtraArgs": {
+            "type": "array",
+            "description": "%param.jtagFlashCommandExtraArgs.title%",
+            "scope": "resource",
+            "default": [
+              "verify",
+              "reset"
+            ],
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -125,6 +125,7 @@
 	"param.exportVars": "Variables que se agregarán a las variables de entorno del sistema",
 	"param.flashBaudRate": "Tasa de baudios de flasheo ESP-IDF",
 	"param.gitPath.title": "Ruta del ejecutable de Git",
+  "param.jtagFlashCommandExtraArgs.title": "Openocd JTAG Flash Argumentos adicionales",
 	"param.launchMonitorOnDebugSession.title": "Iniciar Monitor IDF junto con la sesión de Adaptador de Depuración ESP-IDF",
 	"param.monitorBaudRate": "Tasa de baudios de Monitor IDF ESP-IDF",
 	"param.monitorCustomTimestampFormat": "Formato de marca de tiempo personalizado en Monitor IDF",

--- a/package.nls.json
+++ b/package.nls.json
@@ -125,6 +125,7 @@
   "param.exportVars": "Variables to be added to system environment variables",
   "param.flashBaudRate": "ESP-IDF flash baud rate",
   "param.gitPath.title": "Git executable path",
+  "param.jtagFlashCommandExtraArgs.title": "OpenOCD JTAG flash extra arguments",
   "param.launchMonitorOnDebugSession.title": "Start IDF monitor along with ESP-IDF Debug Adapter session",
   "param.monitorBaudRate": "ESP-IDF monitor baud rate",
   "param.monitorCustomTimestampFormat": "Custom timestamp format in IDF monitor",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -125,6 +125,7 @@
 	"param.exportVars": "Variáveis ​​a serem adicionadas às variáveis ​​de ambiente do sistema",
 	"param.flashBaudRate": "Taxa de transmissão de flash ESP-IDF",
 	"param.gitPath.title": "Caminho executável do Git",
+  "param.jtagFlashCommandExtraArgs.title": "Argumentos extras do Openocd JTAG Flash",
 	"param.launchMonitorOnDebugSession.title": "Inicie o IDF Monitor junto com a sessão do adaptador de depuração ESP-IDF",
 	"param.monitorBaudRate": "Taxa de transmissão do monitor ESP-IDF",
 	"param.monitorCustomTimestampFormat": "Formato de carimbo de data/hora personalizado no IDF Monitor",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -124,6 +124,7 @@
 	"param.espRainmakerPath": "Путь до фреймворка ESP-Rainmaker (RMAKER_PATH)",
 	"param.exportVars": "Переменные, добавляемые к переменным системного окружения",
 	"param.flashBaudRate": "Скорость прошивки ESP-IDF",
+  "param.jtagFlashCommandExtraArgs.title": "Openocd jtag flash дополнительные аргументы",
 	"param.gitPath.title": "Путь к исполняемому файлу Git",
 	"param.launchMonitorOnDebugSession.title": "Запуск монитора IDF вместе с сессией Адаптера Отладки ESP-IDF",
 	"param.monitorBaudRate": "Скорость передачи данных монитора ESP-IDF",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -125,6 +125,7 @@
 	"param.exportVars": "要添加到系统环境变量中的变量",
 	"param.flashBaudRate": "ESP-IDF 烧录速率",
 	"param.gitPath.title": "Git 可执行文件的路径",
+  "param.jtagFlashCommandExtraArgs.title": "openocd jtag flash额外参数",
 	"param.launchMonitorOnDebugSession.title": "在 ESP-IDF 调试适配器会话中启动 IDF 监视器",
 	"param.monitorBaudRate": "ESP-IDF 监视器的波特率值",
 	"param.monitorCustomTimestampFormat": "在 IDF 监视器中自定义时间戳格式",

--- a/src/flash/jtag.ts
+++ b/src/flash/jtag.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Tuesday, 29th September 2020 11:05:15 pm
  * Copyright 2020 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,9 @@ export class JTAGFlash {
             .toString()
             .replace(TCLClient.DELIMITER, "")
             .trim();
+          if (response === "" && args.some((arg) => arg.includes("exit"))) {
+            resolve(response);
+          }
           if (response !== "0") {
             return reject(
               `Failed to flash the device (JTag), please try again [got response: '${response}', expecting: '0']`

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -59,6 +59,10 @@ export async function jtagFlashCommand(workspace: Uri) {
     workspace
   );
   let buildPath = readParameter("idf.buildPath", workspace) as string;
+  let openOCDJTagFlashArguments = readParameter(
+    "idf.jtagFlashCommandExtraArgs",
+    workspace
+  ) as string[];
   const customTask = new CustomTask(workspace);
   if (forceUNIXPathSeparator === true) {
     buildPath = buildPath.replace(/\\/g, "/");
@@ -70,8 +74,7 @@ export async function jtagFlashCommand(workspace: Uri) {
       "program_esp_bins",
       buildPath,
       "flasher_args.json",
-      "verify",
-      "reset"
+      ...openOCDJTagFlashArguments
     );
     await customTask.addCustomTask(CustomTaskType.PostFlash);
     await customTask.runTasks(CustomTaskType.PostFlash);


### PR DESCRIPTION
## Description

Add `idf.jtagFlashCommandExtraArgs` configuration setting to allow customization of OpenOCD JTAG flash command.

Please review https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/index.html#upload-application-for-debugging for possible arguments to use.

Fixes #1437

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open a ESP-IDF project and set in `.vscode/settings.json` a new setting `idf.jtagFlashCommandExtraArgs; ["verify", "reset"]` or using the vscode settings UI.
2. Execute `ESP-IDF: Flash (with JTag)`. The flashing arguments should be used in the Flash task.
3. Observe results.

- Expected behaviour:

JTAG flash arguments can be customized.

- Expected output:

OpenOCD command will include customize JTAG flash arguments.

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
