### PR TITLE
[VSC-1563] add debug conf web extension doc

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,7 @@
+# Documentation has moved to:
+
+# [English](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/debugproject.html)
+
+# 文档已移至
+
+# [中文](https://docs.espressif.com/projects/vscode-esp-idf-extension/zh_CN/latest/debugproject.html)

--- a/docs_espressif/en/additionalfeatures.rst
+++ b/docs_espressif/en/additionalfeatures.rst
@@ -28,3 +28,4 @@ Additional IDE Features
     Unit Testing<additionalfeatures/unit-testing>
     Working with Multiple Projects<additionalfeatures/multiple-projects>
     Using WSL in Windows<additionalfeatures/wsl>
+    Web Extension<additionalfeatures/web-extension>

--- a/docs_espressif/en/additionalfeatures/web-extension.rst
+++ b/docs_espressif/en/additionalfeatures/web-extension.rst
@@ -82,8 +82,8 @@ Press menu **View**, select **Command Palette...** and search for these commands
 .. note:: 
   The ``ESP-IDF-Web Flash`` command depends on ``flasher_args.json`` and the ``ESP-IDF-Web Monitor`` command depends on ``project_description.json`` from ESP-IDF project build directory, where the build directory is defined using ``idf.buildPath`` from `ESP-IDF extension VS Code <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ configuration setting or it will use the currently selected workspace folder ``build`` otherwise (``${workspaceFolder}/build``).
 
-Settings
-------------
+ESP-IDF-Web Settings
+---------------------
 
 ``idfWeb.flashBaudRate``: Allow the user to set the flash baudrate being used to flash the current workspace folder ESP-IDF project application to your device.
 

--- a/docs_espressif/en/additionalfeatures/web-extension.rst
+++ b/docs_espressif/en/additionalfeatures/web-extension.rst
@@ -20,6 +20,7 @@ How to use
 You can also configure a github ESP-IDF project for Codespaces with the ESP-IDF Web extension and the ESP-IDF extension installed by adding a ``.devcontainer/devcontainer.json`` file with the following content:
 
 .. code-block:: JSON
+
   {
     "name": "ESP-IDF Codespaces",
     "build": {
@@ -51,6 +52,7 @@ You can also configure a github ESP-IDF project for Codespaces with the ESP-IDF 
 and a ``.devcontainer/Dockerfile`` file with the following content:
 
 .. code-block::
+
   ARG DOCKER_TAG=latest
   FROM espressif/idf:${DOCKER_TAG}
 
@@ -79,8 +81,9 @@ Press menu **View**, select **Command Palette...** and search for these commands
 
 ``ESP-IDF-Web Disconnect serial port``: Dispose of currently selected serial port. This command is executed when you click the serial port shown in the status bar.
 
-.. note:: 
-  The ``ESP-IDF-Web Flash`` command depends on ``flasher_args.json`` and the ``ESP-IDF-Web Monitor`` command depends on ``project_description.json`` from ESP-IDF project build directory, where the build directory is defined using ``idf.buildPath`` from `ESP-IDF extension VS Code <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ configuration setting or it will use the currently selected workspace folder ``build`` otherwise (``${workspaceFolder}/build``).
+.. note::
+
+    * The ``ESP-IDF-Web Flash`` command depends on ``flasher_args.json`` and the ``ESP-IDF-Web Monitor`` command depends on ``project_description.json`` from ESP-IDF project build directory, where the build directory is defined using ``idf.buildPath`` from `ESP-IDF extension VS Code <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ configuration setting or it will use the currently selected workspace folder ``build`` otherwise (``${workspaceFolder}/build``).
 
 ESP-IDF-Web Settings
 ---------------------

--- a/docs_espressif/en/additionalfeatures/web-extension.rst
+++ b/docs_espressif/en/additionalfeatures/web-extension.rst
@@ -1,0 +1,92 @@
+ESP-IDF Web Extension
+======================
+
+The `ESP-IDF Web Extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-web>`_ is a Visual Studio Code extension that provides a set of tools to enable Web serial communication for Espressif microcontrollers using the ESP-IDF framework.
+
+This extension works on VSCode Web and Codespaces using `esptool-js <https://github.com/espressif/esptool-js>`_ to allow WebSerial/WebUSB for commands such as flash and monitor Espressif devices from the web browser.
+
+When you use ESP-IDF VS Code extension in Web environment, flash and monitor commands will try to use ESP-IDF Web VS Code extension commands instead.
+
+How to use
+----------
+
+1. Open a workspace folder with an ESP-IDF project in CodeSpaces or VSCode Web.
+2. IF you are using Codespaces Install the `ESP-IDF extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ from the Visual Studio Code Marketplace.
+3. Install the `ESP-IDF Web Extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-web>`_ from the Visual Studio Code Marketplace.
+4. The ESP-IDF Web extension will show a status bar flash icon and a monitor icon.
+5. Press menu **View**, select **Command Palette...** and search for **ESP-IDF-Web Select serial port** command to select the serial port to use.
+6. A serial port icon will appear in the status bar with the selected serial port. You can also just run **ESP-IDF-Web Flash** or **ESP-IDF-Web Monitor** commands and it will ask you for the serial port to use.
+
+You can also configure a github ESP-IDF project for Codespaces with the ESP-IDF Web extension and the ESP-IDF extension installed by adding a ``.devcontainer/devcontainer.json`` file with the following content:
+
+.. code-block:: JSON
+  {
+    "name": "ESP-IDF Codespaces",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+        "DOCKER_TAG": "v5.3-rc1"
+      }
+    },
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash",
+          "idf.espIdfPath": "/opt/esp/idf",
+          "idf.customExtraPaths": "",
+          "idf.toolsPath": "/opt/esp",
+          "idf.gitPath": "/usr/bin/git",
+          "idf.showOnboardingOnInit": false,
+          "extensions.ignoreRecommendations": true
+        },
+        "extensions": [
+          "espressif.esp-idf-extension",
+          "espressif.esp-idf-web"
+        ]
+      }
+    },
+    "runArgs": ["--privileged"]
+  }
+
+and a ``.devcontainer/Dockerfile`` file with the following content:
+
+.. code-block::
+  ARG DOCKER_TAG=latest
+  FROM espressif/idf:${DOCKER_TAG}
+
+  RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+
+  ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+
+  CMD ["/bin/bash", "-c"]
+
+After adding these files, just open the project in Codespaces and the ESP-IDF Web extension will be installed and ready to use.
+
+It might be necessary to manually install ESP-IDF-Web extension in Codespaces if it is not automatically installed.
+
+ESP-IDF-Web Commands
+---------------------
+
+Press menu **View**, select **Command Palette...** and search for these commands:
+
+``ESP-IDF-Web Flash``: Flash binaries from selected workspace to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Monitor``: Start a serial monitor terminal connected to the selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Flash and Monitor``: Flash binaries from selected workspace folder to selected serial port and start a serial monitor terminal to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Select serial port``: Show the list of available serial ports for previous commands. The selected serial port will saved and shown in the status bar icon and re used by this extension commands.
+
+``ESP-IDF-Web Disconnect serial port``: Dispose of currently selected serial port. This command is executed when you click the serial port shown in the status bar.
+
+.. note:: 
+  The ``ESP-IDF-Web Flash`` command depends on ``flasher_args.json`` and the ``ESP-IDF-Web Monitor`` command depends on ``project_description.json`` from ESP-IDF project build directory, where the build directory is defined using ``idf.buildPath`` from `ESP-IDF extension VS Code <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ configuration setting or it will use the currently selected workspace folder ``build`` otherwise (``${workspaceFolder}/build``).
+
+Settings
+------------
+
+``idfWeb.flashBaudRate``: Allow the user to set the flash baudrate being used to flash the current workspace folder ESP-IDF project application to your device.
+
+``idfWeb.enableStatusBarIcons``: Show or hide the ESP-IDF Web extension status bar icons: (Selected serial port, Flash and Monitor icons). This setting can only be modified in User Settings.
+
+For ``ESP-IDF-Web Monitor`` command, the baud rate used is determined from build directory's ``project_description.json`` field called ``monitor_baud``.

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -121,7 +121,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     ``{IDF_TARGET_CPU_WATCHPOINT_NUM}`` is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
+     **{IDF_TARGET_CPU_WATCHPOINT_NUM}** is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
 
 Some additional arguments you might use are:
 
@@ -134,11 +134,9 @@ Some additional arguments you might use are:
 .. code-block:: JSON
 
     {
-        ...
         "environment": {
             "VAR": "Value"
         }
-        ...
     }
 
 - ``imageAndSymbols`` :
@@ -146,14 +144,12 @@ Some additional arguments you might use are:
 .. code-block:: JSON
 
     {
-        ...
         "imageAndSymbols": {
             "symbolFileName": "If specified, a symbol file to load at the given (optional) offset",
             "symbolOffset": "If symbolFileName is specified, the offset used to load",
             "imageFileName": "If specified, an image file to load at the given (optional) offset",
             "imageOffset": "If imageFileName is specified, the offset used to load"
         }
-        ...
     }
 
 - ``target``: Configuration for target to be attached. Specifies how to connect to the device to debug. Usually OpenOCD exposes the chip as a remote target on port 3333.

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -105,9 +105,9 @@ To configure the debugging session, open the project's ``.vscode/launch.json`` f
     {
         "configurations": [
             {
-            "type": "gdbtarget",
-            "request": "attach",
-            "name": "Eclipse CDT GDB Adapter"
+                "type": "gdbtarget",
+                "request": "attach",
+                "name": "Eclipse CDT GDB Adapter"
             }
         ]
     }
@@ -121,7 +121,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     {IDF_TARGET_CPU_WATCHPOINT_NUM} is resolved by the extension according to the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
+     ``{IDF_TARGET_CPU_WATCHPOINT_NUM}`` is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
 
 Some additional arguments you might use are:
 
@@ -132,6 +132,7 @@ Some additional arguments you might use are:
 - ``environment``: Environment variables to apply to the ESP-IDF Debug Adapter. It will replace global environment variables and environment variables used by the extension.
 
 .. code-block:: JSON
+
     {
         ...
         "environment": {
@@ -143,6 +144,7 @@ Some additional arguments you might use are:
 - ``imageAndSymbols`` :
 
 .. code-block:: JSON
+
     {
         ...
         "imageAndSymbols": {
@@ -157,6 +159,7 @@ Some additional arguments you might use are:
 - ``target``: Configuration for target to be attached. Specifies how to connect to the device to debug. Usually OpenOCD exposes the chip as a remote target on port 3333.
 
 .. code-block:: JSON
+
     {
         "target": {
             "type": "The kind of target debugging to do. This is passed to -target-select (defaults to remote)",
@@ -170,25 +173,26 @@ Some additional arguments you might use are:
 An example of a modified launch.json file is shown below:
 
 .. code-block:: JSON
+
     {
         "configurations": [
             {
-            "type": "gdbtarget",
-            "request": "attach",
-            "name": "Eclipse CDT GDB Adapter",
-            "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
-            "initCommands": [
-                "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
-                "mon reset halt",
-                "maintenance flush register-cache"
-            ],
-            "gdb": "${command:espIdf.getToolchainGdb}",
-            "target": {
-                "connectCommands": [
-                "set remotetimeout 20",
-                "-target-select extended-remote localhost:3333"
-                ]
-            }
+                "type": "gdbtarget",
+                "request": "attach",
+                "name": "Eclipse CDT GDB Adapter",
+                "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
+                "initCommands": [
+                    "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
+                    "mon reset halt",
+                    "maintenance flush register-cache"
+                ],
+                "gdb": "${command:espIdf.getToolchainGdb}",
+                "target": {
+                    "connectCommands": [
+                        "set remotetimeout 20",
+                        "-target-select extended-remote localhost:3333"
+                    ]
+                }
             }
         ]
     }

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -116,12 +116,12 @@ You can modify the configuration to suit your needs. Let's describe the configur
 
 - ``type``: The type of the debug configuration. It should be set to ``gdbtarget``.
 - ``program``: ELF file of your project build directory to execute the debug session. You can use the command ``${command:espIdf.getProjectName}`` to query the extension to find the current build directory project name.
-- ``initCommands``: GDB Commands to initialize GDB and target. The default value is ``["set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}", "mon reset halt", "maintenance flush register-cache"]``.
+- ``initCommands``: GDB Commands to initialize GDB and target. The default value is ``["set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM", "mon reset halt", "maintenance flush register-cache"]``.
 - ``initialBreakpoint``: When ``initCommands`` is not defined, this command will add to default ``initCommands`` a hardward breakpoint at the given function name. For example app_main, the default value, will add ``thb app_main`` to default initCommmands. If set to "", an empty string, no initial breakpoint will be set and if let undefined it will use the default thb app_main.
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     **{IDF_TARGET_CPU_WATCHPOINT_NUM}** is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
+     **IDF_TARGET_CPU_WATCHPOINT_NUM** is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
 
 Some additional arguments you might use are:
 
@@ -178,7 +178,7 @@ An example of a modified launch.json file is shown below:
                 "name": "Eclipse CDT GDB Adapter",
                 "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
                 "initCommands": [
-                    "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
+                    "set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM",
                     "mon reset halt",
                     "maintenance flush register-cache"
                 ],

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -335,6 +335,7 @@ While we support the ESP-IDF extension, you can also use other extensions to deb
 To do this, you need to configure the launch.json file in the .vscode directory of your project. Here is an example of a launch.json file:
 
 .. code-block:: JSON
+
     {
         "configurations": [
             {
@@ -367,6 +368,7 @@ To do this, you need to configure the launch.json file in the .vscode directory 
 Another recommended debug extension is the `Native Debug <https://marketplace.visualstudio.com/items?itemName=webfreak.debug>`_ extension. Here is an example configuration for the launch.json file:
 
 .. code-block:: JSON
+
     {
         "configurations": [
             {

--- a/docs_espressif/zh_CN/additionalfeatures.rst
+++ b/docs_espressif/zh_CN/additionalfeatures.rst
@@ -28,3 +28,4 @@
     单元测试<additionalfeatures/unit-testing>
     处理多个项目<additionalfeatures/multiple-projects>
     在 Windows 系统中使用 WSL<additionalfeatures/wsl>
+    Web Extension<additionalfeatures/web-extension>

--- a/docs_espressif/zh_CN/additionalfeatures/web-extension.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/web-extension.rst
@@ -1,0 +1,95 @@
+ESP-IDF Web Extension
+======================
+
+The `ESP-IDF Web Extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-web>`_ is a Visual Studio Code extension that provides a set of tools to enable Web serial communication for Espressif microcontrollers using the ESP-IDF framework.
+
+This extension works on VSCode Web and Codespaces using `esptool-js <https://github.com/espressif/esptool-js>`_ to allow WebSerial/WebUSB for commands such as flash and monitor Espressif devices from the web browser.
+
+When you use ESP-IDF VS Code extension in Web environment, flash and monitor commands will try to use ESP-IDF Web VS Code extension commands instead.
+
+How to use
+----------
+
+1. Open a workspace folder with an ESP-IDF project in CodeSpaces or VSCode Web.
+2. IF you are using Codespaces Install the `ESP-IDF extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ from the Visual Studio Code Marketplace.
+3. Install the `ESP-IDF Web Extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-web>`_ from the Visual Studio Code Marketplace.
+4. The ESP-IDF Web extension will show a status bar flash icon and a monitor icon.
+5. Press menu **View**, select **Command Palette...** and search for **ESP-IDF-Web Select serial port** command to select the serial port to use.
+6. A serial port icon will appear in the status bar with the selected serial port. You can also just run **ESP-IDF-Web Flash** or **ESP-IDF-Web Monitor** commands and it will ask you for the serial port to use.
+
+You can also configure a github ESP-IDF project for Codespaces with the ESP-IDF Web extension and the ESP-IDF extension installed by adding a ``.devcontainer/devcontainer.json`` file with the following content:
+
+.. code-block:: JSON
+
+  {
+    "name": "ESP-IDF Codespaces",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "args": {
+        "DOCKER_TAG": "v5.3-rc1"
+      }
+    },
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash",
+          "idf.espIdfPath": "/opt/esp/idf",
+          "idf.customExtraPaths": "",
+          "idf.toolsPath": "/opt/esp",
+          "idf.gitPath": "/usr/bin/git",
+          "idf.showOnboardingOnInit": false,
+          "extensions.ignoreRecommendations": true
+        },
+        "extensions": [
+          "espressif.esp-idf-extension",
+          "espressif.esp-idf-web"
+        ]
+      }
+    },
+    "runArgs": ["--privileged"]
+  }
+
+and a ``.devcontainer/Dockerfile`` file with the following content:
+
+.. code-block::
+
+  ARG DOCKER_TAG=latest
+  FROM espressif/idf:${DOCKER_TAG}
+
+  RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+
+  ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+
+  CMD ["/bin/bash", "-c"]
+
+After adding these files, just open the project in Codespaces and the ESP-IDF Web extension will be installed and ready to use.
+
+It might be necessary to manually install ESP-IDF-Web extension in Codespaces if it is not automatically installed.
+
+ESP-IDF-Web Commands
+---------------------
+
+Press menu **View**, select **Command Palette...** and search for these commands:
+
+``ESP-IDF-Web Flash``: Flash binaries from selected workspace to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Monitor``: Start a serial monitor terminal connected to the selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Flash and Monitor``: Flash binaries from selected workspace folder to selected serial port and start a serial monitor terminal to selected serial port. If no serial port was previously selected, it will ask the user for the serial port to use othewise use previously selected serial port.
+
+``ESP-IDF-Web Select serial port``: Show the list of available serial ports for previous commands. The selected serial port will saved and shown in the status bar icon and re used by this extension commands.
+
+``ESP-IDF-Web Disconnect serial port``: Dispose of currently selected serial port. This command is executed when you click the serial port shown in the status bar.
+
+.. note::
+
+    * The ``ESP-IDF-Web Flash`` command depends on ``flasher_args.json`` and the ``ESP-IDF-Web Monitor`` command depends on ``project_description.json`` from ESP-IDF project build directory, where the build directory is defined using ``idf.buildPath`` from `ESP-IDF extension VS Code <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ configuration setting or it will use the currently selected workspace folder ``build`` otherwise (``${workspaceFolder}/build``).
+
+ESP-IDF-Web Settings
+---------------------
+
+``idfWeb.flashBaudRate``: Allow the user to set the flash baudrate being used to flash the current workspace folder ESP-IDF project application to your device.
+
+``idfWeb.enableStatusBarIcons``: Show or hide the ESP-IDF Web extension status bar icons: (Selected serial port, Flash and Monitor icons). This setting can only be modified in User Settings.
+
+For ``ESP-IDF-Web Monitor`` command, the baud rate used is determined from build directory's ``project_description.json`` field called ``monitor_baud``.


### PR DESCRIPTION
## Description

Add launch.json debug configuration in  debug documentation and ESP-IDF Web extension documentation.

## Type of change

- This change requires a documentation update

Review documentation in the preview link below.

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
