### PR TITLE
fix esp_idf json setups not being recognized

### DIFF
--- a/src/setup/existingIdfSetups.ts
+++ b/src/setup/existingIdfSetups.ts
@@ -101,6 +101,7 @@ export async function loadIdfSetupsFromEspIdfJson(toolsPath: string) {
         idfPath: espIdfJson.idfInstalled[idfInstalledKey].path,
         gitPath: espIdfJson.gitPath,
         version: espIdfJson.idfInstalled[idfInstalledKey].version,
+        python: espIdfJson.idfInstalled[idfInstalledKey].python,
         toolsPath: toolsPath,
         isValid: false,
       } as IdfSetup;


### PR DESCRIPTION
## Description

Fix IDF setup from IDF_TOOLS_PATH/esp_idf.json not being recognized.

Fixes #1435
Fixes #1442


## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Make sure VS Code is not running and Install ESP-IDF from offline installer v5.4  links here: https://dl.espressif.com/dl/esp-idf/
2. Open VS Code and run `ESP-IDF: Configure ESP-IDF extension`. Click `Use existing setup`. 
3. Observe results. You should see the esp-idf setup from ESP-IDF installer of step 1.

- Expected behaviour:
ESP-IDF setups from ESP-IDF Installer should appear.

- Expected output:
ESP-IDF setups from ESP-IDF Installer should appear.

## How has this been tested?

Manual testing using steps above

**Test Configuration**:
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
