### PR TITLE
docs: Provide CN translation for 3 index docs

### DIFF
--- a/docs_espressif/en/additionalfeatures/coverage.rst
+++ b/docs_espressif/en/additionalfeatures/coverage.rst
@@ -5,7 +5,7 @@ Source code coverage is data indicating the count and frequency of every program
 
 Your ESP-IDF project should be configured to generate ``gcda/gcno`` coverage files using ``gcov``. Please read `GCOV Code Coverage <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html#gcov-source-code-coverage>`_ to learn more about code coverage with GCOV in ESP-IDF projects.
 
-You can use the **ESP-IDF: Configure Project SDKConfig for Coverage** to set required configuration in the SDK Configuration Editor. 
+You can use the **ESP-IDF: Configure Project SDKConfig for Coverage** to set required configuration in the SDK Configuration Editor.
 
 Code coverage example
 -------------------------------
@@ -14,7 +14,7 @@ Let's use the ESP-IDF `GCOV Example <https://github.com/espressif/esp-idf/tree/m
 
 - Navigate to **View** > **Command Palette**.
 
-- Type **ESP-IDF: Show Examples Projects** and choose ``Use Current ESP-IDF (/path/to/esp-idf)``. 
+- Type **ESP-IDF: Show Examples Projects** and choose ``Use Current ESP-IDF (/path/to/esp-idf)``.
 
 If you don't see the option, please review the current ESP-IDF setup in :ref:`Installation <installation>`.
 
@@ -76,4 +76,4 @@ Visual Studio code support ``"red"``, ``rgb(255,0,120)`` or ``rgba(120,0,0,0.1)`
 .. image:: ../../../media/tutorials/coverage/html_report.png
 
 .. note::
-  * Check the :ref:`Troubleshooting <troubleshooting>` section if you have any issues.
+  * Check the :ref:`Troubleshooting <troubleshooting-section>` section if you have any issues.

--- a/docs_espressif/en/faqs.rst
+++ b/docs_espressif/en/faqs.rst
@@ -3,7 +3,7 @@ FAQs
 
 **I have an issue or error with the Visual Studio Code extension, what can I do?**
 
-Take a look at the :ref:`Troubleshooting documentation <troubleshooting>` so you can see the error in the extension. You might be able to fix the issue yourself or give enough information for others to help you with the problem.
+Take a look at the :ref:`Troubleshooting documentation <troubleshooting-section>` so you can see the error in the extension. You might be able to fix the issue yourself or give enough information for others to help you with the problem.
 
 Search the `ESP-IDF extension repository <https://github.com/espressif/vscode-esp-idf-extension>`_ for Visual Studio Code first and then this forum, your issue might already be solved.
 
@@ -15,7 +15,7 @@ Check out `ESP-FAQ <https://docs.espressif.com/projects/espressif-esp-faq/en/lat
 
 First of all, have you configure the IDE plugin/extension properly ? Make sure to review the documentation to :ref:`Install ESP-IDF and Tools <installation>`.
 
-There was error in the setup or in your project code itself. Gather the :ref:`Troubleshooting documentation <troubleshooting>` and look for errors in these files. 
+There was error in the setup or in your project code itself. Gather the :ref:`Troubleshooting documentation <troubleshooting-section>` and look for errors in these files.
 
 Chances are that your issue have been posted before in the `ESP-IDF github repository <https://github.com/espressif/vscode-esp-idf-extension>`_ or `ESP-IDF forum <https://esp32.com>`_. If not, you can open a new GitHub issue or open a topic in the forum.
 
@@ -47,7 +47,7 @@ Take a look at `Configure JTAG Interface <https://docs.espressif.com/projects/es
 On Windows, you could try using `IDF-ENV <https://github.com/espressif/idf-env>`_ just running the following command in a Powershell terminal:
 
 .. code-block::
-  
+
   Invoke-WebRequest 'https://dl.espressif.com/dl/idf-env/idf-env.exe' -OutFile .\idf-env.exe; .\idf-env.exe driver install --espressif --ftdi --silabs
 
 Drivers are also part of the `IDF-Installer <https://dl.espressif.com/dl/esp-idf>`_.
@@ -61,7 +61,7 @@ Using the `IDF-ENV <https://github.com/espressif/idf-env>`_ you can manage sever
 First review the `ESP-IDF JTAG Debugging documentation <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html#jtag-debugging-setup-openocd>`_ to understand how debugging works and the expected configuration of your device.
 The debugger is connected to OpenOCD. Please take a look at `OpenOCD Troubleshooting FAQ <https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ>`_ for any OpenOCD errors you might have encountered.
 
-Check your IDE integration log files and post an issue in the respective GitHub repository if the issue is not related to OpenOCD itself. Take a look at the :ref:`Troubleshooting documentation <troubleshooting>` so you can see the error in the extension.
+Check your IDE integration log files and post an issue in the respective GitHub repository if the issue is not related to OpenOCD itself. Take a look at the :ref:`Troubleshooting documentation <troubleshooting-section>` so you can see the error in the extension.
 
 **I have an issue flashing my Espressif device, What should i do?**
 

--- a/docs_espressif/en/installation.rst
+++ b/docs_espressif/en/installation.rst
@@ -1,84 +1,92 @@
 .. _installation:
 
 Install ESP-IDF and Tools
-===============================
+=========================
 
-After installing Visual Studio Code you need to install the ESP-IDF extension for Visual Studio Code.
+:link_to_translation:`zh_CN:[中文]`
 
-- Navigate to  **View** > **Extensions** or keyboard shortcut :kbd:`Ctrl+Shift+X` in Windows/Linux or :kbd:`Shift+⌘+X` in MacOS.
+After installing Visual Studio Code (VS Code), install the ESP-IDF extension for VS Code.
 
-- Search for `ESP-IDF Extension <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ from the list of extensions.
+- Navigate to ``View`` > ``Extensions`` or the keyboard shortcut :kbd:`Ctrl+Shift+X` in Windows/Linux or :kbd:`Shift+⌘+X` in macOS.
 
-1. Install the ESP-IDF extension.
+- Search for `ESP-IDF <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_ in the list of extensions.
 
-- Navigate to **View** > **Command Palette**.
+1.  Install the ESP-IDF extension.
 
-- Type **ESP-IDF: Configure ESP-IDF Extension** and select the command to specify to launch the setup wizard. A loading notification will be shown and later the setup wizard will appear.
+    - Navigate to ``View`` > ``Command Palette``.
 
-.. note::
-  
-  * For versions of ``ESP-IDF < 5.0``, spaces are not supported inside configured paths.
+    - Type ``ESP-IDF: Configure ESP-IDF Extension`` and select the command to launch the setup wizard. A loading notification will appear, followed by the setup wizard.
 
-.. image:: ../../media/tutorials/setup/select-mode.png
+    .. note::
 
-2. Choose **Express** and select the download server:
+        For versions of ESP-IDF < 5.0, spaces are not supported in configured paths.
 
-- **Espressif**: Faster speed in China using Espressif Download servers links.
-- **Github**: Using github releases links.
+    .. image:: ../../media/tutorials/setup/select-mode.png
 
-3. Pick an ESP-IDF version to download or use the ``Find ESP-IDF in your system`` option to search for existing ESP-IDF directory.
+2.  Choose ``Express`` and select the download server:
 
-.. image:: ../../media/tutorials/setup/select-esp-idf.png
+    - ``Espressif``: Faster speed in China using Espressif download servers.
+    - ``Github``: Using GitHub release links.
 
-- Choose the location for ESP-IDF Tools ( ``IDF_TOOLS_PATH``) which is ``%USERPROFILE%\.espressif`` on Windows and ``$HOME\.espressif`` on MacOS/Linux by default.
+3.  Pick an ESP-IDF version to download or use the ``Find ESP-IDF in your system`` option to search for an existing ESP-IDF directory.
 
-.. note::
-  * Make sure that ``IDF_TOOLS_PATH`` doesn't have any spaces to avoid any build issues. Also make sure that ``IDF_TOOLS_PATH`` is not the same directory as ``IDF_PATH``.
+    .. image:: ../../media/tutorials/setup/select-esp-idf.png
 
-.. note::
-  * For MacOS/Linux users, select the Python executable to use to create ESP-IDF python virtual environment.
+    Choose the location for ESP-IDF Tools (``IDF_TOOLS_PATH``), which defaults to ``%USERPROFILE%\.espressif`` on Windows and ``$HOME\.espressif`` on macOS/Linux.
 
-4. Click ``Install`` to begin download and install of ESP-IDF and ESP-IDF Tools.
+    .. note::
 
-5. A page will appear with the setup progress status showing:
+        Make sure that ``IDF_TOOLS_PATH`` does not contain spaces to avoid build issues. Also, ensure that ``IDF_TOOLS_PATH`` is not the same directory as ``IDF_PATH``.
 
-- ESP-IDF download progress
-- ESP-IDF Tools download and install progress
-- Creation of a python virtual environment and ESP-IDF python requirements.
+    .. note::
 
-.. image:: ../../media/tutorials/setup/install-status.png
+        For macOS/Linux users, select the Python executable to create the ESP-IDF Python virtual environment.
 
-6. If everything is installed correctly, you will see a message that all settings have been configured. 
+4.  Click ``Install`` to begin downloading and installing ESP-IDF and ESP-IDF Tools.
 
-.. image:: ../../media/tutorials/setup/install-complete.png
+5.  A page will appear showing the setup progress status:
 
-.. note::
-  For Linux users, a message is shown to add OpenOCD rules in ``/etc/udev/rules.d`` which you need to run with sudo privileges.
+    - ESP-IDF download progress
+    - ESP-IDF Tools download and installation progress
+    - Creation of a Python virtual environment and installation of ESP-IDF Python requirements
 
-7. Next step is to :ref:`Start a ESP-IDF Project <start a esp-idf project>`.
+    .. image:: ../../media/tutorials/setup/install-status.png
 
-.. warning::
-  Check the :ref:`Troubleshooting <troubleshooting>` section if you have any issues during installation.
+6.  If everything installs correctly, you will see a message indicating that all settings have been configured.
+
+    .. image:: ../../media/tutorials/setup/install-complete.png
+
+    .. note::
+
+        For Linux users, a message will prompt you to add OpenOCD rules in ``/etc/udev/rules.d``. You need to run this with sudo privileges.
+
+7.  The next step is to :ref:`Create an ESP-IDF Project <create_an_esp-idf_project>`.
+
+    .. warning::
+
+        Check the :ref:`Troubleshooting <troubleshooting-section>` section if you encounter any issues during installation.
+
 
 Uninstall ESP-IDF VS Code Extension
--------------------------------------
+-----------------------------------
 
 To uninstall the ESP-IDF VS Code extension, follow these steps:
 
-1. Open Command Palette (F1) and type **ESP-IDF: Remove All ESP-IDF Settings** and select the command to remove all ESP-IDF settings.
+1.  Open Command Palette (press shortcut F1) and type ``ESP-IDF: Clear Saved ESP-IDF Setups``. Select the command to remove all ESP-IDF settings.
 
-2. Navigate to **View** > **Extensions** or use the keyboard shortcut :kbd:`Ctrl+Shift+X` in Windows/Linux or :kbd:`Shift+⌘+X` in MacOS.
+2.  Navigate to ``View`` > ``Extensions`` or use the keyboard shortcut :kbd:`Ctrl+Shift+X` in Windows/Linux or :kbd:`Shift+⌘+X` in macOS.
 
-3. Search for `ESP-IDF` and click on the **Uninstall** button.
+3.  Search for `ESP-IDF` and click the ``Uninstall`` button.
 
-4. Ensure you remove the following folders:
+4.  Remove the following folders:
 
-   - Go to your `${VSCODE_EXTENSION_DIR}` and delete the ESP-IDF plugin folder.
-   
-   - `${VSCODE_EXTENSION_DIR}` is the location of the extension:
-     - **Windows**: `%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\`
-     - **MacOS/Linux**: `$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/`
+    - Go to your `${VSCODE_EXTENSION_DIR}` and delete the ESP-IDF plugin folder.
 
-.. note::
+    - `${VSCODE_EXTENSION_DIR}` is the location of the extension:
 
-  Make sure to replace `VERSION` with the actual version number of the ESP-IDF extension installed.
+      - **Windows**: ``%USERPROFILE%/.vscode/extensions/espressif.esp-idf-extension-VERSION/``
+      - **macOS/Linux**: ``$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/``
+
+    .. note::
+
+        Make sure to replace `VERSION` with the actual version number of the installed ESP-IDF extension.

--- a/docs_espressif/en/startproject.rst
+++ b/docs_espressif/en/startproject.rst
@@ -1,52 +1,59 @@
-Start a ESP-IDF Project
-===============================
+.. _create_an_esp-idf_project:
 
-There are three ways one can get started with a project:
+Create an ESP-IDF Project
+=========================
+
+:link_to_translation:`zh_CN:[中文]`
+
+You can start a project in three ways:
 
 1. :ref:`ESP-IDF New Project`
 2. :ref:`ESP-IDF Show Examples Projects`
 3. :ref:`ESP-IDF Existing ESP-IDF Project`
 
-The first option is recommended as it allows you to configure the project while the second and third just create the project with current workspace folder configuration.
+The first option is recommended because it allows to configure the project. The second and third options create the project with the current workspace folder configuration.
 
 .. _ESP-IDF New Project:
 
-1. Using **ESP-IDF: New project**
------------------------------------
+Using ``ESP-IDF: New Project``
+---------------------------------
 
-In Visual Studio Code
+In Visual Studio Code:
 
-- Navigate to **View** > **Command Palette**.
+- Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: New Project** and select the command to launch the New Project wizard. This will open the New Project window as shown below:
+- Type ``ESP-IDF: New Project`` and select the command to launch the New Project wizard.
 
-.. image:: ../../media/tutorials/new_project/new_project_init.png
+    .. image:: ../../media/tutorials/new_project/new_project_init.png
 
-- Choose the project name
-- Choose where to create this new project
-- Select the Espressif board you are using
-- Select the serial port of the device (A list of currently serial devices is shown in the dropdown)
+- Choose the project name.
+- Choose the location for the new project.
+- Select the Espressif board you are using.
+- Select the serial port of the device (a list of currently connected serial devices appears in the dropdown).
 
-.. note::
-  * Please review `Establish serial communication <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/establish-serial-connection.html>`_ if you are not sure about the serial port name.
+    .. note::
 
-.. note::
-  * Please review `Configuration of OpenOCD for Specific Target <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target>`_ to understand which board or configuration to use for your specific hardware.
+        If you are not sure about the serial port name, refer to `Establish Serial Communication <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/establish-serial-connection.html>`_.
 
-- Optionally, You could also choose to import any ESP-IDF component directory ``component-dir`` to the new project which will be copied to the new project's directory ``components`` sub directory (``<project-dir>/components/component-dir``)
+    .. note::
 
-- After that click ``Choose Template`` button.
+        Please refer to `Configuration of OpenOCD for Specific Target <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target>`_ to select the appropriate OpenOCD configuration file based on your hardware.
 
-- Choose ESP-IDF from the dropdown if you want to use an example as template.
+- Optionally, you can import any ESP-IDF component directory ``component-dir`` to the new project. This will copy it to the new project's ``components`` subdirectory (``<project-dir>/components/component-dir``).
 
-.. note::
-  If you want to create a blank project, choose ESP-IDF ``sample_project`` or  Extension ``template-app``.
+- Click the ``Choose Template`` button.
 
-.. image:: ../../media/tutorials/new_project/new_project_templates.png
+- Select ESP-IDF from the dropdown if you want to use a template.
 
-- Choose your desired template and click the **Create Project Using Template <template-name>** button where **<template-name>** is the name of the selected template.
+    .. note::
 
-- After the project is created, a notification window will show up to open the newly created project or not.
+        If you want to create a blank project, choose ESP-IDF ``sample_project`` or Extension ``template-app``.
+
+    .. image:: ../../media/tutorials/new_project/new_project_templates.png
+
+- Choose your desired template and click the ``Create Project Using Template <template-name>`` button, where ``<template-name>`` is the name of the selected template.
+
+- After the project is created, a notification window will appear, asking whether to open the newly created project.
 
 .. image:: ../../media/tutorials/new_project/new_project_confirm.png
   :width: 400px
@@ -54,20 +61,20 @@ In Visual Studio Code
 
 .. _ESP-IDF Show Examples Projects:
 
-2. Using **Show Examples Projects**
------------------------------------
+Using ``ESP-IDF: Show Examples Projects``
+--------------------------------------------
 
-In Visual Studio Code
+In Visual Studio Code:
 
-- Navigate to **View** > **Command Palette**.
+- Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: Show Examples Projects** and select the command to create a new project from ESP-IDF examples.
+- Type ``ESP-IDF: Show Examples Projects`` and select the command to create a new project from ESP-IDF examples.
 
-- Select ``ESP-IDF`` from the dropdown. A window will appear showing a list of ESP-IDF examples.
+- Select ``ESP-IDF`` from the dropdown. A window will appear, showing a list of ESP-IDF examples.
 
-- When you select an example the readme will be shown and a **Create project using example example_name** button.
+- When you select an example, the README file will appear along with a ``Create project using example example_name`` button.
 
-- Choose a destination to create the new project. A notification will be shown to Open folder in a new window.
+- Choose a destination for the new project. A notification will prompt you to open the folder in a new window.
 
 .. image:: ../../media/tutorials/new_project/new_project_confirm.png
   :width: 400px
@@ -75,15 +82,15 @@ In Visual Studio Code
 
 .. _ESP-IDF Existing ESP-IDF Project:
 
-3. Opening an Existing ESP-IDF Project
-----------------------------------------
+Opening an Existing ESP-IDF Project
+--------------------------------------
 
-ESP-IDF projects follow this directory structure: 
+ESP-IDF projects follow this directory structure:
 
 `ESP-IDF Example Project <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-project>`_
 
 .. code-block::
-  
+
   - myProject/
               - CMakeLists.txt
               - sdkconfig
@@ -101,33 +108,34 @@ ESP-IDF projects follow this directory structure:
               - build/
 
 
-In Visual Studio Code
+In Visual Studio Code:
 
-- Navigate to **View** > **Command Palette**.
+- Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: Import ESP-IDF Project** and select the command to import an existing ESP-IDF project.
+- Type ``ESP-IDF: Import ESP-IDF Project`` and select the command to import an existing ESP-IDF project.
 
-This command will add both Visual Studio Code configuration files (settings.json, launch.json) and Docker container files (Dockerfile and .devcontainer.json).
+This command adds both Visual Studio Code configuration files (settings.json, launch.json) and Docker container files (Dockerfile and .devcontainer.json).
 
-Next step is to :ref:`Connect a device <connectdevice>`.
+The next step is to :ref:`Connect a device <connectdevice>`.
+
 
 Adding Visual Studio Code configuration files and Docker container
-----------------------------------------------------------------------
+------------------------------------------------------------------
 
-Open a directory in Visual Studio Code with menu **File** > **Open Folder** which contains a **CMakeLists.txt** file in the root directory (myProject) that follows the ESP-IDF structure.
+In Visual Studio Code, go to ``File`` > ``Open Folder`` and open a directory containing a ``CMakeLists.txt`` file in the root (e.g., myProject), which follows the ESP-IDF structure.
 
-1. You can add vscode configuration files (settings.json, launch.json) by:
+1.  To add Visual Studio Code configuration files (settings.json, launch.json):
 
-- Navigate to **View** > **Command Palette**.
+    - Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: Add .vscode Configuration Folder** command.
+    - Type ``ESP-IDF: Add .vscode Configuration Folder`` and select the command.
 
-2. If you want to open the project within the ESP-IDF Docker container:
+2.  To open the project within the ESP-IDF Docker container:
 
-- Navigate to **View** > **Command Palette**.
+    - Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: Add Docker Container Configuration** and select the command to add the ``.devcontainer`` directory to your current directory.
+    - Type ``ESP-IDF: Add Docker Container Configuration`` and select the command to add the ``.devcontainer`` directory to your current directory.
 
-- Navigate to **View** > **Command Palette**.
+    - Navigate to ``View`` > ``Command Palette``.
 
-- Type **Remote - Containers: Open Folder in Remote Container** and select the command to open the existing project into the recently created container from previous step Dockerfile.
+    - Type ``Dev Containers: Open Folder in Remote Container`` and select the command to open the existing project inside the container created from the Dockerfile in the previous step.

--- a/docs_espressif/en/troubleshooting.rst
+++ b/docs_espressif/en/troubleshooting.rst
@@ -1,30 +1,32 @@
+.. _troubleshooting-section:
+
 Troubleshooting
-===============================
+===============
+
+:link_to_translation:`zh_CN:[中文]`
 
 .. note::
-  * Use **idf.openOcdDebugLevel** configuration setting to 4 or more to show debug logging in OpenOCD server output.
-  * Use **logLevel** in your ``<project-directory>/.vscode/launch.json`` to 3 or more to show more debug adapter output.
 
-In Visual Studio Code select menu **View** > **Output** > **ESP-IDF**. This output information is useful to know what is happening in the extension.
+    * Set ``idf.openOcdDebugLevel`` to 4 or higher to enable debug logging in the OpenOCD server output.
+    * Set ``logLevel`` in your ``<project-directory>/.vscode/launch.json`` to 3 or higher to display more debug adapter output.
 
-In Visual Studio Code select menu **View** > **Command Palette...** and type **ESP-IDF: Doctor Command** to generate a report of your environment configuration and it will be copied in your clipboard to paste anywhere.
+In Visual Studio Code, go to ``View`` > ``Output`` and select ``ESP-IDF`` from the dropdown. This output provides useful information about the extension's activity.
 
-Check log file which can be obtained from:
+In Visual Studio Code, go to ``View`` > ``Command Palette...`` and type ``ESP-IDF: Doctor Command`` to generate a report of your environment configuration. This report will be copied to your clipboard for easy pasting.
 
-Windows 
-  ``%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log``
-MacOS/Linux
-  ``$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/esp_idf_vsc_ext.log``
+Check the log file located at:
 
-In Visual Studio Code, select menu **Help** > **Toggle Developer Tools** and copy any error in the Console tab related to this extension.
+- **Windows**: ``%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log``
+- **macOS/Linux**: ``$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/esp_idf_vsc_ext.log``
 
-Visual Studio Code allows you to configure settings at different levels: **Global (User Settings)**, **Workspace** and **Workspace Folder** so make sure your project is using the right settings. The **ESP-IDF: Doctor command** output will show the settings actually being used.
+In Visual Studio Code, go to ``Help`` > ``Toggle Developer Tools`` and copy any errors from the Console tab related to this extension.
 
-Review the `OpenOCD troubleshooting FAQ <https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ>`_ related to the **OpenOCD** output, for application tracing, debug or any OpenOCD related issues.
+Visual Studio Code allows you to configure settings at different levels: **Global (User Settings)**, **Workspace** and **Workspace Folder**. Ensure your project uses the correct settings. The output from ``ESP-IDF: Doctor command`` will show the settings currently in use.
 
-If there is any Python package error, please try to reinstall the required python packages with the **ESP-IDF: Install ESP-IDF Python Packages** command. Please consider that this extension install ESP-IDF, this extension's and ESP-IDF Debug Adapter python packages when running the **ESP-IDF: Configure ESP-IDF Extension** setup wizard.
+Review `OpenOCD Troubleshooting FAQ <https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ>`_ for information related to OpenOCD output, application tracing, debugging, or any OpenOCD issues.
 
 .. note::
-  * When downloading ESP-IDF using git cloning in Windows if you receive errors like "unable to create symlink", enabling **Developer Mode** while cloning ESP-IDF could help resolve the issue.
 
-If you can't resolve the error, please search in the `github repository issues <http://github.com/espressif/vscode-esp-idf-extension/issues>`_ for existing errors or open a new issue `here <https://github.com/espressif/vscode-esp-idf-extension/issues/new/choose>`_.
+    If you receive errors like "unable to create symlink" while cloning ESP-IDF on Windows, enabling **Developer Mode** may help resolve the issue.
+
+If you cannot resolve the error, please search the `GitHub Repository Issues <http://github.com/espressif/vscode-esp-idf-extension/issues>`_ for existing issues or create a new issue `here <https://github.com/espressif/vscode-esp-idf-extension/issues/new/choose>`_.

--- a/docs_espressif/zh_CN/installation.rst
+++ b/docs_espressif/zh_CN/installation.rst
@@ -1,1 +1,92 @@
-.. include:: ../en/installation.rst
+.. _installation:
+
+安装 ESP-IDF 和相关工具
+=======================
+
+:link_to_translation:`en:[English]`
+
+下载 Visual Studio Code (VS Code) 后，需要在 VS Code 中安装 ESP-IDF 扩展。
+
+- 前往菜单栏 ``查看`` > ``扩展``，也可以在 Windows/Linux 系统中使用快捷键 :kbd:`Ctrl+Shift+X`，或在 macOS 系统中使用快捷键 :kbd:`Shift+⌘+X`。
+
+- 从扩展列表中搜索 `ESP-IDF <https://marketplace.visualstudio.com/items?itemName=espressif.esp-idf-extension>`_。
+
+1.  安装 ESP-IDF 扩展。
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+
+    - 输入 ``ESP-IDF: 配置 ESP-IDF 扩展``，选中该命令以启动设置向导。用户界面将显示加载通知，随后出现设置向导。
+
+    .. note::
+
+        ESP-IDF 5.0 以下的版本不支持在配置路径中添加空格。
+
+    .. image:: ../../media/tutorials/setup/select-mode.png
+
+2.  点击 ``Express`` 并选择下载服务器：
+
+    - ``Espressif``：推荐中国用户使用乐鑫下载服务器，下载速度更快。
+    - ``Github``：使用 GitHub 上的下载链接。
+
+3.  选择要下载的 ESP-IDF 版本，或使用 ``Find ESP-IDF in your system`` 选项搜索现有的 ESP-IDF 目录。
+
+    .. image:: ../../media/tutorials/setup/select-esp-idf.png
+
+    选择保存 ESP-IDF 工具的位置 (``IDF_TOOLS_PATH``)，默认情况下在 Windows 系统中为 ``%USERPROFILE%\.espressif``，在macOS/Linux 系统中为 ``$HOME\.espressif``。
+
+    .. note::
+
+        确保 ``IDF_TOOLS_PATH`` 中没有空格，避免出现构建问题。此外，要注意 ``IDF_TOOLS_PATH`` 与 ``IDF_PATH`` 不能在相同目录下。
+
+    .. note::
+
+        macOS/Linux 用户需要选择用于创建 ESP-IDF Python 虚拟环境的 Python 可执行文件。
+
+4.  点击 ``Install`` 开始下载和安装 ESP-IDF 和 ESP-IDF 工具。
+
+5.  用户界面中将显示设置的进度：
+
+    - ESP-IDF 下载进度
+    - ESP-IDF 工具下载和安装进度
+    - Python 虚拟环境创建进度及 ESP-IDF Python 依赖包安装进度
+
+    .. image:: ../../media/tutorials/setup/install-status.png
+
+6.  若一切安装正确，页面将显示所有设置已完成配置的消息。
+
+    .. image:: ../../media/tutorials/setup/install-complete.png
+
+    .. note::
+
+        扩展会提示 Linux 用户使用 sudo 权限，在 ``/etc/udev/rules.d`` 中添加 OpenOCD 规则。
+
+7.  接下来请 :ref:`创建 ESP-IDF 项目 <create_an_esp-idf_project>`。
+
+    .. warning::
+
+        如果在安装过程中遇到问题，请查看 :ref:`故障排除 <troubleshooting-section>`。
+
+
+卸载 ESP-IDF VS Code 扩展
+-------------------------
+
+可以参照以下操作步骤，卸载 ESP-IDF VS Code 扩展：
+
+1.  打开命令面板（快捷键为 F1），输入 ``ESP-IDF：清除已保存的 ESP-IDF 设置``，选择该命令以移除所有 ESP-IDF 设置。
+
+2.  前往菜单栏 ``查看`` > ``扩展``，也可以在 Windows/Linux 系统中使用快捷键 :kbd:`Ctrl+Shift+X`，或在 macOS 系统中使用快捷键 :kbd:`Shift+⌘+X`。
+
+3.  搜索 `ESP-IDF` 并点击 ``Uninstall`` 按钮。
+
+4.  确保删除以下文件夹：
+
+    - 前往 `${VSCODE_EXTENSION_DIR}` 并删除 ESP-IDF 插件文件夹。
+
+    - 扩展存储在 `${VSCODE_EXTENSION_DIR}`：
+
+      - **Windows**：``%USERPROFILE%/.vscode/extensions/espressif.esp-idf-extension-VERSION/``
+      - **macOS/Linux**：``$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/``
+
+    .. note::
+
+        请将 `VERSION` 替换为已安装的 ESP-IDF 扩展的实际版本号。

--- a/docs_espressif/zh_CN/startproject.rst
+++ b/docs_espressif/zh_CN/startproject.rst
@@ -1,1 +1,141 @@
-.. include:: ../en/startproject.rst
+.. _create_an_esp-idf_project:
+
+创建 ESP-IDF 项目
+=================
+
+:link_to_translation:`en:[English]`
+
+可以通过三种方式启动 ESP-IDF 项目：
+
+1. :ref:`ESP-IDF New Project`
+2. :ref:`ESP-IDF Show Examples Projects`
+3. :ref:`ESP-IDF Existing ESP-IDF Project`
+
+推荐使用第一种方式来自行配置项目，而第二和第三种方式则使用当前工作区文件夹配置来创建项目。
+
+.. _ESP-IDF New Project:
+
+使用 ``ESP-IDF：新建项目``
+--------------------------------
+
+在 Visual Studio Code 中：
+
+- 前往菜单栏 ``查看`` > ``命令面板``。
+
+- 输入 ``ESP-IDF：新建项目``，选择该命令以启动新项目向导窗口。
+
+    .. image:: ../../media/tutorials/new_project/new_project_init.png
+
+- 输入项目名称
+- 选择保存新项目的位置
+- 选择当前使用的乐鑫开发板名称
+- 选择设备的串口（下拉菜单中会显示当前连接的串行设备列表）
+
+    .. note::
+
+        如果不确定串口名称，可以查看 `创建串口连接 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/get-started/establish-serial-connection.html>`_。
+
+    .. note::
+
+        请查看 `根据目标芯片配置 OpenOCD <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target>`_，为你的硬件选择合适的 OpenOCD 配置文件。
+
+- 你也可以将 ESP-IDF 组件目录 ``component-dir`` 导入到新项目中。该组件目录将被复制到新项目的 ``components`` 子目录中 (``<project-dir>/components/component-dir``)。
+
+- 点击 ``Choose Template`` 按钮。
+
+- 如果想使用例程模板，请在下拉菜单中选择 ESP-IDF。
+
+    .. note::
+
+        如果想创建一个空白项目，请选择 ``sample_project`` 或 ``template-app``。
+
+    .. image:: ../../media/tutorials/new_project/new_project_templates.png
+
+- 选择想要使用的模板并点击 ``Create Project Using Template <template-name>`` 按钮，其中 ``<template-name>`` 是所选模板的名称。
+
+- 成功创建项目后，将弹出一个通知窗口，询问是否打开新创建的项目。
+
+.. image:: ../../media/tutorials/new_project/new_project_confirm.png
+  :width: 400px
+  :align: center
+
+.. _ESP-IDF Show Examples Projects:
+
+使用 ``ESP-IDF：展示示例项目``
+-------------------------------------
+
+在 Visual Studio Code 中：
+
+- 前往菜单栏 ``查看`` > ``命令面板``。
+
+- 输入 ``ESP-IDF：展示示例项目``，选择该命令并从 ESP-IDF 例程中创建新项目。
+
+- 在下拉菜单中选择 ``ESP-IDF``，弹出的窗口中会显示 ESP-IDF 例程列表。
+
+- 选好例程后，界面中会出现 README 文件和 ``Create project using example example_name`` 按钮。
+
+- 为新项目选择存储位置，通知会提示你在新窗口中打开文件夹。
+
+.. image:: ../../media/tutorials/new_project/new_project_confirm.png
+  :width: 400px
+  :align: center
+
+.. _ESP-IDF Existing ESP-IDF Project:
+
+打开已有的 ESP-IDF 项目
+--------------------------
+
+ESP-IDF 项目遵循以下目录结构：
+
+`ESP-IDF 示例项目 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#example-project-structure>`_
+
+.. code-block::
+
+  - myProject/
+              - CMakeLists.txt
+              - sdkconfig
+              - components/ - component1/ - CMakeLists.txt
+                                          - Kconfig
+                                          - src1.c
+                            - component2/ - CMakeLists.txt
+                                          - Kconfig
+                                          - src1.c
+                                          - include/ - component2.h
+              - main/       - CMakeLists.txt
+                            - src1.c
+                            - src2.c
+
+              - build/
+
+
+在 Visual Studio Code 中：
+
+- 前往菜单栏 ``查看`` > ``命令面板``。
+
+- 输入 ``ESP-IDF：导入 ESP-IDF 项目``，选择该命令以导入现有的 ESP-IDF 项目。
+
+此命令将添加 Visual Studio Code 配置文件 (settings.json, launch.json) 和 Docker 容器文件 (Dockerfile and .devcontainer.json)。
+
+接下来请 :ref:`连接设备 <connectdevice>`。
+
+
+添加 Visual Studio Code 配置文件和 Docker 容器
+----------------------------------------------
+
+在 Visual Studio Code 中，前往菜单栏 ``文件`` > ``打开文件夹``。打开一个根目录中包含 ``CMakeLists.txt`` 文件的文件夹（如 myProject），该文件夹应符合 ESP-IDF 项目结构。
+
+1.  可以通过以下方式添加 Visual Studio Code 配置文件 (settings.json, launch.json)：
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+
+    - 输入 ``ESP-IDF：添加 VS Code 配置文件夹``，并选中该命令。
+
+2.  可以通过以下方式在 ESP-IDF Docker 容器中打开项目：
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+
+    - 输入 ``ESP-IDF：添加 Docker 容器配置``，选中该命令从而将 ``.devcontainer`` 目录添加到当前目录下。
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+
+    - 输入 ``开发容器: 在容器中打开文件夹`` 并选中该命令，在由 Dockerfile 创建的容器中打开现有的项目。

--- a/docs_espressif/zh_CN/troubleshooting.rst
+++ b/docs_espressif/zh_CN/troubleshooting.rst
@@ -1,1 +1,32 @@
-.. include:: ../en/troubleshooting.rst
+.. _troubleshooting-section:
+
+故障排除
+========
+
+:link_to_translation:`en:[English]`
+
+.. note::
+
+    * 将 ``idf.openOcdDebugLevel`` 等级配置为 4 及以上，从而在 OpenOCD 服务器输出中启用调试日志。
+    * 在 ``<project-directory>/.vscode/launch.json`` 文件中，将 ``logLevel`` 等级设置为 3 及以上，从而显示更多调试适配器的输出信息。
+
+在 Visual Studio Code 中，前往菜单栏 ``查看`` > ``输出``，在下拉框中选择 ``ESP-IDF``，该输出窗口会提供有关 ESP-IDF 扩展活动的有用信息。
+
+在 Visual Studio Code 中，前往菜单栏 ``查看`` > ``命令面板``，选择 ``ESP-IDF：诊断命令`` 以生成环境配置报告。该报告将自动复制到剪贴板上以便粘贴。
+
+可以从以下位置获取并查看日志文件：
+
+- **Windows**：``%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log``
+- **macOS/Linux**：``$HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/esp_idf_vsc_ext.log``
+
+在 Visual Studio Code 中，前往菜单栏 ``帮助`` > ``切换开发人员工具``，在 Console 选项卡中复制与此扩展相关的错误。
+
+Visual Studio Code 支持不同级别的设置，如：**全局（用户设置）**、**工作区** 和 **工作区文件夹**，请确保正确设置项目。运行 ``ESP-IDF：诊断命令`` 可以查看当前使用的设置。
+
+查看 `OpenOCD 故障排除 FAQ <https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ>`_，获取有关 OpenOCD 输出、应用程序跟踪、调试等相关的问题。
+
+.. note::
+
+    在 Windows 系统中克隆 ESP-IDF 时，如果收到类似 "unable to create symlink" 的错误，可以尝试启用 **Developer Mode**。
+
+如果遇到无法解决的问题，请在 `GitHub 仓库问题 <http://github.com/espressif/vscode-esp-idf-extension/issues>`_ 中搜索现有问题或点击 `此处 <https://github.com/espressif/vscode-esp-idf-extension/issues/new/choose>`_ 创建新问题。


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions in installation.rst&startproject.rst&troubleshooting.rst based on Espressif Style Guide
- Provides CN translation for above three documents
- TODO: Closes [DOC-10389](https://jira.espressif.com:8443/browse/DOC-10389) once merged
