### PR TITLE
Fix OpenOCD rules copy command in App.vue

### DIFF
--- a/src/views/setup/App.vue
+++ b/src/views/setup/App.vue
@@ -21,7 +21,7 @@ const isLinuxPlatform = computed(() => {
 
 const openOCDRulesPathText = computed(() => {
   return openOCDRulesPath.value !== ""
-    ? `sudo cp --update=none ${openOCDRulesPath.value} /etc/udev/rules.d`
+    ? `sudo cp -u ${openOCDRulesPath.value} /etc/udev/rules.d/`
     : "";
 });
 </script>


### PR DESCRIPTION
## Description  

During the ESP-IDF extension setup in VSCode on a Linux system, the user is prompted to copy the `60-openocd.rules` file at the end of the configuration process. However, the generated command contains an incorrect `cp` option (`--update=none`), which results in an error.  

This PR corrects the command by replacing `--update=none` with the valid `-u` option, ensuring the file copies correctly to `/etc/udev/rules.d/`.

## Type of change  

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update

## Steps to test this pull request  

1. Configure the **ESP-IDF extension** in VSCode on a Linux system.  
2. At the end of the setup process, observe the generated command for copying `60-openocd.rules`.  
3. Copy and execute the command in a terminal.  

### **Expected behavior:**  
- The command should execute successfully without errors.  
- The `60-openocd.rules` file should be copied to `/etc/udev/rules.d/`.  

### **Expected output:**  
```sh
$ sudo cp -u /path/to/60-openocd.rules /etc/udev/rules.d/
```
No error messages should appear, and the file should be correctly placed in the target directory.

## How has this been tested?  

The fix has been tested manually by:  

- Checking the updated command syntax.  
- Running the corrected command in a Linux terminal to verify it executes correctly.  

### **Test Configuration:**  
- **ESP-IDF Version:** 1.9.1
- **OS:** Linux

## Dependent components impacted by this PR  

None.

## Checklist  

- [x] PR Self Reviewed  
- [x] Applied Code formatting  
- [ ] Added Documentation *(Not required for this fix)*  
- [ ] Added Unit Test *(Not required for this fix)*  
- [x] Verified on all platforms - Windows, Linux, and macOS *(Only Linux is applicable for this change)*