### PR TITLE
remove use of editor tab size set static 2 spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/Issue-report.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Doctor command output
       description: What is the output of the 'ESP-IDF Doctor command' command?
-      placeholder: ex. DevKitC, plain module on breadboard, etc. If your hardware is custom or unusual, please attach a photo.
+      placeholder: A doctor command output is a list of all the tools and their versions that are installed in your system.
     validations:
       required: true
   - type: textarea
@@ -64,7 +64,7 @@ body:
       label: Extension
       description: |
         Please share related content of extension log file located in:
-        * Windows (%USERPROFILE%\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log)
+        * Windows (%USERPROFILE%\\.vscode\extensions\espressif.esp-idf-extension-VERSION\esp_idf_vsc_ext.log)
         * Linux-MacOS ($HOME/.vscode/extensions/espressif.esp-idf-extension-VERSION/esp_idf_vsc_ext.log)
   - type: textarea
     id: Description

--- a/src/examples/ExamplesPanel.ts
+++ b/src/examples/ExamplesPanel.ts
@@ -235,7 +235,7 @@ export class ExamplesPlanel {
       settingsJson["idf.pythonInstallPath"] = idfSetup.sysPythonPath;
     }
     await writeJSON(settingsJsonPath, settingsJson, {
-      spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+      spaces: 2,
     });
   }
 }

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -72,7 +72,9 @@ export class NewProjectPanel {
       localResourceRoots.push(vscode.Uri.file(newProjectArgs.espAdfPath));
     }
     if (newProjectArgs.espIdfSetup.idfPath) {
-      localResourceRoots.push(vscode.Uri.file(newProjectArgs.espIdfSetup.idfPath));
+      localResourceRoots.push(
+        vscode.Uri.file(newProjectArgs.espIdfSetup.idfPath)
+      );
     }
     if (newProjectArgs.espMdfPath) {
       localResourceRoots.push(vscode.Uri.file(newProjectArgs.espMdfPath));
@@ -172,7 +174,10 @@ export class NewProjectPanel {
             const defConfigFiles =
               newProjectArgs.boards && newProjectArgs.boards.length > 0
                 ? newProjectArgs.boards[0].configFiles.join(",")
-                : ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32.cfg"].join(",");
+                : [
+                    "interface/ftdi/esp32_devkitj_v1.cfg",
+                    "target/esp32.cfg",
+                  ].join(",");
             this.panel.webview.postMessage({
               boards: newProjectArgs.boards,
               command: "initialLoad",
@@ -292,8 +297,7 @@ export class NewProjectPanel {
             workspaceFolder
           );
           await writeJSON(settingsJsonPath, settingsJson, {
-            spaces:
-              vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+            spaces: 2,
           });
 
           if (components && components.length > 0) {
@@ -316,7 +320,11 @@ export class NewProjectPanel {
           }
         } catch (error) {
           OutputChannel.appendLine(error.message);
-          Logger.errorNotify(error.message, error, "NewProjectPanel createProject");
+          Logger.errorNotify(
+            error.message,
+            error,
+            "NewProjectPanel createProject"
+          );
         }
       }
     );

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -207,12 +207,7 @@ export async function writeTextReport(
   }
   if (reportedResult.latestError) {
     output += `----------------------------------------------------------- Latest error -----------------------------------------------------------------${EOL}`;
-    output +=
-      JSON.stringify(
-        reportedResult.latestError,
-        undefined,
-        vscode.workspace.getConfiguration().get("editor.tabSize") || 2
-      ) + EOL;
+    output += JSON.stringify(reportedResult.latestError, undefined, 2) + EOL;
   }
   output += lineBreak;
   const logFile = join(context.extensionPath, "esp_idf_vsc_ext.log");
@@ -226,7 +221,7 @@ export async function writeTextReport(
   await writeFile(resultFile, output);
   const resultJson = join(context.extensionPath, "report.json");
   await writeJson(resultJson, reportedResult, {
-    spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+    spaces: 2,
   });
   return output;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -323,7 +323,7 @@ export async function updateCCppPropertiesJson(
   ) {
     cCppPropertiesJson.configurations[0][fieldToUpdate] = newFieldValue;
     await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
-      spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+      spaces: 2,
     });
   }
 }
@@ -519,7 +519,7 @@ export function readJson(jsonPath: string) {
 
 export function writeJson(jsonPath: string, object: any) {
   return writeJSON(jsonPath, object, {
-    spaces: vscode.workspace.getConfiguration().get("editor.tabSize") || 2,
+    spaces: 2,
   });
 }
 


### PR DESCRIPTION
## Description

Remove use of `editor.tabSize` to determine spaces equivalent for tabs in generated json files such as c_cpp_properties.json, settings.json, etc.

Fixes #1503
Fixes #1506 
Fixes #1509

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: New Project" to create a new project. All json files should have a fixed 2 spaces tab size.

- Expected behaviour:
All json files should have a fixed 2 spaces tab size.

- Expected output:

## How has this been tested?

Manual testing with steps above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows MacOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
