### PR TITLE
docs: Provide CN translation for eight additionalfeatures docs

### DIFF
--- a/docs_espressif/en/additionalfeatures/application-size-analysis.rst
+++ b/docs_espressif/en/additionalfeatures/application-size-analysis.rst
@@ -1,20 +1,19 @@
 ESP-IDF Application Size Analysis
-===================================
+=================================
 
-The ESP-IDF Application Size Analysis tool provides a detailed breakdown of your application’s memory usage, helping developers optimize storage allocation. For a visual size analysis:
+:link_to_translation:`zh_CN:[中文]`
 
-- Navigate to **View** > **Command Palette**.
+The ESP-IDF application size analysis tool provides a detailed breakdown of your application’s memory usage, helping developers optimize storage allocation. To view a visual size analysis:
 
-- Type **ESP-IDF: Size Analysis of the Binaries** and select the command to visually review the application size information.
+-   Navigate to ``View`` > ``Command Palette``.
+-   Type ``ESP-IDF: Size Analysis of the Binaries`` and select the command to review the application size information.
 
-.. image:: ../../../media/tutorials/basic_use/size.png
+    .. image:: ../../../media/tutorials/basic_use/size.png
 
-Follow the below instructions to view applciation size analysis from CLI:
+To view application size analysis from the CLI:
 
-- Navigate to **View** > **Command Palette**.
+-   Navigate to ``View`` > ``Command Palette``.
+-   Type ``ESP-IDF: Build your Project`` and select the command to build your project.
+-   The application size analysis task will be executed in a terminal, showing the size analysis results. You can enable or disable this task with ``idf.enableSizeTaskAfterBuildTask`` in your ``settings.json``.
 
-- Type **ESP-IDF: Build your Project** and select the command to specify the build your project.
-
-- The application size analysis task will be executed in a terminal showing the size analysis results. You can enable or disable this task being executed with **idf.enableSizeTaskAfterBuildTask** in your settings.json.
-
-.. image:: ../../../media/tutorials/basic_use/size_terminal.png
+    .. image:: ../../../media/tutorials/basic_use/size_terminal.png

--- a/docs_espressif/en/additionalfeatures/dfu.rst
+++ b/docs_espressif/en/additionalfeatures/dfu.rst
@@ -1,37 +1,40 @@
-Device Firmware Upgrade via USB.
+Device Firmware Upgrade (DFU) via USB
 =====================================
 
-Requirements:
-----------------------
+:link_to_translation:`zh_CN:[中文]`
 
-- ESP32-S2 or an ESP32-S3 chip
-- You will need to do some electrical connection work. `Here is a guide for the S2 board <https://blog.espressif.com/dfu-using-the-native-usb-on-esp32-s2-for-flashing-the-firmware-b2c4af3335f1>`_
-- The chip needs to be in bootloader mode for it to be detected as a DFU device. This can be achieved by pressing the “reset” button, while holding the “boot” button pressed
-- For Windows only: You have to register on Windows the device with the WinUSB driver.
+Requirements
+------------
 
-.. note::
-  The drivers can be installed by the `Zadig tool <https://zadig.akeo.ie/>`_. Please make sure that the device is in download mode before you run the tool and that it detects the ESP32-S2 device before you install the drivers. The Zadig tool might detect several USB interfaces of ESP32-S2. Please install the WinUSB driver only for the interface where there is no driver installed (probably it is Interface 2) and do not re-install the driver for the other interface.
+- ESP32-S2 or ESP32-S3 chip.
+- Complete electrical connections. Here is `a guide for the ESP32-S2 board <https://blog.espressif.com/dfu-using-the-native-usb-on-esp32-s2-for-flashing-the-firmware-b2c4af3335f1>`_.
+- The chip must be in bootloader mode to be detected as a DFU device. This can be achieved by pressing the "reset" button while holding the "boot" button.
+- For Windows: Register the device with the **WinUSB** driver.
 
-Flashing:
-~~~~~~~~~~~~
+    .. note::
 
-1. Select a device target which is DFU compatible (ESP32-S2/ ESP32-S3)
+        Install the drivers using the `Zadig tool <https://zadig.akeo.ie/>`_. Ensure the device is in download mode before running the tool. The tool should detect the ESP32-S2 device before installing the drivers. The Zadig tool may detect several USB interfaces of ESP32-S2. Install the WinUSB driver only for the interface without a driver (likely **Interface 2**) and do not reinstall the driver for other interfaces.
 
-.. image:: ../../../media/tutorials/dfu/select_device.png
+Flashing
+~~~~~~~~
 
-2. Select DFU as flashing method
+1.  Select a DFU-compatible device (ESP32-S2 or ESP32-S3).
 
-.. image:: ../../../media/tutorials/dfu/flash_method.png
+    .. image:: ../../../media/tutorials/dfu/select_device.png
 
-3. Build the project
+2.  Select DFU as the flashing method.
 
-.. image:: ../../../media/tutorials/dfu/build_project.png
+    .. image:: ../../../media/tutorials/dfu/flash_method.png
 
-4. Flash
+3.  Build the project.
 
-.. image:: ../../../media/tutorials/dfu/flash.png
+    .. image:: ../../../media/tutorials/dfu/build_project.png
+
+4.  Flash the firmware.
+
+    .. image:: ../../../media/tutorials/dfu/flash.png
 
 Useful Links
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
-`Espressif DFU api guide <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/dfu.html?highlight=dfu%20util#api-guide-dfu-build>`_
+`Espressif DFU API guide <https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/dfu.html>`_

--- a/docs_espressif/en/additionalfeatures/efuse.rst
+++ b/docs_espressif/en/additionalfeatures/efuse.rst
@@ -1,24 +1,25 @@
-EFuse Explorer
-========================
+eFuse Explorer
+==============
+
+:link_to_translation:`zh_CN:[中文]`
 
 This feature requires ESP-IDF ``>=v4.3``.
 
-Espressif chips has a number of eFuses which can store system and user parameters. Each eFuse is a one-bit field which can be programmed to 1 after which it cannot be reverted back to 0. This feature is based on ESP-IDF `espfuse.py <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/efuse.html#espefuse-py>`_ script to read and write efuses.
+Espressif chips have several eFuses that store system and user parameters. Each eFuse is a one-bit field that can be programmed to 1 and cannot be reverted to 0. This feature uses the ESP-IDF `espfuse.py <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/efuse.html#espefuse-py>`_ script to read and write eFuses.
 
-1. Select the Serial Port:
+1.  Select the Serial Port:
 
-- Navigate to **View** > **Command Palette**.
+    - Navigate to ``View`` > ``Command Palette``.
+    - Type ``ESP-IDF: Select Port to Use`` and select the command to specify your device's serial port.
 
-- Type **ESP-IDF: Select Port to Use** and select the command to specify the serial port of your device.
+2.  Click ``ESP-IDF: Explorer`` in the Visual Studio Code activity bar. In the ``eFuse Explorer`` section, click ``Connect your Board First``.
 
-2. Click the ``ESP-IDF Explorer`` in the `Visual Studio Code Activity bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_. On the ``EFUSE EXPLORER`` section, click the ``Connect your Board First``.
+    .. image:: ../../../media/tutorials/efuse/efuse_connect.png
 
-.. image:: ../../../media/tutorials/efuse/efuse_connect.png
+3.  A list of eFuse categories appears in a tree structure.
 
-3. A list of EFuses categories will now be shown in a tree structure.
+    .. image:: ../../../media/tutorials/efuse/efuse_list.png
 
-.. image:: ../../../media/tutorials/efuse/efuse_list.png
+4.  Click any category to view the eFuses and their values.
 
-4. If you click on any category, you will see the category Efuses and Values.
-
-.. image:: ../../../media/tutorials/efuse/efuse_expanded.png
+    .. image:: ../../../media/tutorials/efuse/efuse_expanded.png

--- a/docs_espressif/en/additionalfeatures/hints-viewer.rst
+++ b/docs_espressif/en/additionalfeatures/hints-viewer.rst
@@ -1,24 +1,28 @@
+.. _hints_viewer:
+
 Hints Viewer
-=================
+============
+
+:link_to_translation:`zh_CN:[中文]`
 
 This feature enhances your development experience by providing helpful hints for errors detected in your code.
 
-``idf.py`` will try to suggest hints on how to resolve errors. It works with a database of hints stored in ``$IDF_PATH/tools/idf_py_actions/hints.yml`` and the hints will be printed if a match is found for the given error. 
+The ``idf.py`` tool suggests hints for resolving errors. It uses a database of hints stored in ``$IDF_PATH/tools/idf_py_actions/hints.yml``. Hints will be printed if a match is found for the given error.
 
 Hover Over Errors for Hints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you hover over errors in the text editor, if the error matches one listed in our hints.yml file, a hint is displayed.
+When you hover over errors in the text editor, a hint displays if the error matches one listed in the ``hints.yml`` file.
 
 .. image:: ../../../media/tutorials/hints/hover.gif
 
 Bottom Panel for Hints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
-1. **Automatic Updates:** The ESP-IDF bottom panel automatically updates to display hints based on the errors in your currently opened file.
+1.  **Automatic Updates:** The ESP-IDF bottom panel updates automatically to display hints based on the errors in your currently opened file.
 
-.. image:: ../../../media/tutorials/hints/bottom_panel.png
+    .. image:: ../../../media/tutorials/hints/bottom_panel.png
 
-2. **Manual Search:** You can manually search for hints by copy pasting errors.
+2.  **Manual Search:** You can manually search for hints by copying and pasting errors.
 
-.. image:: ../../../media/tutorials/hints/manual_search.gif
+    .. image:: ../../../media/tutorials/hints/manual_search.gif

--- a/docs_espressif/en/additionalfeatures/install-esp-components.rst
+++ b/docs_espressif/en/additionalfeatures/install-esp-components.rst
@@ -1,24 +1,27 @@
 Install ESP-IDF Components
-===============================
+==========================
 
-The **ESP-IDF: ESP Component Registry** will launch a UI showing the `ESP Component Registry <https://components.espressif.com>`_.
+:link_to_translation:`zh_CN:[中文]`
+
+The ``ESP-IDF: Show ESP Component Registry`` command launches a UI showing the `ESP Component Registry <https://components.espressif.com>`_.
 
 .. image:: ../../../media/tutorials/features/component-registry.png
 
-You can browse many different ESP components and install them on your current ESP-IDF project with the ``Install`` button.
+You can browse various ESP components and install them in your current ESP-IDF project using the ``Install`` button.
 
 .. image:: ../../../media/tutorials/features/install-component.png
 
-You can also create a new project from ESP component example using the ``Create project from this template`` button.
+You can also create a new project from an ESP component example using the ``Create project from this example`` button.
 
 .. image:: ../../../media/tutorials/features/create-project-from-component-example.png
 
-Find out more about the `ESP Component Registry official documentation <https://docs.espressif.com/projects/idf-component-manager/en/latest/>`_.
+For more information, refer to `ESP Component Registry Documentation <https://docs.espressif.com/projects/idf-component-manager/en/latest/>`_.
 
 Install Arduino-ESP32 as Component
--------------------------------------
+----------------------------------
 
-The **ESP-IDF: Add Arduino-ESP32 as ESP-IDF Component** command will add `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_ as a ESP-IDF component in your current directory (``${CURRENT_DIRECTORY}/components/arduino``). You can also use the **ESP-IDF: Create Project from Extension Template** command with ``arduino-as-component`` template to create a new project directory that includes Arduino-esp32 as an ESP-IDF component.
+The ``ESP-IDF: Add Arduino-ESP32 as ESP-IDF Component`` command adds `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_ as an ESP-IDF component in your current directory (``${CURRENT_DIRECTORY}/components/arduino``). You can also use the ``ESP-IDF: Create Project from Extension Template`` command with the ``arduino-as-component`` template to create a new project directory that includes Arduino-ESP32 as an ESP-IDF component.
 
 .. note::
-  Not all versions of ESP-IDF are supported. Make sure to check `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_ to see if your ESP-IDF version is compatible.
+
+    Not all versions of ESP-IDF are supported. Check `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_ to see if your ESP-IDF version is compatible.

--- a/docs_espressif/en/additionalfeatures/nvs-partition-editor.rst
+++ b/docs_espressif/en/additionalfeatures/nvs-partition-editor.rst
@@ -1,40 +1,41 @@
 NVS Partition Editor
-=========================
+====================
 
-The **ESP-IDF: Open NVS Partition Editor** allows you to create a NVS partition binary file based on key-value pairs in CSV file. 
+:link_to_translation:`zh_CN:[中文]`
 
-The resulting binary file is compatible with NVS architecture defined in `ESP-IDF Non Volatile Storage <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_flash.html>`_.
+The ``ESP-IDF: Open NVS Partition Editor`` command allows you to create a NVS partition binary file based on key-value pairs in a CSV file.
 
-The expected CSV format is:
+The resulting binary file is compatible with the NVS architecture defined in `ESP-IDF Non-Volatile Storage Library <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_flash.html>`_.
+
+The expected CSV format is as follows:
 
 .. code-block::
 
-  key,type,encoding,value     <-- column header (must be the first line)
-  namespace_name,namespace,,  <-- First entry must be of type "namespace"
-  key1,data,u8,1
-  key2,file,string,/path/to/file
+    key,type,encoding,value     <-- column header (must be the first line)
+    namespace_name,namespace,,  <-- First entry must be of type "namespace"
+    key1,data,u8,1
+    key2,file,string,/path/to/file
 
-1. Click menu **View** > **Command Palette...** 
-2. Type **ESP-IDF: Open NVS Partition Editor** and select the command (to create a new file) or right click an existing partition table CSV file.
+1.  Go to ``View`` > ``Command Palette``.
+2.  Type ``ESP-IDF: Open NVS Partition Editor`` and select the command to create a new file or right-click an existing partition table CSV file.
+3.  If creating a new file, choose the file name. It will be created in the current editor directory.
 
-3. If creating a new file, choose the name of the file. It will be created in the current editor directory.
+    .. note::
 
-.. note::
-  Make sure first 2 lines of existing CSV file are as shown in expected CSV format above.
+        Ensure the first two lines of the existing CSV file match the expected CSV format above.
 
-4. Make desired changes to CSV file.
+4.  Make desired changes to CSV file.
 
-.. note::
-  Make sure that the size of partition is enough for inserted data.
+    .. note::
 
-.. image:: ../../../media/tutorials/nvs/nvs_partition_editor.png
+        Ensure the partition size is sufficient for the inserted data.
 
-5. Save the CSV data (First time will create the CSV file).
+    .. image:: ../../../media/tutorials/nvs/nvs_partition_editor.png
 
-6. (OPTIONAL) Enable encryption of the binary. If encrypt is enable, can disable the generate key option to use your own key if desired, in which case you need to set the key absolute path.
-
-7. Generate the partition binary.
+5.  Save the CSV data. The first save will create the CSV file.
+6.  (OPTIONAL) Enable encryption of the binary. If encryption is enabled, you can disable the generate key option to use your own key. In this case, set the key's absolute path.
+7.  Generate the partition binary.
 
 This feature is based on ESP-IDF `NVS Partition Generator Utility <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/nvs_partition_gen.html>`_.
 
-Make sure extension is configured as shown in :ref:`Install ESP-IDF and Tools <installation>` documentation for this feature to work properly.
+Make sure the extension is configured as shown in :ref:`Install ESP-IDF and Tools <installation>` documentation for this feature to work properly.

--- a/docs_espressif/en/additionalfeatures/partition-table-editor.rst
+++ b/docs_espressif/en/additionalfeatures/partition-table-editor.rst
@@ -1,26 +1,28 @@
 Partition Table Editor
-=========================
+======================
 
-- Click menu **View** > **Command Palette...** 
-- Type **ESP-IDF: SDK Configuration Editor** and select the command.
+:link_to_translation:`zh_CN:[中文]`
 
-.. image:: ../../../media/tutorials/partition_table/sdkconfig.png
+-   Go to ``View`` > ``Command Palette``.
+-   Type ``ESP-IDF: SDK Configuration Editor`` and select the command.
 
-- Search for ``partition_table_custom`` and select ``Custom Partition Table CSV`` from Partition Table and set the filename. It will search this file in your current project directory.
+    .. image:: ../../../media/tutorials/partition_table/sdkconfig.png
 
-.. image:: ../../../media/tutorials/partition_table/partition_table_custom.png
+-   Search for ``partition_table_custom``, select ``Custom Partition Table CSV`` from the ``Partition Table`` dropdown list, and set the filename. The tool will search for this file in your current project directory.
 
-- If the partition table file doesn't exists, when you execute the command the file will be created. But if the partition table file already exists, make sure that the first two lines of the partion table CSV file are:
+    .. image:: ../../../media/tutorials/partition_table/partition_table_custom.png
 
-.. code-block::
+-   If the partition table file does not exist, executing the command will create the file. If the partition table file already exists, ensure that the first two lines of the partition table CSV file match the format below:
 
-  # ESP-IDF Partition Table
-  # Name, Type, SubType, Offset, Size, Flag
+    .. code-block::
 
-- Once partition table editor is open, you can edit the partition table as desired. For more information please refer to `ESP-IDF Partition Tables <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html>`_ documentation.
+        # ESP-IDF Partition Table
+        # Name, Type, SubType, Offset, Size, Flag
 
-.. image:: ../../../media/tutorials/partition_table/partition_editor.png
+-   Once the partition table editor is open, you can edit the partition table as needed. For more information, refer to `ESP-IDF Partition Tables <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html>`_.
 
-- Once you are satisfied press ``Save`` to save the changes, ``this will override the content of CSV file``.
+    .. image:: ../../../media/tutorials/partition_table/partition_editor.png
 
-- Now you can click the ``Select Flash Method``, ``Build``, ``Flash`` right top buttons in order to build and flash the partition table to the chip.
+-   Once you are satisfied, click ``Save`` to save the changes. This will override the content of the CSV file.
+
+-   Now you can click ``Select Flash Method``, ``Build``, and ``Flash`` buttons at the top right to build and flash the partition table to the chip.

--- a/docs_espressif/en/additionalfeatures/rainmaker.rst
+++ b/docs_espressif/en/additionalfeatures/rainmaker.rst
@@ -1,21 +1,24 @@
-ESP Rainmaker
-====================
+ESP RainMaker
+=============
 
-This tutorial will show you how to use `ESP Rainmaker <https://rainmaker.espressif.com>`_ integration in this extension.
+:link_to_translation:`zh_CN:[中文]`
 
-You need to have a Espressif device and a ESP Rainmaker Account, if you don't have these please `refer here <https://rainmaker.espressif.com/docs/get-started.html>`_.
+This tutorial shows you how to integrate the `ESP RainMaker <https://rainmaker.espressif.com>`_ feature in the ESP-IDF extension.
 
-Click the ``ESP-IDF Explorer`` in the `Activity bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_. On the ``Rainmaker`` section, click the ``Connect Rainmaker``.
+You need an Espressif device and an ESP RainMaker account. If you do not have these, please refer `here <https://rainmaker.espressif.com/docs/get-started.html>`_.
+
+Click ``ESP-IDF: Explorer`` in the Visual Studio Code activity bar. In the ``RainMaker`` section, click the ``Connect RainMaker``.
 
 .. image:: ../../../media/tutorials/rainmaker/connect.png
 
-You will be prompted for the authentication method to connect with Rainmaker, either using the Rainmaker account user and password or with an OAuth app like Google, Github or Apple.
+You will be prompted to choose an authentication method to connect with RainMaker. You can use your RainMaker account username and password or an OAuth app like Google, GitHub, or Apple.
 
 .. note::
-  * For OAuth to work properly, you will be asked to provide permission to Visual Studio Code and the broswer to open Visual Studio Code back once the OAuth flow is done.
+
+    For OAuth to work properly, you must grant permission to Visual Studio Code and the browser to reopen Visual Studio Code after the OAuth flow is complete.
 
 .. image:: ../../../media/tutorials/rainmaker/auth_method.png
 
-You will see a list of nodes associated to the account here. Next to the account name there is an ``Add new node`` and ``Unlink Rainmaker account`` icons. Next to the device there is a ``Remove this node`` icon. Below you can see the type of rainmaker device (for example Switch) with a set of parameters that you can modify such as ``Name`` and ``Power`` with the ``Update param for this device`` icon.
+You will see a list of nodes associated with your account. Next to the account name, there are icons for ``Add new node`` and ``Unlink RainMaker account``. Next to each device, there is a ``Remove this node`` icon. Below, you can see the type of RainMaker device (e.g., ``Switch``) with a set of parameters you can modify (e.g., ``Name`` and ``Power``), using the ``Update param for this device`` icon.
 
 .. image:: ../../../media/tutorials/rainmaker/nodes_info.png

--- a/docs_espressif/en/buildproject.rst
+++ b/docs_espressif/en/buildproject.rst
@@ -21,6 +21,6 @@ Build Your Project
 
     .. image:: ../../media/tutorials/basic_use/size_terminal.png
 
-The ESP-IDF build output will provide hints to resolve errors, which can be viewed using the :ref:`Hints Viewer <hints viewer>`.
+The ESP-IDF build output will provide hints to resolve errors, which can be viewed using the :ref:`Hints Viewer <hints_viewer>`.
 
 Next, proceed to :ref:`Flash onto the Device <flash the device>`.

--- a/docs_espressif/zh_CN/additionalfeatures/application-size-analysis.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/application-size-analysis.rst
@@ -1,1 +1,19 @@
-.. include:: ../../en/additionalfeatures/application-size-analysis.rst
+ESP-IDF 应用程序大小分析
+========================
+
+:link_to_translation:`en:[English]`
+
+ESP-IDF 应用程序大小分析工具提供了应用程序内存使用情况的详细分析，能够帮助开发者优化存储分配。查看可视化分析的步骤如下：
+
+-   前往菜单栏 ``查看`` > ``命令面板``。
+-   输入 ``ESP-IDF：二进制文件大小分析``，选中该命令以查看应用程序大小信息。
+
+    .. image:: ../../../media/tutorials/basic_use/size.png
+
+也可以在命令行界面查看应用程序大小分析：
+
+-   前往菜单栏 ``查看`` > ``命令面板``。
+-   输入 ``ESP-IDF：构建项目``，选中该命令以构建项目。
+-   应用程序大小分析任务将在终端中执行，并显示分析结果。可以通过在 ``settings.json`` 文件中设置 ``idf.enableSizeTaskAfterBuildTask`` 选项来启用或禁用此任务。
+
+    .. image:: ../../../media/tutorials/basic_use/size_terminal.png

--- a/docs_espressif/zh_CN/additionalfeatures/dfu.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/dfu.rst
@@ -1,1 +1,40 @@
-.. include:: ../../en/additionalfeatures/dfu.rst
+通过 USB 升级设备固件 (DFU)
+===========================
+
+:link_to_translation:`en:[English]`
+
+准备指南
+~~~~~~~~
+
+- 准备 ESP32-S2 或 ESP32-S3 芯片。
+- 确保开发板正确连接电脑或其他设备。可参考 `针对 ESP32-S2 开发板的指南 <https://blog.espressif.com/dfu-using-the-native-usb-on-esp32-s2-for-flashing-the-firmware-b2c4af3335f1>`_。
+- 芯片必须处于引导加载程序模式 (bootloader mode)，才能被识别为 DFU 设备。在按住 "boot" 键的同时按下 "reset" 键可以进入引导加载程序模式。
+- Windows 系统需使用 **WinUSB** 驱动程序注册设备。
+
+    .. note::
+
+        使用 `Zadig 工具 <https://zadig.akeo.ie/>`_ 安装驱动程序。请确保设备在下载模式下运行该工具。Zadig 工具应在安装驱动前检测到 ESP32-S2 设备，且可能会检测到 ESP32-S2 的多个 USB 接口。请注意，只需为没有驱动程序的接口（通常是 **Interface 2**）安装 WinUSB 驱动，不要为其他接口重新安装驱动程序。
+
+固件烧录
+~~~~~~~~
+
+1.  选择支持 DFU 的设备（ESP32-S2 或 ESP32-S3）。
+
+    .. image:: ../../../media/tutorials/dfu/select_device.png
+
+2.  选择 DFU 作为烧录方式。
+
+    .. image:: ../../../media/tutorials/dfu/flash_method.png
+
+3.  编译项目。
+
+    .. image:: ../../../media/tutorials/dfu/build_project.png
+
+4.  烧录固件。
+
+    .. image:: ../../../media/tutorials/dfu/flash.png
+
+相关链接
+~~~~~~~~
+
+`乐鑫 DFU API 指南 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32s2/api-guides/dfu.html>`_

--- a/docs_espressif/zh_CN/additionalfeatures/efuse.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/efuse.rst
@@ -1,1 +1,25 @@
-.. include:: ../../en/additionalfeatures/efuse.rst
+eFuse 资源管理器
+================
+
+:link_to_translation:`en:[English]`
+
+此功能要求 ESP-IDF 版本 ``>=v4.3``。
+
+乐鑫芯片包含多个 eFuse，可用于存储系统参数和用户参数。每个 eFuse 都是一个一位字段，可以烧写为 1，之后就不能再恢复为 0。eFuse 资源管理器使用 ESP-IDF 提供的 `espfuse.py <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/system/efuse.html#espefuse-py>`_ 脚本来读取和写入 eFuse。
+
+1.  选择串口：
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+    - 输入 ``ESP-IDF：选择要使用的端口`` 并选中该命令，指定设备的串口。
+
+2.  点击 Visual Studio Code 左侧活动栏中的 ``ESP-IDF：资源管理器`` 图标，然后点击 ``eFuse 资源管理器`` 选项卡中的 ``Connect your Board First`` 选项。
+
+    .. image:: ../../../media/tutorials/efuse/efuse_connect.png
+
+3.  eFuse 类别列表以树形结构呈现。
+
+    .. image:: ../../../media/tutorials/efuse/efuse_list.png
+
+4.  点击任意类别即可查看 eFuse 及其对应的值。
+
+    .. image:: ../../../media/tutorials/efuse/efuse_expanded.png

--- a/docs_espressif/zh_CN/additionalfeatures/hints-viewer.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/hints-viewer.rst
@@ -1,1 +1,28 @@
-.. include:: ../../en/additionalfeatures/hints-viewer.rst
+.. _hints_viewer:
+
+提示查看器
+==========
+
+:link_to_translation:`en:[English]`
+
+提示查看器可以检测代码中存在的错误并提供有用的提示，从而优化开发体验。
+
+利用存储在 ``$IDF_PATH/tools/idf_py_actions/hints.yml`` 文件中的数据库，``idf.py`` 工具能针对错误提供解决方案。如果检测到的错误与数据库中的错误相匹配，则会显示相应的解决方案。
+
+悬停鼠标查看提示
+~~~~~~~~~~~~~~~~
+
+在文本编辑器中，将鼠标悬停在错误上，如果该错误与 ``hints.yml`` 文件中的记录匹配，则会显示相应的提示。
+
+.. image:: ../../../media/tutorials/hints/hover.gif
+
+在底部面板查看提示
+~~~~~~~~~~~~~~~~~~
+
+1.  **自动更新：** 基于当前打开文件中的错误，ESP-IDF 底部面板会自动更新并显示相应的提示。
+
+    .. image:: ../../../media/tutorials/hints/bottom_panel.png
+
+2.  **手动搜索：** 也可以通过复制粘贴错误信息来手动搜索提示。
+
+    .. image:: ../../../media/tutorials/hints/manual_search.gif

--- a/docs_espressif/zh_CN/additionalfeatures/install-esp-components.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/install-esp-components.rst
@@ -1,1 +1,27 @@
-.. include:: ../../en/additionalfeatures/install-esp-components.rst
+安装 ESP-IDF 组件
+=================
+
+:link_to_translation:`en:[English]`
+
+使用 ``ESP-IDF：乐鑫组件注册表`` 命令开启用户界面，查看 `乐鑫组件注册表 <https://components.espressif.com>`_。
+
+.. image:: ../../../media/tutorials/features/component-registry.png
+
+在此界面中，可以浏览各类乐鑫组件，并通过点击 ``Install`` 按钮将其安装到当前的 ESP-IDF 项目中。
+
+.. image:: ../../../media/tutorials/features/install-component.png
+
+也可以点击 ``Create project from this example`` 按钮，基于组件示例创建一个新项目。
+
+.. image:: ../../../media/tutorials/features/create-project-from-component-example.png
+
+更多信息请参考 `乐鑫组件注册表文档中心 <https://docs.espressif.com/projects/idf-component-manager/en/latest/>`_。
+
+安装 Arduino-ESP32 组件
+-----------------------
+
+使用 ``ESP-IDF：添加 Arduino ESP32 为 ESP-IDF 组件`` 命令，可以将 `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_ 添加为 ESP-IDF 组件，存放在当前目录下 (``${CURRENT_DIRECTORY}/components/arduino``)。也可以使用 ``ESP-IDF：基于模板创建新项目`` 命令，选择 ``arduino-as-component`` 为模板，创建一个包含 Arduino-ESP32 组件的新项目目录。
+
+.. note::
+
+    部分 ESP-IDF 版本不支持 Arduino ESP32。请查看 `Arduino-ESP32 <https://github.com/espressif/arduino-esp32>`_，确认 ESP-IDF 版本是否兼容。

--- a/docs_espressif/zh_CN/additionalfeatures/nvs-partition-editor.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/nvs-partition-editor.rst
@@ -1,1 +1,41 @@
-.. include:: ../../en/additionalfeatures/nvs-partition-editor.rst
+NVS 分区编辑器
+==============
+
+:link_to_translation:`en:[English]`
+
+通过 ``ESP-IDF：打开 NVS 分区编辑器`` 指令，可以根据 CSV 文件中的键值对创建 NVS 分区二进制文件。
+
+生成的二进制文件与 `ESP-IDF 非易失性存储库 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/storage/nvs_flash.html>`_ 中定义的 NVS 架构兼容。
+
+CSV 文件格式应如下所示：
+
+.. code-block::
+
+    key,type,encoding,value     <-- 列标题（必须在第一行）
+    namespace_name,namespace,,  <-- 第一项必须是 "namespace" 类型
+    key1,data,u8,1
+    key2,file,string,/path/to/file
+
+1.  前往菜单栏 ``查看`` > ``命令面板``。
+2.  输入 ``ESP-IDF：打开 NVS 分区编辑器``，选择该命令以创建新文件，或右键单击已有的分区表 CSV 文件。
+3.  如果选择创建新文件，请输入文件名。新文件将存储在当前编辑器目录下。
+
+    .. note::
+
+        请确保现有 CSV 文件的前两行内容与示例中的 CSV 格式一致。
+
+4.  对 CSV 文件进行必要更改。
+
+    .. note::
+
+        请确保分区大小足以容纳插入的数据。
+
+    .. image:: ../../../media/tutorials/nvs/nvs_partition_editor.png
+
+5.  保存 CSV 数据。首次保存将创建新的 CSV 文件。
+6. （可选）启用二进制文件加密。启用加密后，可以禁用生成密钥选项从而选择自己的密钥。此时，需要为密钥设置绝对路径。
+7.  生成分区二进制文件。
+
+此功能基于 ESP-IDF `NVS 分区生成工具 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/storage/nvs_partition_gen.html>`_。
+
+为确保此功能正常运行，请确保按照 :ref:`安装 ESP-IDF 和相关工具 <installation>` 中的说明来配置扩展。

--- a/docs_espressif/zh_CN/additionalfeatures/partition-table-editor.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/partition-table-editor.rst
@@ -1,1 +1,28 @@
-.. include:: ../../en/additionalfeatures/partition-table-editor.rst
+分区表编辑器
+============
+
+:link_to_translation:`en:[English]`
+
+-   前往菜单栏 ``查看`` > ``命令面板``。
+-   输入 ``ESP-IDF：SDK 配置编辑器`` 并选中该命令。
+
+    .. image:: ../../../media/tutorials/partition_table/sdkconfig.png
+
+-   搜索 ``partition_table_custom``，在 ``Partition Table`` 下拉框中选择 ``Custom partition table CSV``，并输入文件名。分区表编辑器将从当前项目目录中查找该 CSV 文件。
+
+    .. image:: ../../../media/tutorials/partition_table/partition_table_custom.png
+
+-   如果分区表文件不存在，执行该命令将创建新文件；如果分区表文件已存在，请确保分区表 CSV 文件的前两行符合以下格式：
+
+    .. code-block::
+
+        # ESP-IDF Partition Table
+        # Name, Type, SubType, Offset, Size, Flag
+
+-   打开分区表编辑器后，可以根据需要编辑分区表。更多信息请参考 ESP-IDF 编程指南的 `分区表 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/partition-tables.html>`_ 章节。
+
+    .. image:: ../../../media/tutorials/partition_table/partition_editor.png
+
+-   完成编辑后，点击 ``Save`` 按钮保存更改。这将覆盖原 CSV 文件的内容。
+
+-   现在，就可以点击右上角的 ``Select Flash Method``、``Build`` 以及 ``Flash`` 按钮，编译项目并将分区表烧录到芯片中。

--- a/docs_espressif/zh_CN/additionalfeatures/rainmaker.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/rainmaker.rst
@@ -1,1 +1,24 @@
-.. include:: ../../en/additionalfeatures/rainmaker.rst
+ESP Rainmaker
+=============
+
+:link_to_translation:`en:[English]`
+
+本文将展示如何在 ESP-IDF 扩展中使用 `ESP Rainmaker <https://rainmaker.espressif.com/zh-hans/>`_ 集成功能。
+
+首先需要准备好乐鑫设备和 ESP Rainmaker 账户。更多信息请参考 `RainMaker 文档 <https://rainmaker.espressif.com/zh-hans/docs/get-started/>`_。
+
+点击 Visual Studio Code 左侧活动栏中的 ``ESP-IDF：资源管理器`` 图标，然后点击 ``RainMaker`` 选项卡中的 ``连接 RainMaker`` 选项。
+
+.. image:: ../../../media/tutorials/rainmaker/connect.png
+
+系统会提示你选择一种身份验证方式来连接 RainMaker。可以使用 RainMaker 账户的用户名和密码，也可以使用 Google、GitHub、Apple 等 OAuth 应用进行身份验证。
+
+.. note::
+
+    若选择使用 OAuth 应用进行身份验证，则必须授予 Visual Studio Code 和浏览器权限，以便在 OAuth 认证流程完成后重新打开 Visual Studio Code。
+
+.. image:: ../../../media/tutorials/rainmaker/auth_method.png
+
+完成身份验证后，你将看到与账户关联的节点列表。在账户名称旁边，有用于 ``添加新节点`` 和 ``取消与 Rainmaker 帐户的绑定`` 的图标。每个设备旁都有一个 ``移除此节点`` 图标。在每个 Rainmaker 设备（如 ``Switch``）下方，会显示一组可以修改的参数（例如 ``Name`` 和 ``Power``），你可以点击 ``为设备更新参数`` 图标来修改参数。
+
+.. image:: ../../../media/tutorials/rainmaker/nodes_info.png

--- a/docs_espressif/zh_CN/buildproject.rst
+++ b/docs_espressif/zh_CN/buildproject.rst
@@ -21,6 +21,6 @@
 
     .. image:: ../../media/tutorials/basic_use/size_terminal.png
 
-ESP-IDF 构建输出中会提示如何解决构建错误，这些提示可以通过 :ref:`提示查看器 <hints viewer>` 显示。
+ESP-IDF 构建输出中会提示如何解决构建错误，这些提示可以通过 :ref:`提示查看器 <hints_viewer>` 显示。
 
 接下来请 :ref:`烧录项目 <flash the device>`。


### PR DESCRIPTION
This PR:

- Adjusts some format issues and unclear expressions in **nvs-partition-editor.rst/dfu.rst/rainmaker.rst/partition-table-editor.rst/install-esp-components.rst/efuse.rst/hints-viewer.rst/application-size-analysis.rst** based on - Espressif Style Guide
- Provides CN translation for above eight documents
- TODO: Closes [DOC-10436](https://jira.espressif.com:8443/browse/DOC-10436) once merged
