### PR TITLE
[VSC-1640] profiles env should merge customExtraVars with profile env

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -209,5 +209,7 @@
   "Warning: Could not fully remove setting {0}: {1}": "Advertencia: No se pudo eliminar completamente la configuración {0}: {1}",
   "ESP-IDF settings removed successfully.": "Configuraciones de ESP-IDF eliminadas exitosamente.",
   "Failed to remove settings: {0}": "Error al eliminar las configuraciones: {0}",
-  "Error: {0}": "Error: {0}"
+  "Error: {0}": "Error: {0}",
+  "IDF_TARGET mismatch: SDKConfig value is \"{0}\" but settings value is \"{1}\".": "Desajuste de IDF_TARGET: el valor de SDKConfig es \"{0}\" pero el valor de configuración es \"{1}\".",
+  "Set IDF_TARGET": "Establecer IDF_TARGET"
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -209,5 +209,7 @@
   "Warning: Could not fully remove setting {0}: {1}": "Aviso: Não foi possível remover completamente a configuração {0}: {1}",
   "ESP-IDF settings removed successfully.": "Configurações ESP-IDF removidas com sucesso.",
   "Failed to remove settings: {0}": "Falha ao remover configurações: {0}",
-  "Error: {0}": "Erro: {0}"
+  "Error: {0}": "Erro: {0}",
+  "IDF_TARGET mismatch: SDKConfig value is \"{0}\" but settings value is \"{1}\".": "Incompatibilidade de IDF_TARGET: o valor de SDKConfig é \"{0}\" mas o valor das configurações é \"{1}\".",
+  "Set IDF_TARGET": "Definir IDF_TARGET"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -209,5 +209,7 @@
   "Warning: Could not fully remove setting {0}: {1}": "Предупреждение: Не удалось полностью удалить настройку {0}: {1}",
   "ESP-IDF settings removed successfully.": "Настройки ESP-IDF успешно удалены.",
   "Failed to remove settings: {0}": "Не удалось удалить настройки: {0}",
-  "Error: {0}": "Ошибка: {0}"
+  "Error: {0}": "Ошибка: {0}",
+  "IDF_TARGET mismatch: SDKConfig value is \"{0}\" but settings value is \"{1}\".": "Несоответствие IDF_TARGET: значение SDKConfig \"{0}\", но значение настроек \"{1}\".",
+  "Set IDF_TARGET": "Установить IDF_TARGET"
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -209,5 +209,7 @@
   "Warning: Could not fully remove setting {0}: {1}": "警告：无法完全删除设置 {0}：{1}",
   "ESP-IDF settings removed successfully.": "ESP-IDF设置已成功删除。",
   "Failed to remove settings: {0}": "删除设置失败：{0}",
-  "Error: {0}": "错误：{0}"
+  "Error: {0}": "错误：{0}",
+  "IDF_TARGET mismatch: SDKConfig value is \"{0}\" but settings value is \"{1}\".": "IDF_TARGET 不匹配：SDKConfig 值为 \"{0}\"，但设置值为 \"{1}\"。",
+  "Set IDF_TARGET": "设置 IDF_TARGET"
 }

--- a/src/espIdf/setTarget/getTargets.ts
+++ b/src/espIdf/setTarget/getTargets.ts
@@ -28,8 +28,13 @@ export interface IdfTarget {
   target: string;
 }
 
-export async function getTargetsFromEspIdf(workspaceFolder: Uri) {
-  const idfPathDir = readParameter("idf.espIdfPath", workspaceFolder);
+export async function getTargetsFromEspIdf(
+  workspaceFolder: Uri,
+  givenIdfPathDir?: string
+) {
+  const idfPathDir = givenIdfPathDir
+    ? givenIdfPathDir
+    : readParameter("idf.espIdfPath", workspaceFolder);
   const idfPyPath = join(idfPathDir, "tools", "idf.py");
   const modifiedEnv = await appendIdfAndToolsToPath(workspaceFolder);
   const pythonBinPath = await getVirtualEnvPythonPath(workspaceFolder);

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -34,6 +34,7 @@ import { OutputChannel } from "../../logger/outputChannel";
 import { getBoards, getOpenOcdScripts } from "../openOcd/boardConfiguration";
 import { getTargetsFromEspIdf } from "./getTargets";
 import { setTargetInIDF } from "./setTargetInIdf";
+import { updateCurrentProfileIdfTarget } from "../../project-conf";
 
 export async function setIdfTarget(
   placeHolderMsg: string,
@@ -77,6 +78,7 @@ export async function setIdfTarget(
           configurationTarget,
           workspaceFolder.uri
         );
+        await updateCurrentProfileIdfTarget(selectedTarget.target, workspaceFolder.uri);
         const openOcdScriptsPath = await getOpenOcdScripts(workspaceFolder.uri);
         const boards = await getBoards(
           openOcdScriptsPath,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -478,8 +478,6 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  context.subscriptions.push(projectConfigManager);
-
   vscode.debug.onDidTerminateDebugSession((e) => {
     if (isOpenOCDLaunchedByDebug && !isDebugRestarted) {
       isOpenOCDLaunchedByDebug = false;
@@ -3740,24 +3738,19 @@ export async function activate(context: vscode.ExtensionContext) {
     context,
     statusBarItems
   );
+  context.subscriptions.push(projectConfigManager);
 
-  const projectConfCommandDisposable = vscode.commands.registerCommand(
-    "espIdf.projectConf",
-    async () => {
-      PreCheck.perform([openFolderCheck], async () => {
-        if (projectConfigManager) {
-          await projectConfigManager.selectProjectConfiguration();
-        } else {
-          vscode.window.showErrorMessage(
-            "Project Configuration Manager not initialized."
-          );
-        }
-      });
-    }
-  );
-
-  // Add the disposable to context subscriptions
-  context.subscriptions.push(projectConfCommandDisposable);
+  registerIDFCommand("espIdf.projectConf", () => {
+    PreCheck.perform([openFolderCheck], async () => {
+      if (projectConfigManager) {
+        await projectConfigManager.selectProjectConfiguration();
+      } else {
+        vscode.window.showErrorMessage(
+          "Project Configuration Manager not initialized."
+        );
+      }
+    });
+  });
 }
 
 function checkAndNotifyMissingCompileCommands() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,6 +171,7 @@ import { IdfSetup } from "./views/setup/types";
 import { asyncRemoveEspIdfSettings } from "./uninstall";
 import { ProjectConfigurationManager } from "./project-conf/ProjectConfigurationManager";
 import { readPartition } from "./espIdf/partition-table/partitionReader";
+import { getTargetsFromEspIdf } from "./espIdf/setTarget/getTargets";
 
 // Global variables shared by commands
 let workspaceRoot: vscode.Uri;
@@ -1151,9 +1152,11 @@ export async function activate(context: vscode.ExtensionContext) {
             progress: vscode.Progress<{ message: string; increment: number }>
           ) => {
             try {
+              const targetsFromIdf = await getTargetsFromEspIdf(workspaceRoot);
               projectConfigurationPanel.createOrShow(
                 context.extensionPath,
-                workspaceRoot
+                workspaceRoot,
+                targetsFromIdf
               );
             } catch (error) {
               Logger.errorNotify(

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -81,6 +81,9 @@ export function parameterToProjectConfigMap(
         resultVars[projectConfEnvKey] =
           currentProjectConf.env[projectConfEnvKey];
       }
+      if (currentProjectConf.idfTarget) {
+        resultVars["IDF_TARGET"] = currentProjectConf.idfTarget;
+      }
       return resultVars;
     case "idf.flashBaudRate":
       return currentProjectConf.flashBaudRate;

--- a/src/idfConfiguration.ts
+++ b/src/idfConfiguration.ts
@@ -34,7 +34,10 @@ export function addWinIfRequired(param: string) {
   return param;
 }
 
-export function parameterToProjectConfigMap(param: string) {
+export function parameterToProjectConfigMap(
+  param: string,
+  scope?: vscode.ConfigurationScope
+) {
   if (!ESP.ProjectConfiguration.store) {
     return "";
   }
@@ -66,7 +69,19 @@ export function parameterToProjectConfigMap(param: string) {
         ? currentProjectConf.build.sdkconfigDefaults
         : "";
     case "idf.customExtraVars":
-      return currentProjectConf.env;
+      const paramUpdated = addWinIfRequired(param);
+      let settingsVars = vscode.workspace
+        .getConfiguration("", scope)
+        .get(paramUpdated) as { [key: string]: any };
+      let resultVars = {};
+      for (const envKey of Object.keys(settingsVars)) {
+        resultVars[envKey] = settingsVars[envKey];
+      }
+      for (const projectConfEnvKey of Object.keys(currentProjectConf.env)) {
+        resultVars[projectConfEnvKey] =
+          currentProjectConf.env[projectConfEnvKey];
+      }
+      return resultVars;
     case "idf.flashBaudRate":
       return currentProjectConf.flashBaudRate;
     case "idf.monitorBaudRate":

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -28,6 +28,7 @@ import {
   loadIdfSetupsFromEspIdfJson,
 } from "../setup/existingIdfSetups";
 import { IdfSetup } from "../views/setup/types";
+import { getTargetsFromEspIdf, IdfTarget } from "../espIdf/setTarget/getTargets";
 
 export interface INewProjectArgs {
   espIdfSetup: IdfSetup;
@@ -36,6 +37,7 @@ export interface INewProjectArgs {
   espMatterPath: string;
   espHomeKitSdkPath: string;
   espRainmakerPath: string;
+  idfTargets: IdfTarget[];
   boards: IdfBoard[];
   components: IComponent[];
   serialPortList: string[];
@@ -163,6 +165,9 @@ export async function getNewProjectArgs(
     const homeKitSdkTemplates = getExamplesList(espHomeKitSdkPath);
     templates["ESP-HOMEKIT-SDK"] = homeKitSdkTemplates;
   }
+
+  const targetsFromIdf = await getTargetsFromEspIdf(workspace, idfSetup.idfPath);
+  
   progress.report({ increment: 50, message: "Initializing wizard..." });
   return {
     boards: espBoards,
@@ -170,6 +175,7 @@ export async function getNewProjectArgs(
     espIdfSetup: idfSetup,
     espAdfPath: adfExists ? espAdfPath : undefined,
     espMdfPath: mdfExists ? espMdfPath : undefined,
+    idfTargets: targetsFromIdf,
     espMatterPath: matterExists ? espMatterPath : undefined,
     espHomeKitSdkPath: homekitSdkExists ? espHomeKitSdkPath : undefined,
     espRainmakerPath: rainmakerExists ? espRainmakerPath : undefined,

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -124,7 +124,8 @@ export class NewProjectPanel {
             message.port &&
             message.projectName &&
             message.openOcdConfigFiles &&
-            message.template
+            message.template &&
+            message.selectedIdfTarget
           ) {
             this.createProject(
               newProjectArgs.espIdfSetup,
@@ -134,7 +135,8 @@ export class NewProjectPanel {
               message.projectName,
               JSON.parse(message.template),
               message.openOcdConfigFiles,
-              newProjectArgs.workspaceFolder
+              newProjectArgs.workspaceFolder,
+              message.selectedIdfTarget
             );
           }
           break;
@@ -183,6 +185,7 @@ export class NewProjectPanel {
               command: "initialLoad",
               containerDirectory: containerPath,
               projectName: "project-name",
+              idfTargets: newProjectArgs.idfTargets,
               serialPortList: newProjectArgs.serialPortList,
               openOcdConfigFiles: defConfigFiles,
               templates: newProjectArgs.templates,
@@ -211,7 +214,8 @@ export class NewProjectPanel {
     projectName: string,
     template: IExample,
     openOcdConfigs?: string,
-    workspaceFolder?: vscode.Uri
+    workspaceFolder?: vscode.Uri,
+    selectedIdfTarget?: string
   ) {
     const newProjectPath = path.join(projectDirectory, projectName);
     let isSkipped = false;
@@ -293,6 +297,7 @@ export class NewProjectPanel {
             settingsJsonPath,
             idfSetup,
             port,
+            selectedIdfTarget,
             openOcdConfigs,
             workspaceFolder
           );

--- a/src/newProject/utils.ts
+++ b/src/newProject/utils.ts
@@ -26,6 +26,7 @@ export async function setCurrentSettingsInTemplate(
   settingsJsonPath: string,
   idfSetup: IdfSetup,
   port: string,
+  selectedIdfTarget: string,
   openOcdConfigs?: string,
   workspace?: Uri
 ) {
@@ -62,6 +63,10 @@ export async function setCurrentSettingsInTemplate(
   }
   if (idfSetup.toolsPath) {
     settingsJson["idf.toolsPath" + isWin] = idfSetup.toolsPath;
+  }
+  if (selectedIdfTarget) {
+    settingsJson["idf.customExtraVars"] = settingsJson["idf.customExtraVars"] || {};
+    settingsJson["idf.customExtraVars"]["IDF_TARGET"] = selectedIdfTarget;
   }
   return settingsJson;
 }

--- a/src/project-conf/ProjectConfigurationManager.ts
+++ b/src/project-conf/ProjectConfigurationManager.ts
@@ -1,5 +1,19 @@
-import * as vscode from "vscode";
-import * as utils from "../utils";
+import {
+  ExtensionContext,
+  FileSystemWatcher,
+  StatusBarItem,
+  window,
+  workspace,
+  Uri,
+  l10n,
+  commands,
+} from "vscode";
+import {
+  fileExists,
+  readFileSync,
+  readJson,
+  setCCppPropertiesJsonCompileCommands,
+} from "../utils";
 import { ESP } from "../config";
 import { ConfserverProcess } from "../espIdf/menuconfig/confServerProcess";
 import { CommandKeys, createCommandDictionary } from "../cmdTreeView/cmdStore";
@@ -7,33 +21,32 @@ import { createStatusBarItem } from "../statusBar";
 import { getIdfTargetFromSdkconfig } from "../workspaceConfig";
 import { Logger } from "../logger/logger";
 import { getProjectConfigurationElements } from "./index";
-import { ensureDir } from "fs-extra";
 
 export class ProjectConfigurationManager {
   private readonly configFilePath: string;
   private configVersions: string[] = [];
-  private configWatcher: vscode.FileSystemWatcher;
-  private statusBarItems: { [key: string]: vscode.StatusBarItem };
-  private workspaceRoot: vscode.Uri;
-  private context: vscode.ExtensionContext;
+  private configWatcher: FileSystemWatcher;
+  private statusBarItems: { [key: string]: StatusBarItem };
+  private workspaceRoot: Uri;
+  private context: ExtensionContext;
   private commandDictionary: any;
 
   constructor(
-    workspaceRoot: vscode.Uri,
-    context: vscode.ExtensionContext,
-    statusBarItems: { [key: string]: vscode.StatusBarItem }
+    workspaceRoot: Uri,
+    context: ExtensionContext,
+    statusBarItems: { [key: string]: StatusBarItem }
   ) {
     this.workspaceRoot = workspaceRoot;
     this.context = context;
     this.statusBarItems = statusBarItems;
     this.commandDictionary = createCommandDictionary();
 
-    this.configFilePath = vscode.Uri.joinPath(
+    this.configFilePath = Uri.joinPath(
       workspaceRoot,
       ESP.ProjectConfiguration.PROJECT_CONFIGURATION_FILENAME
     ).fsPath;
 
-    this.configWatcher = vscode.workspace.createFileSystemWatcher(
+    this.configWatcher = workspace.createFileSystemWatcher(
       this.configFilePath,
       false,
       false,
@@ -45,16 +58,16 @@ export class ProjectConfigurationManager {
   }
 
   private initialize(): void {
-    if (!utils.fileExists(this.configFilePath)) {
+    if (!fileExists(this.configFilePath)) {
       // File doesn't exist - this is normal for projects without multiple configurations
       this.configVersions = [];
-      
+
       // If configuration status bar item exists, remove it
       if (this.statusBarItems["projectConf"]) {
         this.statusBarItems["projectConf"].dispose();
         this.statusBarItems["projectConf"] = undefined;
       }
-      
+
       // Clear any potentially stale configuration
       const currentSelectedConfig = ESP.ProjectConfiguration.store.get<string>(
         ESP.ProjectConfiguration.SELECTED_CONFIG
@@ -65,12 +78,12 @@ export class ProjectConfigurationManager {
           ESP.ProjectConfiguration.SELECTED_CONFIG
         );
       }
-      
+
       return;
     }
-    
+
     try {
-      const configContent = utils.readFileSync(this.configFilePath);
+      const configContent = readFileSync(this.configFilePath);
 
       // Handle edge case: File exists but is empty
       if (!configContent || configContent.trim() === "") {
@@ -83,18 +96,18 @@ export class ProjectConfigurationManager {
 
       const configData = JSON.parse(configContent);
       this.configVersions = Object.keys(configData);
-      
+
       // Check if the currently selected configuration is valid
       const currentSelectedConfig = ESP.ProjectConfiguration.store.get<string>(
         ESP.ProjectConfiguration.SELECTED_CONFIG
       );
 
-      if (currentSelectedConfig && this.configVersions.includes(currentSelectedConfig)) {
+      if (
+        currentSelectedConfig &&
+        this.configVersions.includes(currentSelectedConfig)
+      ) {
         // Current selection is valid, keep it
-        this.updateConfiguration(
-          currentSelectedConfig,
-          configData[currentSelectedConfig]
-        );
+        this.updateConfiguration(currentSelectedConfig);
       } else if (currentSelectedConfig) {
         // Current selection is invalid, clear it
         ESP.ProjectConfiguration.store.clear(currentSelectedConfig);
@@ -104,7 +117,7 @@ export class ProjectConfigurationManager {
         this.setNoConfigurationSelectedStatus();
       } else if (this.configVersions.length > 0) {
         // No current selection but configurations exist
-        vscode.window.showInformationMessage(
+        window.showInformationMessage(
           `Loaded ${
             this.configVersions.length
           } project configuration(s): ${this.configVersions.join(", ")}`
@@ -118,7 +131,7 @@ export class ProjectConfigurationManager {
         this.setNoConfigurationSelectedStatus();
       }
     } catch (error) {
-      vscode.window.showErrorMessage(
+      window.showErrorMessage(
         `Error reading or parsing project configuration file (${this.configFilePath}): ${error.message}`
       );
       Logger.errorNotify(
@@ -156,7 +169,7 @@ export class ProjectConfigurationManager {
 
   private async handleConfigFileChange(): Promise<void> {
     try {
-      const configData = JSON.parse(utils.readFileSync(this.configFilePath));
+      const configData = await readJson(this.configFilePath);
       const currentVersions = Object.keys(configData);
 
       // Find added versions
@@ -170,13 +183,13 @@ export class ProjectConfigurationManager {
       );
 
       if (addedVersions.length > 0) {
-        vscode.window.showInformationMessage(
+        window.showInformationMessage(
           `New versions added: ${addedVersions.join(", ")}`
         );
       }
 
       if (removedVersions.length > 0) {
-        vscode.window.showInformationMessage(
+        window.showInformationMessage(
           `Versions removed: ${removedVersions.join(", ")}`
         );
       }
@@ -190,12 +203,12 @@ export class ProjectConfigurationManager {
       );
 
       // Handle the status based on whether current selection is valid
-      if (currentSelectedConfig && currentVersions.includes(currentSelectedConfig)) {
+      if (
+        currentSelectedConfig &&
+        currentVersions.includes(currentSelectedConfig)
+      ) {
         // Current selection is still valid
-        await this.updateConfiguration(
-          currentSelectedConfig, 
-          configData[currentSelectedConfig]
-        );
+        await this.updateConfiguration(currentSelectedConfig);
       } else if (currentSelectedConfig) {
         // Current selection no longer exists, clear it
         ESP.ProjectConfiguration.store.clear(currentSelectedConfig);
@@ -208,9 +221,7 @@ export class ProjectConfigurationManager {
         this.setNoConfigurationSelectedStatus();
       }
     } catch (error) {
-      vscode.window.showErrorMessage(
-        `Error parsing config file: ${error.message}`
-      );
+      window.showErrorMessage(`Error parsing config file: ${error.message}`);
       this.setNoConfigurationSelectedStatus();
     }
   }
@@ -218,48 +229,48 @@ export class ProjectConfigurationManager {
   private async handleConfigFileDelete(): Promise<void> {
     // When the config file is deleted, clear all configurations
     this.configVersions = [];
-    
+
     // Clear any selected configuration
     const currentSelectedConfig = ESP.ProjectConfiguration.store.get<string>(
       ESP.ProjectConfiguration.SELECTED_CONFIG
     );
-    
+
     if (currentSelectedConfig) {
       ESP.ProjectConfiguration.store.clear(currentSelectedConfig);
       ESP.ProjectConfiguration.store.clear(
         ESP.ProjectConfiguration.SELECTED_CONFIG
       );
     }
-    
+
     // Remove the status bar item completely when the config file is deleted
     if (this.statusBarItems["projectConf"]) {
       this.statusBarItems["projectConf"].dispose();
       this.statusBarItems["projectConf"] = undefined;
     }
-    
+
     // Optionally notify the user
-    vscode.window.showInformationMessage(
+    window.showInformationMessage(
       "Project configuration file has been deleted."
     );
   }
 
   private async handleConfigFileCreate(): Promise<void> {
     try {
-      const configData = JSON.parse(utils.readFileSync(this.configFilePath));
+      const configData = await readJson(this.configFilePath);
       this.configVersions = Object.keys(configData);
 
       // If we have versions, check if current selection is valid
       if (this.configVersions.length > 0) {
-        const currentSelectedConfig = ESP.ProjectConfiguration.store.get<string>(
-          ESP.ProjectConfiguration.SELECTED_CONFIG
-        );
+        const currentSelectedConfig = ESP.ProjectConfiguration.store.get<
+          string
+        >(ESP.ProjectConfiguration.SELECTED_CONFIG);
 
-        if (currentSelectedConfig && this.configVersions.includes(currentSelectedConfig)) {
+        if (
+          currentSelectedConfig &&
+          this.configVersions.includes(currentSelectedConfig)
+        ) {
           // Current selection is valid
-          await this.updateConfiguration(
-            currentSelectedConfig,
-            configData[currentSelectedConfig]
-          );
+          await this.updateConfiguration(currentSelectedConfig);
         } else {
           // No valid selection, show "No Configuration Selected"
           if (currentSelectedConfig) {
@@ -269,9 +280,9 @@ export class ProjectConfigurationManager {
             );
           }
           this.setNoConfigurationSelectedStatus();
-          
+
           // Notify the user about available configurations
-          vscode.window.showInformationMessage(
+          window.showInformationMessage(
             `Project configuration file created with ${this.configVersions.length} configuration(s). Select one to use.`
           );
         }
@@ -280,7 +291,7 @@ export class ProjectConfigurationManager {
         this.setNoConfigurationSelectedStatus();
       }
     } catch (error) {
-      vscode.window.showErrorMessage(
+      window.showErrorMessage(
         `Error parsing newly created config file: ${error.message}`
       );
       this.setNoConfigurationSelectedStatus();
@@ -292,7 +303,8 @@ export class ProjectConfigurationManager {
    */
   private setNoConfigurationSelectedStatus(): void {
     const statusBarItemName = "No Configuration Selected";
-    const statusBarItemTooltip = "No project configuration selected. Click to select one";
+    const statusBarItemTooltip =
+      "No project configuration selected. Click to select one";
     const commandToUse = "espIdf.projectConf";
 
     if (this.statusBarItems["projectConf"]) {
@@ -311,10 +323,7 @@ export class ProjectConfigurationManager {
     );
   }
 
-  private async updateConfiguration(
-    configName: string,
-    configData: any
-  ): Promise<void> {
+  private async updateConfiguration(configName: string): Promise<void> {
     // Update the configuration in store
     ESP.ProjectConfiguration.store.set(
       ESP.ProjectConfiguration.SELECTED_CONFIG,
@@ -349,7 +358,7 @@ export class ProjectConfigurationManager {
       this.workspaceRoot,
       this.statusBarItems["target"]
     );
-    await utils.setCCppPropertiesJsonCompileCommands(this.workspaceRoot);
+    await setCCppPropertiesJsonCompileCommands(this.workspaceRoot);
     ConfserverProcess.dispose();
   }
 
@@ -367,18 +376,18 @@ export class ProjectConfigurationManager {
         !projectConfigurations ||
         Object.keys(projectConfigurations).length === 0
       ) {
-        const emptyOption = await vscode.window.showInformationMessage(
-          vscode.l10n.t("No project configuration found"),
+        const emptyOption = await window.showInformationMessage(
+          l10n.t("No project configuration found"),
           "Open editor"
         );
 
         if (emptyOption === "Open editor") {
-          vscode.commands.executeCommand("espIdf.projectConfigurationEditor");
+          commands.executeCommand("espIdf.projectConfigurationEditor");
         }
         return;
       }
 
-      const selectConfigMsg = vscode.l10n.t("Select configuration to use:");
+      const selectConfigMsg = l10n.t("Select configuration to use:");
       let quickPickItems = Object.keys(projectConfigurations).map((k) => {
         return {
           description: k,
@@ -387,35 +396,22 @@ export class ProjectConfigurationManager {
         };
       });
 
-      const option = await vscode.window.showQuickPick(quickPickItems, {
+      const option = await window.showQuickPick(quickPickItems, {
         placeHolder: selectConfigMsg,
       });
 
       if (!option) {
-        const noOptionMsg = vscode.l10n.t("No option selected.");
+        const noOptionMsg = l10n.t("No option selected.");
         Logger.infoNotify(noOptionMsg);
         return;
       }
 
-      await this.updateConfiguration(
-        option.target,
-        projectConfigurations[option.target]
-      );
+      await this.updateConfiguration(option.target);
     } catch (error) {
-      vscode.window.showErrorMessage(
+      window.showErrorMessage(
         `Error selecting configuration: ${error.message}`
       );
     }
-  }
-
-  /**
-   * Register the configuration selection command
-   */
-  public registerConfigSelectionCommand(): vscode.Disposable {
-    return vscode.commands.registerCommand(
-      "espIdf.projectConf",
-      async () => await this.selectProjectConfiguration()
-    );
   }
 
   /**

--- a/src/project-conf/index.ts
+++ b/src/project-conf/index.ts
@@ -81,7 +81,7 @@ export async function updateCurrentProfileIdfTarget(
     selectedConfig,
     projectConfJson[selectedConfig]
   );
-  await this.saveProjectConfFile(workspaceFolder, projectConfJson);
+  await saveProjectConfFile(workspaceFolder, projectConfJson);
 }
 
 export async function saveProjectConfFile(

--- a/src/project-conf/index.ts
+++ b/src/project-conf/index.ts
@@ -284,6 +284,7 @@ export async function getProjectConfigurationElements(
           sdkconfigFilePath: sdkconfigFilePath,
         },
         env: processedEnv ?? {},
+        idfTarget: rawConfig.idfTarget,
         flashBaudRate: rawConfig.flashBaudRate,
         monitorBaudRate: rawConfig.monitorBaudRate,
         openOCD: {

--- a/src/project-conf/projectConfPanel.ts
+++ b/src/project-conf/projectConfPanel.ts
@@ -29,11 +29,16 @@ import {
 import { join } from "path";
 import { ESP } from "../config";
 import { getProjectConfigurationElements, saveProjectConfFile } from ".";
+import { IdfTarget } from "../espIdf/setTarget/getTargets";
 
 export class projectConfigurationPanel {
   public static currentPanel: projectConfigurationPanel | undefined;
 
-  public static createOrShow(extensionPath: string, workspaceFolder: Uri) {
+  public static createOrShow(
+    extensionPath: string,
+    workspaceFolder: Uri,
+    idfTargets?: IdfTarget[]
+  ) {
     const column = window.activeTextEditor
       ? window.activeTextEditor.viewColumn
       : ViewColumn.One;
@@ -44,7 +49,8 @@ export class projectConfigurationPanel {
       projectConfigurationPanel.currentPanel = new projectConfigurationPanel(
         extensionPath,
         column,
-        workspaceFolder
+        workspaceFolder,
+        idfTargets
       );
     }
   }
@@ -63,11 +69,10 @@ export class projectConfigurationPanel {
   constructor(
     private extensionPath: string,
     column: ViewColumn,
-    private workspaceFolder: Uri
+    private workspaceFolder: Uri,
+    idfTargets: IdfTarget[]
   ) {
-    const projectConfPanelTitle = l10n.t(
-      "ESP-IDF Project Configuration"
-    );
+    const projectConfPanelTitle = l10n.t("ESP-IDF Project Configuration");
 
     this.panel = window.createWebviewPanel(
       projectConfigurationPanel.viewType,
@@ -102,6 +107,7 @@ export class projectConfigurationPanel {
           this.panel.webview.postMessage({
             command: "initialLoad",
             confList: projectConfObj,
+            idfTargets,
           });
           break;
         case "saveProjectConfFile":

--- a/src/project-conf/projectConfiguration.ts
+++ b/src/project-conf/projectConfiguration.ts
@@ -25,6 +25,7 @@ export interface ProjectConfElement {
     sdkconfigFilePath: string;
   };
   env: { [key: string]: string };
+  idfTarget: string;
   flashBaudRate: string;
   monitorBaudRate: string;
   openOCD: {

--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -158,6 +158,7 @@ suite("Project tests", () => {
       settingsJsonPath,
       idfSetup,
       "no port",
+      "esp32",
       openOcdConfigs,
       Uri.file(projectPath)
     );

--- a/src/views/new-project/main.ts
+++ b/src/views/new-project/main.ts
@@ -73,6 +73,12 @@ window.addEventListener("message", (event) => {
       if (msg.openOcdConfigFiles) {
         store.openOcdConfigFiles = msg.openOcdConfigFiles;
       }
+      if (msg.idfTargets) {
+        store.idfTargets = msg.idfTargets;
+        console.log("first idf target");
+        console.log(msg.idfTargets[0]);
+        store.selectedIdfTarget = msg.idfTargets[0];
+      }
       break;
     case "setContainerDirectory":
       if (msg.projectDirectory) {

--- a/src/views/new-project/store.ts
+++ b/src/views/new-project/store.ts
@@ -20,6 +20,7 @@ import { IComponent } from "../../espIdf/idfComponent/IdfComponent";
 import { IExample, IExampleCategory } from "../../examples/Example";
 import { IdfBoard } from "../../espIdf/openOcd/boardConfiguration";
 import { Ref, ref } from "vue";
+import { IdfTarget } from "../../espIdf/setTarget/getTargets";
 
 declare var acquireVsCodeApi: any;
 let vscode: any;
@@ -37,6 +38,12 @@ export const useNewProjectStore = defineStore("newProject", () => {
   const hasTemplateDetail: Ref<boolean> = ref(false);
   const openOcdConfigFiles: Ref<string> = ref("");
   const projectName: Ref<string> = ref("");
+  const idfTargets: Ref<IdfTarget[]> = ref([]);
+  const selectedIdfTarget: Ref<IdfTarget> = ref({
+    label: "esp32",
+    isPreview: false,
+    target: "esp32",
+  });
   const selectedBoard: Ref<IdfBoard> = ref({
     name: "",
     description: "",
@@ -64,6 +71,7 @@ export const useNewProjectStore = defineStore("newProject", () => {
       port: selectedPort.value,
       projectName: projectName.value,
       template: JSON.stringify(selectedTemplate.value),
+      selectedIdfTarget: selectedIdfTarget.value.target,
     });
   }
 
@@ -98,11 +106,13 @@ export const useNewProjectStore = defineStore("newProject", () => {
     containerDirectory,
     currentComponentPath,
     hasTemplateDetail,
+    idfTargets,
     openOcdConfigFiles,
     projectName,
     searchString,
     selectedBoard,
     selectedFramework,
+    selectedIdfTarget,
     selectedPort,
     selectedTemplate,
     serialPortList,

--- a/src/views/project-conf/components/SelectElement.vue
+++ b/src/views/project-conf/components/SelectElement.vue
@@ -45,11 +45,11 @@ let customValue = computed({
 <template>
   <div class="block">
     <div class="field">
-      <label class="label">{{ title }}</label>
+      <label class="label">{{ props.title }}</label>
       <div class="control">
         <div class="select">
           <select v-model="selectedValue">
-            <option v-for="opt of options" :value="opt.value" :key="opt.name">{{
+            <option v-for="opt of props.options" :value="opt.value" :key="opt.name">{{
               opt.name
             }}</option>
           </select>

--- a/src/views/project-conf/components/projectConfElem.vue
+++ b/src/views/project-conf/components/projectConfElem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { ProjectConfElement } from "../../../project-conf/projectConfiguration";
 import { useProjectConfStore } from "../store";
 import ArrayElement from "./ArrayElement.vue";
@@ -20,6 +21,16 @@ const openOcdDebugLevelOptions: { name: string; value: number }[] = [
   { name: "Debug", value: 3 },
   { name: "Verbose", value: 4 },
 ];
+
+const idfTargets = computed(() => {
+  const results = store.idfTargets.map((idfTarget) => {
+    return {
+      name: idfTarget.label,
+      value: idfTarget.target,
+    };
+  });
+  return results;
+});
 
 function updateElement(sections: string[], newValue: any) {
   store.updateConfigElement({ confKey: props.title, sections, newValue });
@@ -48,34 +59,42 @@ function removeValueFromArray(sections: string[], index: number) {
 
 <template>
   <div class="notification">
-    <h2 class="title centerize">{{ title }}</h2>
+    <h2 class="title centerize">{{ props.title }}</h2>
     <a class="delete" @click="$emit('delete')"></a>
     <label class="is-size-4 has-text-weight-bold">Build</label>
     <div class="small-margin">
       <ArrayElement
         title="Compile arguments"
-        :values="el.build.compileArgs ? el.build.compileArgs : []"
+        :values="props.el.build.compileArgs ? props.el.build.compileArgs : []"
         :sections="['build', 'compileArgs']"
         :addValue="addValueToArray"
         :removeValue="removeValueFromArray"
       />
       <ArrayElement
         title="Ninja arguments"
-        :values="el.build.ninjaArgs ? el.build.ninjaArgs : []"
+        :values="props.el.build.ninjaArgs ? props.el.build.ninjaArgs : []"
         :sections="['build', 'ninjaArgs']"
         :addValue="addValueToArray"
         :removeValue="removeValueFromArray"
       />
       <StringElement
         title="Build Directory path"
-        :value="el.build.buildDirectoryPath ? el.build.buildDirectoryPath : ''"
+        :value="
+          props.el.build.buildDirectoryPath
+            ? props.el.build.buildDirectoryPath
+            : ''
+        "
         :sections="['build', 'buildDirectoryPath']"
         :updateMethod="updateElement"
         :openMethod="openBuildDir"
       />
       <ArrayElement
         title="sdkconfig defaults"
-        :values="el.build.sdkconfigDefaults ? el.build.sdkconfigDefaults : []"
+        :values="
+          props.el.build.sdkconfigDefaults
+            ? props.el.build.sdkconfigDefaults
+            : []
+        "
         :sections="['build', 'sdkconfigDefaults']"
         :addValue="addValueToArray"
         :removeValue="removeValueFromArray"
@@ -83,28 +102,37 @@ function removeValueFromArray(sections: string[], index: number) {
       <StringElement
         title="sdkconfig file path"
         :value.sync="
-          el.build.sdkconfigFilePath ? el.build.sdkconfigFilePath : ''
+          props.el.build.sdkconfigFilePath
+            ? props.el.build.sdkconfigFilePath
+            : ''
         "
         :sections="['build', 'sdkconfigFilePath']"
         :updateMethod="updateElement"
         :openMethod="openFilePath"
       />
     </div>
+    <SelectElement
+      :selectValue="props.el.idfTarget ? props.el.idfTarget : ''"
+      title="IDF Target"
+      :options="idfTargets"
+      :sections="['idfTarget']"
+      :updateMethod="updateElement"
+    />
     <DictionaryElement
       title="Environment variables"
-      :elements="el.env"
+      :elements="props.el.env"
       :sections="['env']"
       :updateMethod="updateElement"
     />
     <StringElement
       title="Flash baud rate"
-      :value="el.flashBaudRate ? el.flashBaudRate : ''"
+      :value="props.el.flashBaudRate ? props.el.flashBaudRate : ''"
       :sections="['flashBaudRate']"
       :updateMethod="updateElement"
     />
     <StringElement
       title="Monitor baud rate"
-      :value="el.monitorBaudRate ? el.monitorBaudRate : ''"
+      :value="props.el.monitorBaudRate ? props.el.monitorBaudRate : ''"
       :sections="['monitorBaudRate']"
       :updateMethod="updateElement"
     />
@@ -112,7 +140,9 @@ function removeValueFromArray(sections: string[], index: number) {
     <label class="is-size-4 has-text-weight-bold">OpenOCD</label>
     <div class="small-margin">
       <SelectElement
-        :selectValue="el.openOCD.debugLevel ? el.openOCD.debugLevel : ''"
+        :selectValue="
+          props.el.openOCD.debugLevel ? props.el.openOCD.debugLevel : ''
+        "
         title="Debug Level"
         :options="openOcdDebugLevelOptions"
         :sections="['openOCD', 'debugLevel']"
@@ -120,14 +150,14 @@ function removeValueFromArray(sections: string[], index: number) {
       />
       <ArrayElement
         title="Config files"
-        :values="el.openOCD.configs ? el.openOCD.configs : []"
+        :values="props.el.openOCD.configs ? props.el.openOCD.configs : []"
         :sections="['openOCD', 'configs']"
         :addValue="addValueToArray"
         :removeValue="removeValueFromArray"
       />
       <ArrayElement
         title="Arguments"
-        :values="el.openOCD.args ? el.openOCD.args : []"
+        :values="props.el.openOCD.args ? props.el.openOCD.args : []"
         :sections="['openOCD', 'args']"
         :addValue="addValueToArray"
         :removeValue="removeValueFromArray"
@@ -138,25 +168,25 @@ function removeValueFromArray(sections: string[], index: number) {
     <div class="small-margin">
       <StringElement
         title="Pre Build"
-        :value="el.tasks.preBuild ? el.tasks.preBuild : ''"
+        :value="props.el.tasks.preBuild ? props.el.tasks.preBuild : ''"
         :sections="['tasks', 'preBuild']"
         :updateMethod="updateElement"
       />
       <StringElement
         title="Pre Flash"
-        :value="el.tasks.preFlash ? el.tasks.preFlash : ''"
+        :value="props.el.tasks.preFlash ? props.el.tasks.preFlash : ''"
         :sections="['tasks', 'preFlash']"
         :updateMethod="updateElement"
       />
       <StringElement
         title="Post Build"
-        :value="el.tasks.postBuild ? el.tasks.postBuild : ''"
+        :value="props.el.tasks.postBuild ? props.el.tasks.postBuild : ''"
         :sections="['tasks', 'postBuild']"
         :updateMethod="updateElement"
       />
       <StringElement
         title="Post Flash"
-        :value="el.tasks.postFlash ? el.tasks.postFlash : ''"
+        :value="props.el.tasks.postFlash ? props.el.tasks.postFlash : ''"
         :sections="['tasks', 'postFlash']"
         :updateMethod="updateElement"
       />

--- a/src/views/project-conf/main.ts
+++ b/src/views/project-conf/main.ts
@@ -54,6 +54,9 @@ window.addEventListener("message", (event: MessageEvent) => {
       if (msg.confList) {
         store.elements = msg.confList;
       }
+      if (msg.idfTargets && msg.idfTargets.length > 0) {
+        store.idfTargets = msg.idfTargets; 
+      }
     default:
       break;
   }

--- a/src/views/project-conf/store.ts
+++ b/src/views/project-conf/store.ts
@@ -19,6 +19,7 @@
 import { defineStore } from "pinia";
 import { Ref, ref } from "vue";
 import { ProjectConfElement } from "../../project-conf/projectConfiguration";
+import { IdfTarget } from "../../espIdf/setTarget/getTargets";
 
 declare var acquireVsCodeApi: any;
 let vscode: any;
@@ -31,6 +32,7 @@ try {
 
 export const useProjectConfStore = defineStore("project-config", () => {
   const elements: Ref<{ [key: string]: ProjectConfElement }> = ref({});
+  const idfTargets: Ref<IdfTarget[]> = ref([]);
   const emptyElement: Ref<ProjectConfElement> = ref({
     build: {
       compileArgs: [],
@@ -132,10 +134,13 @@ export const useProjectConfStore = defineStore("project-config", () => {
     } else if (
       payload.sections &&
       payload.sections.length === 2 &&
-      Object.keys(elements.value[payload.confKey]).indexOf(payload.sections[0]) !== -1
+      Object.keys(elements.value[payload.confKey]).indexOf(
+        payload.sections[0]
+      ) !== -1
     ) {
-      elements.value[payload.confKey][payload.sections[0]][payload.sections[1]] =
-        payload.newValue;
+      elements.value[payload.confKey][payload.sections[0]][
+        payload.sections[1]
+      ] = payload.newValue;
     }
   }
 
@@ -145,15 +150,19 @@ export const useProjectConfStore = defineStore("project-config", () => {
     valueToAdd: any;
   }) {
     if (payload.sections && payload.sections.length === 1) {
-      elements.value[payload.confKey][payload.sections[0]].push(payload.valueToAdd);
+      elements.value[payload.confKey][payload.sections[0]].push(
+        payload.valueToAdd
+      );
     } else if (
       payload.sections &&
       payload.sections.length === 2 &&
-      Object.keys(elements.value[payload.confKey]).indexOf(payload.sections[0]) !== -1
+      Object.keys(elements.value[payload.confKey]).indexOf(
+        payload.sections[0]
+      ) !== -1
     ) {
-      elements.value[payload.confKey][payload.sections[0]][payload.sections[1]].push(
-        payload.valueToAdd
-      );
+      elements.value[payload.confKey][payload.sections[0]][
+        payload.sections[1]
+      ].push(payload.valueToAdd);
     }
   }
 
@@ -163,11 +172,16 @@ export const useProjectConfStore = defineStore("project-config", () => {
     index: number;
   }) {
     if (payload.sections && payload.sections.length === 1) {
-      elements.value[payload.confKey][payload.sections[0]].splice(payload.index, 1);
+      elements.value[payload.confKey][payload.sections[0]].splice(
+        payload.index,
+        1
+      );
     } else if (
       payload.sections &&
       payload.sections.length === 2 &&
-      Object.keys(elements.value[payload.confKey]).indexOf(payload.sections[0]) !== -1
+      Object.keys(elements.value[payload.confKey]).indexOf(
+        payload.sections[0]
+      ) !== -1
     ) {
       elements.value[payload.confKey][payload.sections[0]][
         payload.sections[1]
@@ -178,6 +192,7 @@ export const useProjectConfStore = defineStore("project-config", () => {
   return {
     elements,
     emptyElement,
+    idfTargets,
     textDictionary,
     addNewConfigToList,
     addValueToConfigElement,


### PR DESCRIPTION
## Description

When the user is working with multiple profiles, the profile env should merge with `idf.customExtraVars` instead of fully replace it. This is necessary to support IDF_TARGET when sdkconfig file doesn't exists.

Fixes #1497
Fixes #1302

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Create a project with multiple profile configurations. See https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/project-configuration.html
2. Select a device using `ESP-IDF: Set Espressif Device Target` command. the `IDF_TARGET` should be saved in settings.json `idf.customExtraVars`
3. Delete the sdkconfig file. The IDF_TARGET in status bar should remains the same. When user tries to build it should also remain the same.

- Expected behaviour:
Even if sdkconfig file is deleted, the selected target is persisted with idf.customExtraVars["IDF_TARGET"]

- Expected output:

Status bar IDF_TARGET remains what is currently selected

## How has this been tested?

Manual testing using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
