### PR TITLE
fix build flash monitor release serial port

### DIFF
--- a/docs_espressif/en/settings.rst
+++ b/docs_espressif/en/settings.rst
@@ -192,8 +192,8 @@ Extension Behaviour Settings
       - Enable timestamps in IDF Monitor (default ``false``)
     * - **idf.monitorCustomTimestampFormat**
       - Custom timestamp format in IDF Monitor
-    * - **idf.monitorStartDelayBeforeDebug**
-      - Delay to start debug session after IDF monitor execution
+    * - **idf.monitorDelay**
+      - Delay to start debug session after IDF monitor execution or breaking monitor session (milliseconds).
     * - **idf.enableStatusBar**
       - Show or hide the extension status bar items
     * - **idf.enableSizeTaskAfterBuildTask**

--- a/docs_espressif/zh_CN/settings.rst
+++ b/docs_espressif/zh_CN/settings.rst
@@ -190,8 +190,8 @@ ESP-IDF 相关设置
       - 启用 IDF 监视器中的时间戳（该选项默认禁用）
     * - **idf.monitorCustomTimestampFormat**
       - 在 IDF 监视器中自定义时间戳格式
-    * - **idf.monitorStartDelayBeforeDebug**
-      - 启动 IDF 监视器后延迟开始调试会话
+    * - **idf.monitorDelay**
+      - 在执行 IDF 监视器或中断监视器会话后启动调试会话的延迟（毫秒）。
     * - **idf.enableStatusBar**
       - 显示或隐藏扩展状态栏项目
     * - **idf.enableSizeTaskAfterBuildTask**

--- a/package.json
+++ b/package.json
@@ -1077,7 +1077,7 @@
           },
           "idf.monitorStartDelayBeforeDebug": {
             "type": "number",
-            "default": 5000,
+            "default": 1000,
             "scope": "resource",
             "description": "%param.monitorStartDelayBeforeDebug%"
           },

--- a/package.json
+++ b/package.json
@@ -1075,11 +1075,11 @@
             "scope": "resource",
             "description": "%param.deleteComponentsOnFullClean%"
           },
-          "idf.monitorStartDelayBeforeDebug": {
+          "idf.monitorDelay": {
             "type": "number",
             "default": 1000,
             "scope": "resource",
-            "description": "%param.monitorStartDelayBeforeDebug%"
+            "description": "%param.monitorDelay%"
           },
           "idf.monitorNoReset": {
             "type": "boolean",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -132,7 +132,7 @@
 	"param.monitorCustomTimestampFormat": "Formato de marca de tiempo personalizado en Monitor IDF",
 	"param.monitorEnableTimestamps": "Habilitar marcas de tiempo en Monitor IDF",
 	"param.monitorNoReset": "Habilitar bandera de no reinicio en Monitor IDF",
-	"param.monitorStartDelayBeforeDebug": "Retraso para iniciar la sesión de depuración después de la ejecución del monitor IDF (ms)",
+	"param.monitorDelay": "Retraso para iniciar la sesión de depuración después de la ejecución del monitor IDF o al interrumpir la sesión del monitor (ms)",
 	"param.ninjaArgs": "Argumentos para tarea de construcción Ninja",
 	"param.notificationMode": "Modo de notificaciones de la extensión ESP-IDF y modo de enfoque de salida.",
 	"param.notificationMode.all": "Mostrar notificaciones y enfocar la salida de tareas.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -132,7 +132,7 @@
   "param.monitorCustomTimestampFormat": "Custom timestamp format in IDF monitor",
   "param.monitorEnableTimestamps": "Enable timestamps in IDF monitor",
   "param.monitorNoReset": "Enable no-reset flag to IDF monitor",
-  "param.monitorStartDelayBeforeDebug": "Delay to start debug session after IDF monitor execution (ms)",
+  "param.monitorDelay": "Delay to start debug session after IDF monitor execution or breaking monitor session (ms)",
   "param.ninjaArgs": "Arguments for Ninja build task",
   "param.notificationMode": "ESP-IDF extension notifications and output focus mode",
   "param.notificationMode.all": "Show notifications and focus on tasks output",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -132,7 +132,7 @@
 	"param.monitorCustomTimestampFormat": "Formato de carimbo de data/hora personalizado no IDF Monitor",
 	"param.monitorEnableTimestamps": "Habilitar carimbos de data/hora no IDF Monitor",
 	"param.monitorNoReset": "Habilite o sinalizador de não reinicialização para o IDF Monitor",
-	"param.monitorStartDelayBeforeDebug": "Atraso para iniciar a sessão de depuração após a execução do monitor IDF (ms)",
+	"param.monitorDelay": "Atraso para iniciar a sessão de depuração após a execução do monitor IDF ou ao interromper a sessão do monitor (ms)",
 	"param.ninjaArgs": "Argumentos para tarefa de construção Ninja",
 	"param.notificationMode": "Notificações de extensão ESP-IDF e modo de foco de saída.",
 	"param.notificationMode.all": "Mostre notificações e concentre a saída das tarefas.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -132,7 +132,7 @@
 	"param.monitorCustomTimestampFormat": "Пользовательский формат временной метки в мониторе IDF",
 	"param.monitorEnableTimestamps": "Включить временные метки в мониторе IDF",
 	"param.monitorNoReset": "Включить флаг no-reset для монитора IDF",
-	"param.monitorStartDelayBeforeDebug": "Задержка начала сеанса отладки после запуска монитора IDF (мс)",
+	"param.monitorDelay": "Задержка перед запуском сеанса отладки после выполнения IDF-монитора или при прерывании сеанса монитора (мс)",
 	"param.ninjaArgs": "Аргументы Ninja в задаче сборки",
 	"param.notificationMode": "Уведомления расширениия ESP-IDF и режим фокусировки вывода",
 	"param.notificationMode.all": "Показывать уведомления и фокусировать вывод задач",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -132,7 +132,7 @@
 	"param.monitorCustomTimestampFormat": "在 IDF 监视器中自定义时间戳格式",
 	"param.monitorEnableTimestamps": "启用 IDF 监视器中的时间戳",
 	"param.monitorNoReset": "启用 IDF 监视器的不重置标志",
-	"param.monitorStartDelayBeforeDebug": "运行 IDF 监视器后延迟启动调试会话 (ms)",
+	"param.monitorDelay": "在执行 IDF 监视器或中断监视器会话后启动调试会话的延迟（毫秒）",
 	"param.ninjaArgs": "Ninja 构建任务的参数",
 	"param.notificationMode": "选择 ESP-IDF 扩展的通知和输出窗口显示",
 	"param.notificationMode.all": "显示通知，并切换到任务输出窗口",

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -129,7 +129,7 @@ export async function createNewIdfMonitor(
     const idfVersion = await utils.getEspIdfFromCMake(idfPath);
     if (idfVersion <= "5.0") {
       const monitorDelay = readParameter(
-        "idf.monitorStartDelayBeforeDebug",
+        "idf.monitorDelay",
         workspaceFolder
       ) as number;
       await utils.sleep(monitorDelay);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -695,6 +695,11 @@ export async function activate(context: vscode.ExtensionContext) {
     PreCheck.perform([webIdeCheck, openFolderCheck], async () => {
       if (IDFMonitor.terminal) {
         IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
+        const monitorDelay = idfConf.readParameter(
+          "idf.monitorStartDelayBeforeDebug",
+          workspaceRoot
+        ) as number;
+        await utils.sleep(monitorDelay);
       }
       const pythonBinPath = await getVirtualEnvPythonPath(workspaceRoot);
       const idfPathDir = idfConf.readParameter(
@@ -4219,6 +4224,11 @@ async function startFlashing(
 
   if (IDFMonitor.terminal) {
     IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
+    const monitorDelay = idfConf.readParameter(
+      "idf.monitorStartDelayBeforeDebug",
+      workspaceRoot
+    ) as number;
+    await utils.sleep(monitorDelay);
   }
 
   if (encryptPartitions) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4217,6 +4217,10 @@ async function startFlashing(
     flashType = await selectFlashMethod();
   }
 
+  if (IDFMonitor.terminal) {
+    IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
+  }
+
   if (encryptPartitions) {
     const encryptionValidationResult = await checkFlashEncryption(
       flashType,
@@ -4239,9 +4243,6 @@ async function startFlashing(
     "idf.flashBaudRate",
     workspaceRoot
   );
-  if (IDFMonitor.terminal) {
-    IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
-  }
   const canFlash = await verifyCanFlash(
     flashBaudRate,
     port,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -696,7 +696,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (IDFMonitor.terminal) {
         IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
         const monitorDelay = idfConf.readParameter(
-          "idf.monitorStartDelayBeforeDebug",
+          "idf.monitorDelay",
           workspaceRoot
         ) as number;
         await utils.sleep(monitorDelay);
@@ -4225,7 +4225,7 @@ async function startFlashing(
   if (IDFMonitor.terminal) {
     IDFMonitor.terminal.sendText(ESP.CTRL_RBRACKET);
     const monitorDelay = idfConf.readParameter(
-      "idf.monitorStartDelayBeforeDebug",
+      "idf.monitorDelay",
       workspaceRoot
     ) as number;
     await utils.sleep(monitorDelay);


### PR DESCRIPTION
## Description

The IDF Monitor should send `CTRL + ]` before flash encryption verification.

Fixes #1494

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Build Flash Monitor" command. Make sure that the Monitor is released before is used again.
2. Execute action. Make sure that the Monitor is released before is used again.
3. Observe results.

- Expected behaviour:
Make sure that the Monitor is released before is used again when using build flash monitor command.

- Expected output:
Make sure that the Monitor is released before is used again.

## How has this been tested?

Manual testing with steps above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): macOS Windows 11

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
