### PR TITLE
docs: Provide CN translation for project-configuration.rst

### DIFF
--- a/docs_espressif/en/additionalfeatures/project-configuration.rst
+++ b/docs_espressif/en/additionalfeatures/project-configuration.rst
@@ -1,57 +1,77 @@
 Project Configuration Editor
-====================================
+============================
 
-To allow you to have multiple configurations for the same project, you can define several settings to produce different build results. For example, take a look at the `Multiple configuration tutorial <multiple_config>`_ which uses the ESP-IDF CMake build system `multi_config <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ example.
+:link_to_translation:`zh_CN:[中文]`
 
-1. Click menu **View** > **Command Palette...** 
-2. Type **ESP-IDF: Open Project Configuration** and select the command. 
-3. This will launch a Project configuration wizard to manage the project configuration profiles to record the following settings for each configuration:
+Project Configuration Editor allows you to enable multiple configurations for the same project. You can define various settings to generate different build results. For example, refer to `Multiple Configuration Tutorial <multiple_config>`_, which demonstrates how to use the ESP-IDF CMake build system with `multi_config <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ example.
 
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| Setting ID                        | Description                                                                               |
-+===================================+===========================================================================================+
-| **idf.cmakeCompilerArgs**         | Arguments for CMake compilation task                                                      |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.ninjaArgs**                 | Arguments for Ninja build task                                                            |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.buildPath**                 | Custom build directory name for extension commands. (Default: \${workspaceFolder}/build)  |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.sdkconfigFilePath**         | Absolute path for sdkconfig file                                                          |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.sdkconfigDefaults**         | List of sdkconfig default values for initial build configuration                          |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.customExtraVars**           | Variables to be added to system environment variables                                     |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.flashBaudRate**             | Flash Baud rate                                                                           |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.monitorBaudRate**           | Monitor Baud Rate (Empty by default to use SDKConfig CONFIG_ESP_CONSOLE_UART_BAUDRATE)    |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.openOcdDebugLevel**         | Set openOCD Debug Level (0-4) Default: 2                                                  |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.openOcdConfigs**            | Configuration Files for OpenOCD. Relative to OPENOCD_SCRIPTS folder                       |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.openOcdLaunchArgs**         | Launch Arguments for OpenOCD before idf.openOcdDebugLevel and idf.openOcdConfigs          |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.preBuildTask**              | Command string to execute before build task                                               |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.postBuildTask**             | Command string to execute after build task                                                |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.preFlashTask**              | Command string to execute before flash task                                               |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
-| **idf.postFlashTask**             | Command string to execute after flash task                                                |
-+-----------------------------------+-------------------------------------------------------------------------------------------+
+1.  Go to ``View`` > ``Command Palette``.
+2.  Type ``ESP-IDF: Open Project Configuration`` and select the command.
+3.  This will launch a project configuration wizard to manage project configuration profiles and record the following settings for each configuration:
 
-4. After defining a profile and the settings for each profile use:
+.. list-table::
+    :header-rows: 1
+    :widths: 30 70
 
-- Click menu **View** > **Command Palette...** 
-- Type **ESP-IDF: Select Project Configuration** command to choose the configuration to override extension configuration settings.
+    * - Setting ID
+      - Description
 
-There are many use cases for having multiple configurations profiles. It allows you to store settings together and easily switch between one and the other. Let's explore one of this use cases here, having a development and production build profiles.
+    * - **idf.cmakeCompilerArgs**
+      - Arguments for the CMake compilation task
+
+    * - **idf.ninjaArgs**
+      - Arguments for the Ninja build task
+
+    * - **idf.buildPath**
+      - Custom build directory name for extension commands (Default: \${workspaceFolder}/build)
+
+    * - **idf.sdkconfigFilePath**
+      - Absolute path for the sdkconfig file
+
+    * - **idf.sdkconfigDefaults**
+      - List of sdkconfig default values for the initial build configuration
+
+    * - **idf.customExtraVars**
+      - Variables to add to system environment variables
+
+    * - **idf.flashBaudRate**
+      - Flash baud rate
+
+    * - **idf.monitorBaudRate**
+      - Monitor baud rate (empty by default to use sdkconfig ``CONFIG_ESP_CONSOLE_UART_BAUDRATE``)
+
+    * - **idf.openOcdDebugLevel**
+      - Set OpenOCD debug level (0–4); default: 2
+
+    * - **idf.openOcdConfigs**
+      - Configuration files for OpenOCD, relative to the OPENOCD_SCRIPTS folder
+
+    * - **idf.openOcdLaunchArgs**
+      - Launch arguments for OpenOCD before **idf.openOcdDebugLevel** and **idf.openOcdConfigs**
+
+    * - **idf.preBuildTask**
+      - Command string to execute before the build task
+
+    * - **idf.postBuildTask**
+      - Command string to execute after the build task
+
+    * - **idf.preFlashTask**
+      - Command string to execute before the flash task
+
+    * - **idf.postFlashTask**
+      - Command string to execute after the flash task
+
+4.  After defining a profile and the settings for each profile, use:
+
+    - Go to ``View`` > ``Command Palette``.
+    - Enter ``ESP-IDF: Select Project Configuration`` to choose the configuration that overrides extension configuration settings.
+
+Multiple configuration profiles have many use cases. They allow you to store settings together and easily switch between them. The following explores one of these use cases: creating **development** and **production** build profiles.
 
 Development and Release Profiles for ESP-IDF Project
--------------------------------------------------------
+----------------------------------------------------
 
-A typical `ESP-IDF Project Structure <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-project>`_ is like this:
+A typical `ESP-IDF Project Structure <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#example-project>`_ looks like this:
 
 .. code-block::
 
@@ -71,32 +91,36 @@ A typical `ESP-IDF Project Structure <https://docs.espressif.com/projects/esp-id
 
                 - build/
 
-In the ESP-IDF CMake build system, the project configuration settings are saved using the SDK Configuration Editor which store these values in a ``/path/to/esp-project/sdkconfig`` file. The default case is to create an ``/path/to/esp-project/sdkconfig`` file in the ESP-IDF project root directory and a ``/path/to/esp-project/build`` directory as the build directory path.
+In the ESP-IDF CMake build system, the project configuration settings are saved using the SDK Configuration Editor, which stores these values in the ``/path/to/esp-project/sdkconfig`` file. By default, the build system creates a ``/path/to/esp-project/sdkconfig`` file in the project root directory and a ``/path/to/esp-project/build`` directory as the build directory.
 
-When the current ESP-IDF project is under version control system, the ``/path/to/esp-project/sdkconfig`` can change on any user build which can alter the project expected behavior. For such a reason is better to move those project specific settings to an ``sdkconfig.defaults`` file (or list of files) which is not modified by the build system. ``/path/to/esp-project/sdkconfig`` can be added to the ``.gitignore`` list. This ``sdkconfig.defaults`` can be generated by the **ESP-IDF: Save Default SDKCONFIG file (save-defconfig)** (ESP-IDF v5.0 or higher) command.
+When the current ESP-IDF project is under version control, the ``/path/to/esp-project/sdkconfig`` file can change with each user build, altering the project's expected behavior. Therefore, it is better to move project-specific settings to a ``sdkconfig.defaults`` file (or a list of files) that the build system does not modify. You can add ``/path/to/esp-project/sdkconfig`` to the ``.gitignore`` list. The ``ESP-IDF: Save Default SDKCONFIG File (save-defconfig)`` command (available in ESP-IDF v5.0 or higher) can generate this ``sdkconfig.defaults`` file.
 
 .. note::
-  The ``sdkconfig.defaults`` file is used by the build system to override defaults project settings when creating the ``sdkconfig`` file as described in the ESP-IDF documentation `custom sdkconfig defaults <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults>`_.
 
-With this extension settings, the default build path (/path/to/esp-project/build), sdkconfig file path and sdkconfig.defaults can be modified from their default location, the one described in the project structure before. With the **ESP-IDF: Project Configuration Editor** you can define multiple locations of the build directory with ``Build Directory Path``, ``SDKConfig File Path`` for the SDKConfig file and ``SDKConfig Defaults`` list of SDKConfig files to create the SDKConfig file in the specified ``SDKConfig File Path`` path. 
+    The ``sdkconfig.defaults`` file is used by the build system to override default project settings when creating the ``sdkconfig`` file, as described in `Custom Sdkconfig Defaults <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults>`_.
 
-For this example we will create two profiles, **development** and **production**, to create 2 different build directories and 2 different sdkconfig files.
+With these extension settings, you can modify the default build path ``/path/to/esp-project/build``, sdkconfig file path, and ``sdkconfig.defaults`` from their default locations described in the project structure. Using the ``ESP-IDF: Project Configuration Editor``, you can define multiple build directory locations with the ``Build Directory Path``, specify the path for the sdkconfig file, and list ``sdkconfig.defaults`` files to create the sdkconfig file in the specified ``SDKConfig File Path``.
 
-1. Click menu **View** > **Command Palette...** 
-2. Type **ESP-IDF: Save Default SDKCONFIG file (save-defconfig)** select the command to generate a `sdkconfig.defaults` file. This command is added in ESP-IDF v5.0. You can also create this sdkconfig.defaults manually.
-3. Click menu **View** > **Command Palette...** 
-4. Type **ESP-IDF: Open Project Configuration** select the command and create a new profile with name ``production``. Set ``SDKConfig Defaults`` the previous ``sdkconfig.defaults`` file. If you want to separate the build directory of this new **production** profile from the default ``/path/to/esp-project/build`` directory, specify a build directory path using the ``Build Directory Path`` field to something like ``/path/to/esp-project/build_production`` and the ``SDKConfig file path`` field to something like ``/path/to/esp-project/build_production/sdkconfig``.
+In this example, we create two profiles: **development** and **production**, to define separate build directories and sdkconfig files.
 
-5. Create a new profile with name ``development``. You can set the build directory path using the ``Build Directory Path`` field to something like ``/path/to/esp-project/build_dev`` and the ``SDKConfig File Path`` field to something like ``/path/to/esp-project/build_dev/sdkconfig`` to avoid mixing **development** with **production** files.
+1. Go to ``View`` > ``Command Palette``.
 
-6. After creating each profile and the configuration settings for each profile, click the ``Save`` button and use the extension **ESP-IDF: Select Project Configuration** command to choose desired profile.
+2. Type ``ESP-IDF: Save Default SDKCONFIG file (save-defconfig)`` and select the command to generate a ``sdkconfig.defaults`` file. This command is available in ESP-IDF v5.0 or higher. You can also create this ``sdkconfig.defaults`` file manually.
 
-7. When you choose the **production** profile and use the **ESP-IDF: Build your Project** the ``/path/to/esp-project/build_production/sdkconfig`` would be created and the binaries are going to be created in ``/path/to/esp-project/build_production``.
+3. Go to ``View`` > ``Command Palette``.
 
-8. If you choose the **development** profile, the ``/path/to/esp-project/build_dev/sdkconfig`` would be created and the binaries are going to be created in ``/path/to/esp-project/build_dev``.
+4. Type ``ESP-IDF: Open Project Configuration`` and select the command to create a new profile named **production**. Set ``SDKConfig Defaults`` to the existing ``sdkconfig.defaults`` file. If you want to separate the build directory for this new **production** profile from the default ``/path/to/esp-project/build`` directory, specify a custom path in the ``Build Directory Path`` field (e.g., ``/path/to/esp-project/build_production``). Similarly, set the ``SDKConfig File Path`` field to a custom location (e.g., ``/path/to/esp-project/build_production/sdkconfig``).
 
-9. These profiles and each profile settings are going to be saved in the ``/path/to/esp-project/esp_idf_project_configuration.json``.
+5. Create a new profile named **development**. To keep **development** and **production** files separate, set ``Build Directory Path`` to a custom location (e.g., /path/to/esp-project/build_dev) and ``SDKConfig File Path`` to ``/path/to/esp-project/build_dev/sdkconfig``.
 
-The previous production profile could be split into multiple production profiles, as it is done in the `ESP-IDF CMake Multiple configuration example <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ and the `Multiple configuration tutorial <multiple_config>`_ by separating ``sdkconfig.defaults`` into common SDKConfig settings in a ``sdkconfig.prod_common`` file and product specific settings in ``sdkconfig.prod1`` file and ``sdkconfig.prod2`` file respectively. Multiple SDKConfig defaults files can be specified in the project configuration editor profile ``sdkconfig defaults`` field as ``sdkconfig.prod_common;sdkconfig.prod1`` where the values are loaded in order as explained in `here <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html?highlight=sdkconfig%20defaults#custom-sdkconfig-defaults>`_.
+6. After creating each profile and configuring the settings, click the ``Save`` button. Use the ``ESP-IDF: Select Project Configuration`` command to choose the desired profile.
 
-This is just an example of the possibility of this project configuration editor. You can define multiple settings for different kinds of development scenarios such as testing, profiling, etc.
+7. When you choose the **production** profile and use the ``ESP-IDF: Build your Project`` command, the ``/path/to/esp-project/build_production/sdkconfig`` file will be created, and the binaries will be generated in ``/path/to/esp-project/build_production``.
+
+8. If you choose the **development** profile, the ``/path/to/esp-project/build_dev/sdkconfig`` file will be created, and the binaries will be generated in ``/path/to/esp-project/build_dev``.
+
+9. These profiles and their settings will be saved in the ``/path/to/esp-project/esp_idf_project_configuration.json``.
+
+The previous **production** profile can be divided into multiple **production** profiles, as demonstrated in the ESP-IDF CMake `multi_config <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ example and `Multiple Configuration Tutorial <multiple_config>`_. This is achieved by splitting the ``sdkconfig.defaults`` file into a common settings file (``sdkconfig.prod_common``) and product-specific settings files (``sdkconfig.prod1`` and ``sdkconfig.prod2``). In the Project Configuration Editor, you can specify multiple ``SDKConfig Defaults`` files using a semicolon-separated format (e.g., ``sdkconfig.prod_common;sdkconfig.prod1``), and these files will be loaded in order as explained `here <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults>`_.
+
+This is just one example of what the Project Configuration Editor can do. You can also define multiple profiles for other development scenarios, such as testing, profiling, and more.

--- a/docs_espressif/zh_CN/additionalfeatures/project-configuration.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/project-configuration.rst
@@ -1,1 +1,126 @@
-.. include:: ../../en/additionalfeatures/project-configuration.rst
+项目配置编辑器
+==============
+
+:link_to_translation:`en:[English]`
+
+使用项目配置编辑器，可以为同一项目启用多种配置。通过定义多种设置，可以生成不同的构建结果。例如，可以参考 `多配置教程 <multiple_config>`_，利用 ESP-IDF CMake 构建系统的 `multi_config <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ 示例来实现这一功能。
+
+1.  前往菜单栏 ``查看`` > ``命令面板``。
+2.  输入 ``ESP-IDF：打开项目配置`` 并选择该命令。
+3.  在开启的项目配置向导界面中，进行项目配置文件管理并记录以下配置：
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 70
+
+    * - 设置 ID
+      - 功能描述
+
+    * - **idf.cmakeCompilerArgs**
+      - CMake 编译任务的参数
+
+    * - **idf.ninjaArgs**
+      - Ninja 构建任务的参数
+
+    * - **idf.buildPath**
+      - 扩展命令的自定义构建目录名称（默认为 \${workspaceFolder}/build）
+
+    * - **idf.sdkconfigFilePath**
+      - sdkconfig 文件的绝对路径
+
+    * - **idf.sdkconfigDefaults**
+      - 初始构建配置的 sdkconfig 默认值列表
+
+    * - **idf.customExtraVars**
+      - 添加到系统环境变量的变量
+
+    * - **idf.flashBaudRate**
+      - 烧录波特率
+
+    * - **idf.monitorBaudRate**
+      - 监视器波特率（默认为空，并使用 sdkconfig 文件中定义的 ``CONFIG_ESP_CONSOLE_UART_BAUDRATE``）
+
+    * - **idf.openOcdDebugLevel**
+      - 设置 OpenOCD 调试级别 (0～4)，默认为 2
+
+    * - **idf.openOcdConfigs**
+      - OpenOCD 的配置文件，路径相对于 OPENOCD_SCRIPTS 文件夹
+
+    * - **idf.openOcdLaunchArgs**
+      - **idf.openOcdDebugLevel** 和 **idf.openOcdConfigs** 之前的 OpenOCD 启动参数
+
+    * - **idf.preBuildTask**
+      - 构建任务之前执行的命令字符串
+
+    * - **idf.postBuildTask**
+      - 构建任务之后执行的命令字符串
+
+    * - **idf.preFlashTask**
+      - 烧录任务之前执行的命令字符串
+
+    * - **idf.postFlashTask**
+      - 烧录任务之后执行的命令字符串
+
+4.  定义好配置文件和每个配置文件的设置后，使用：
+
+    - 前往菜单栏 ``查看`` > ``命令面板``。
+    - 输入 ``ESP-IDF：选择项目配置`` 并选择该命令，覆盖扩展设置的配置。
+
+多配置文件有许多用例，例如统一存储设置并在不同设置之间轻松切换。下文展示了其中一个用例：创建 **development** 和 **production** 构建配置文件。
+
+ESP-IDF 项目的开发和发布配置文件
+--------------------------------
+
+`ESP-IDF 项目结构 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#example-project-structure>`_ 通常如下所示：
+
+.. code-block::
+
+    - /path/to/esp-project/
+                - CMakeLists.txt
+                - sdkconfig
+                - components/ - component1/ - CMakeLists.txt
+                                            - Kconfig
+                                            - src1.c
+                              - component2/ - CMakeLists.txt
+                                            - Kconfig
+                                            - src1.c
+                                            - include/ - component2.h
+                - main/       - CMakeLists.txt
+                              - src1.c
+                              - src2.c
+
+                - build/
+
+在 ESP-IDF CMake 构建系统中，项目配置设置通过 SDK 配置编辑器保存，这些值存储在 ``/path/to/esp-project/sdkconfig`` 文件中。默认情况下，构建系统会在项目根目录下创建 ``/path/to/esp-project/sdkconfig`` 文件，并在 ``/path/to/esp-project/build`` 目录下生成构建目录。
+
+若当前 ESP-IDF 项目处于版本控制中，则 ``/path/to/esp-project/sdkconfig`` 文件会随着每次构建而更新，项目的行为也会有所不同。因此，建议将特定的项目设置移至 ``sdkconfig.defaults`` 文件（或一组配置文件）中，避免构建系统对其进行修改。你可以将 ``/path/to/esp-project/sdkconfig`` 文件添加到 ``.gitignore`` 列表中。在 ESP-IDF v5.0 及更高版本中，可以通过执行 ``ESP-IDF：保存默认 SDKCONFIG 文件 (save-defconfig)`` 命令生成 ``sdkconfig.defaults`` 文件。
+
+.. note::
+
+    在创建 ``sdkconfig`` 文件时，构建系统会使用 ``sdkconfig.defaults`` 文件覆盖默认项目设置。详情请参阅 ESP-IDF 文档中的 `自定义 sdkconfig 的默认值 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults>`_。
+
+使用上述扩展设置，你可以修改默认的构建路径 ``/path/to/esp-project/build``、sdkconfig 文件及 ``sdkconfig.defaults`` 文件路径，将它们从项目结构中的默认位置移动到其他位置。通过 ``ESP-IDF：项目配置编辑器`` 命令，你可以使用 ``Build Directory Path`` 来定义多个构建目录位置，也可以指定 sdkconfig 文件的路径并列出 ``sdkconfig.defaults`` 文件，从而在指定的 ``SDKConfig File Path`` 中创建 sdkconfig 文件。
+
+在此示例中，我们将创建 **development** 和 **production** 两个配置文件，并为其定义不同的构建目录和 sdkconfig 文件。
+
+1. 前往菜单栏 ``查看`` > ``命令面板``。
+
+2. 输入 ``ESP-IDF：保存默认 SDKCONFIG 文件 (save-defconfig)`` 并选择该命令以生成 ``sdkconfig.defaults`` 文件。此命令需 ESP-IDF v5.0 及以上版本才可使用。你也可以手动创建 ``sdkconfig.defaults`` 文件。
+
+3. 前往菜单栏 ``查看`` > ``命令面板``。
+
+4. 输入 ``ESP-IDF：打开项目配置`` 并选择该命令，创建一个名为 **production** 的新配置文件。将 ``SDKConfig Defaults`` 设置为已有的 ``sdkconfig.defaults`` 文件。若要区分 **production** 配置文件的构建目录与默认的 ``/path/to/esp-project/build`` 目录，可在 ``Build Directory Path`` 字段中自定义目录路径，例如 ``/path/to/esp-project/build_production``。同样地，也可以在 ``SDKConfig File Path`` 字段中设置自定义路径，例如 ``/path/to/esp-project/build_production/sdkconfig``。
+
+5. 创建一个名为 **development** 的新配置文件。为避免混淆 **development** 和 **production** 文件，可在 ``Build Directory Path`` 字段中设置自定义路径（如 ``/path/to/esp-project/build_dev``），并将 ``SDKConfig File Path`` 设置为 ``/path/to/esp-project/build_dev/sdkconfig``。
+
+6. 创建好两个配置文件并完成配置后，点击 ``Save`` 按钮，后续可通过 ``ESP-IDF：选择项目配置`` 命令来选择所需的配置文件。
+
+7. 若选择 **production** 配置文件并执行 ``ESP-IDF：构建项目`` 命令，系统会在 ``/path/to/esp-project/build_production`` 目录中生成二进制文件，并创建 ``/path/to/esp-project/build_production/sdkconfig`` 文件。
+
+8. 若选择 **development** 配置文件，系统会在 ``/path/to/esp-project/build_dev`` 目录中生成二进制文件，并创建 ``/path/to/esp-project/build_dev/sdkconfig`` 文件。
+
+9. 这些配置文件及其设置将保存在 ``/path/to/esp-project/esp_idf_project_configuration.json`` 文件中。
+
+如 ESP-IDF CMake `multi_config <https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config>`_ 和 `多配置教程 <multiple_config>`_ 所示，上文提到的 **production** 配置文件可以进一步拆分为多个 **production** 配置文件。你可以将 ``sdkconfig.defaults`` 文件拆分为通用设置文件 ``sdkconfig.prod_common`` 和产品特定设置文件 ``sdkconfig.prod1`` 及 ``sdkconfig.prod2``。在项目配置编辑器中，可以在 ``SDKConfig Defaults`` 字段中指定多个 sdkconfig 默认文件并以分号隔开（如 ``sdkconfig.prod_common;sdkconfig.prod1``），这些文件将按照指定顺序依次加载。详情请参阅 `此处 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#custom-sdkconfig-defaults>`_。
+
+以上示例展示了项目配置编辑器的功能之一。你也可以根据不同的开发场景（如测试、性能分析等）定义多个配置文件。


### PR DESCRIPTION
This PR:

- Provides CN translation for docs_espressif/en/additionalfeatures/project-configuration.rst
- TODO: Closes [DOC-10489](https://jira.espressif.com:8443/browse/DOC-10489) once merged