### PR TITLE
[VSC-1631] fix created project path from task output

### DIFF
--- a/src/component-manager/panel.ts
+++ b/src/component-manager/panel.ts
@@ -150,16 +150,7 @@ export class ComponentManagerUIPanel {
             cancellable: false,
           },
           async () => {
-            await createProject(selectedFolder[0], message.example);
-            const match = message.example.match(/(?<=:).*/);
-            if (!match) {
-              return;
-            }
-            let projectName =
-              (process.platform === "win32" ? "\\" : "/") + match[0];
-            const projectPath = vscode.Uri.file(
-              selectedFolder[0].fsPath + projectName
-            );
+            const projectPath = await createProject(selectedFolder[0], message.example);
             await vscode.commands.executeCommand(
               "vscode.openFolder",
               projectPath,


### PR DESCRIPTION
## Description

VSCode extension was parsing resulting project name from format `namespace/name=1.0.0:example` but for the example with this command

```
idf.py create-project-from-example "espressif/esp-modbus=2.0.2:tcp/mb_tcp_slave"
```

will generate a project named `mb_tcp_slave` instead of expected `tcp/mb_tcp_slave`.

Fixes https://github.com/espressif/esp-modbus/issues/100

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Open ESP Component Registry."
2. Search for `esp-modbus`. Select `examples` tab and click on `tcp/mb_tcp_slave`. Create a project example  with the red button shown.
3. Observe results. The example project should be created and a new window opened in the newly created project.

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
