### PR TITLE
use vscode env remoteName to detect codespaces

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -4,7 +4,7 @@
   " has been updated": " ha sido actualizado",
   "File project_description.json cannot be found.": "No se puede encontrar el archivo project_description.json.",
   "Open a folder first.": "Primero abra una carpeta.",
-  "Selected command is not available in Web": "El comando seleccionado no está disponible en Web",
+  "Selected command is not available in Codespaces": "El comando seleccionado no está disponible en Codespaces",
   "Use current folder: {workspace}": "Usar carpeta actual: {workspace}",
   "Choose a container directory...": "Elija un directorio de contenedor...",
   "Select a directory to use": "Seleccione un directorio para usar",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -4,7 +4,7 @@
   " has been updated": " foi atualizado",
   "File project_description.json cannot be found.": "O arquivo project_description.json não pode ser encontrado.",
   "Open a folder first.": "Abra uma pasta primeiro.",
-  "Selected command is not available in Web": "O comando selecionado não está disponível no Web",
+  "Selected command is not available in Codespaces": "O comando selecionado não está disponível no Codespaces",
   "Use current folder: {workspace}": "Use a pasta atual: {workspace}",
   "Choose a container directory...": "Escolha um diretório de contêiner...",
   "Select a directory to use": "Selecione um diretório para usar",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -4,7 +4,7 @@
   " has been updated": " был обновлен",
   "File project_description.json cannot be found.": "Файл project_description.json не найден.",
   "Open a folder first.": "Сначала откройте папку.",
-  "Selected command is not available in Web": "Выбранная команда недоступна в Web",
+  "Selected command is not available in Codespaces": "Выбранная команда недоступна в Codespaces",
   "Use current folder: {workspace}": "Использовать текущую папку: {workspace}",
   "Choose a container directory...": "Выберите каталог контейнера...",
   "Select a directory to use": "Выберите каталог для использования",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -4,7 +4,7 @@
   " has been updated": " 已经升级",
   "File project_description.json cannot be found.": "找不到 project_description.json 文件。",
   "Open a folder first.": "先打开一个文件夹。",
-  "Selected command is not available in Web": "所选命令在 Web 中不可用",
+  "Selected command is not available in Codespaces": "所选命令在 Codespaces 中不可用",
   "Use current folder: {workspace}": "使用当前文件夹：{workspace}",
   "Choose a container directory...": "选择容器目录…",
   "Select a directory to use": "选择目录",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,7 +225,7 @@ let wsServer: WSServer;
 
 const openFolderFirstMsg = vscode.l10n.t("Open a folder first.");
 const cmdNotForWebIdeMsg = vscode.l10n.t(
-  "Selected command is not available in Web"
+  "Selected command is not available in Codespaces"
 );
 const openFolderCheck = [
   PreCheck.isWorkspaceFolderOpen,

--- a/src/support/checkSystemInfo.ts
+++ b/src/support/checkSystemInfo.ts
@@ -35,4 +35,5 @@ export async function checkSystemInfo(reportedResult: reportObj) {
   reportedResult.systemInfo.systemName = os.release();
   reportedResult.systemInfo.shell = vscode.env.shell;
   reportedResult.systemInfo.vscodeVersion = vscode.version;
+  reportedResult.systemInfo.remoteName = vscode.env.remoteName;
 }

--- a/src/support/initReportObj.ts
+++ b/src/support/initReportObj.ts
@@ -110,6 +110,7 @@ export function initializeReportObject() {
     platform: undefined,
     systemName: undefined,
     vscodeVersion: undefined,
+    remoteName: undefined,
   };
   report.workspaceFolder = undefined;
   report.projectConfigurations = {};

--- a/src/support/types.ts
+++ b/src/support/types.ts
@@ -78,6 +78,7 @@ export class SystemInfo {
   platform: string;
   systemName: string;
   vscodeVersion: string;
+  remoteName: string;
 }
 
 export class pyPkgVersion {

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -34,6 +34,7 @@ export async function writeTextReport(
   output += `System environment variable IDF_PYTHON_ENV_PATH ${EOL} ${reportedResult.systemInfo.envIdfPythonEnvPath} ${EOL}`;
   output += `System environment variable PATH ${EOL} ${reportedResult.systemInfo.envPath} ${EOL}`;
   output += `System environment variable PYTHON ${EOL} ${reportedResult.systemInfo.envPython} ${EOL}`;
+  output += `Visual Studio Code Remote name ${reportedResult.systemInfo.remoteName} ${EOL}`;
   output += `Visual Studio Code version ${reportedResult.systemInfo.vscodeVersion} ${EOL}`;
   output += `Visual Studio Code language ${reportedResult.systemInfo.language} ${EOL}`;
   output += `Visual Studio Code shell ${reportedResult.systemInfo.shell} ${EOL}`;

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -31,9 +31,7 @@ import { getConfigurationSettings } from "../support/configurationSettings";
 import { readFile, readJSON } from "fs-extra";
 import { getPipVersion } from "../support/pipVersion";
 import { checkEspIdfRequirements } from "../support/checkEspIdfRequirements";
-import {
-  checkDebugAdapterRequirements
-} from "../support/checkExtensionRequirements";
+import { checkDebugAdapterRequirements } from "../support/checkExtensionRequirements";
 import {
   checkCCppPropertiesJson,
   checkLaunchJson,
@@ -268,6 +266,7 @@ suite("Doctor Command tests", () => {
     expectedOutput += `System environment variable IDF_PYTHON_ENV_PATH ${os.EOL} ${process.env.IDF_PYTHON_ENV_PATH} ${os.EOL}`;
     expectedOutput += `System environment variable PATH ${os.EOL} ${processPathEnvVar} ${os.EOL}`;
     expectedOutput += `System environment variable PYTHON ${os.EOL} ${process.env.PYTHON} ${os.EOL}`;
+    expectedOutput += `Visual Studio Code Remote name ${vscode.env.remoteName} ${os.EOL}`;
     expectedOutput += `Visual Studio Code version ${vscode.version} ${os.EOL}`;
     expectedOutput += `Visual Studio Code language ${vscode.env.language} ${os.EOL}`;
     expectedOutput += `Visual Studio Code shell ${vscode.env.shell} ${os.EOL}`;
@@ -298,9 +297,7 @@ suite("Doctor Command tests", () => {
         expectedOutput += `    ${key}: ${reportObj.configurationSettings.userExtraVars[key]}${os.EOL}`;
       }
     }
-    expectedOutput += `System python Path (idf.pythonInstallPath) ${
-      reportObj.configurationSettings.sysPythonBinPath
-    }${os.EOL}`;
+    expectedOutput += `System python Path (idf.pythonInstallPath) ${reportObj.configurationSettings.sysPythonBinPath}${os.EOL}`;
     expectedOutput += `Virtual environment Python path (computed) ${
       process.env.IDF_PYTHON_ENV_PATH + "/bin/python"
     }${os.EOL}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export class PreCheck {
     );
   }
   public static notUsingWebIde(): boolean {
-    if (vscode.env.uiKind === vscode.UIKind.Web) {
+    if (vscode.env.remoteName === "codespaces") {
       return false;
     }
     return process.env.WEB_IDE ? false : true;


### PR DESCRIPTION
## Description

Code-server is uses web UI which makes user detection fail. Now we should check that the remote is Codespaces to disable specific commands.

Fixes #1461

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Configure ESP-IDF extension"
2. Should not work in Codespaces.
3. Running the Command in Code-server instance should work.


**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Codespaces and local

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
