### PR TITLE
[VSC-1642] add current setup to list of setups in examples new project wizards

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -4,7 +4,7 @@
   " has been updated": " ha sido actualizado",
   "File project_description.json cannot be found.": "No se puede encontrar el archivo project_description.json.",
   "Open a folder first.": "Primero abra una carpeta.",
-  "Selected command is not available in Codespaces": "El comando seleccionado no está disponible en Codespaces",
+  "Selected command is not available in {envName}": "El comando seleccionado no está disponible en {envName}",
   "Use current folder: {workspace}": "Usar carpeta actual: {workspace}",
   "Choose a container directory...": "Elija un directorio de contenedor...",
   "Select a directory to use": "Seleccione un directorio para usar",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -4,7 +4,7 @@
   " has been updated": " foi atualizado",
   "File project_description.json cannot be found.": "O arquivo project_description.json não pode ser encontrado.",
   "Open a folder first.": "Abra uma pasta primeiro.",
-  "Selected command is not available in Codespaces": "O comando selecionado não está disponível no Codespaces",
+  "Selected command is not available in {envName}": "O comando selecionado não está disponível no {envName}",
   "Use current folder: {workspace}": "Use a pasta atual: {workspace}",
   "Choose a container directory...": "Escolha um diretório de contêiner...",
   "Select a directory to use": "Selecione um diretório para usar",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -4,7 +4,7 @@
   " has been updated": " был обновлен",
   "File project_description.json cannot be found.": "Файл project_description.json не найден.",
   "Open a folder first.": "Сначала откройте папку.",
-  "Selected command is not available in Codespaces": "Выбранная команда недоступна в Codespaces",
+  "Selected command is not available in {envName}": "Выбранная команда недоступна в {envName}",
   "Use current folder: {workspace}": "Использовать текущую папку: {workspace}",
   "Choose a container directory...": "Выберите каталог контейнера...",
   "Select a directory to use": "Выберите каталог для использования",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -4,7 +4,7 @@
   " has been updated": " 已经升级",
   "File project_description.json cannot be found.": "找不到 project_description.json 文件。",
   "Open a folder first.": "先打开一个文件夹。",
-  "Selected command is not available in Codespaces": "所选命令在 Codespaces 中不可用",
+  "Selected command is not available in {envName}": "所选命令在 {envName} 中不可用",
   "Use current folder: {workspace}": "使用当前文件夹：{workspace}",
   "Choose a container directory...": "选择容器目录…",
   "Select a directory to use": "选择目录",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -224,7 +224,12 @@ let wsServer: WSServer;
 
 const openFolderFirstMsg = vscode.l10n.t("Open a folder first.");
 const cmdNotForWebIdeMsg = vscode.l10n.t(
-  "Selected command is not available in Codespaces"
+  "Selected command is not available in {envName}",
+  { envName: "Codespaces" }
+);
+const cmdNotDockerContainerMsg = vscode.l10n.t(
+  "Selected command is not available in {envName}",
+  { envName: "Docker container" }
 );
 const openFolderCheck = [
   PreCheck.isWorkspaceFolderOpen,
@@ -233,6 +238,10 @@ const openFolderCheck = [
 const webIdeCheck = [
   PreCheck.notUsingWebIde,
   cmdNotForWebIdeMsg,
+] as utils.PreCheckInput;
+const isNotDockerContainerCheck = [
+  PreCheck.isNotDockerContainer,
+  cmdNotDockerContainerMsg,
 ] as utils.PreCheckInput;
 
 const minIdfVersionCheck = async function (
@@ -2054,7 +2063,7 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   registerIDFCommand("espIdf.setup.start", (setupArgs?: ISetupInitArgs) => {
-    PreCheck.perform([webIdeCheck], async () => {
+    PreCheck.perform([webIdeCheck, isNotDockerContainerCheck], async () => {
       try {
         if (SetupPanel.isCreatedAndHidden()) {
           SetupPanel.createOrShow(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3904,7 +3904,8 @@ async function getFrameworksPickItems() {
       );
       existingIdfSetups = [...existingIdfSetups, ...systemIdfSetups];
     }
-    let setupsToUse = [...idfSetups, ...existingIdfSetups];
+    const currentIdfSetup = await getCurrentIdfSetup(workspaceRoot);
+    let setupsToUse = [...idfSetups, ...existingIdfSetups, currentIdfSetup];
     setupsToUse = setupsToUse.filter(
       (setup, index, self) =>
         index ===
@@ -3921,7 +3922,6 @@ async function getFrameworksPickItems() {
         setupsToUse.filter((i) => i.isValid).map((item) => [item.idfPath, item])
       ).values(),
     ];
-    const currentIdfSetup = await getCurrentIdfSetup(workspaceRoot);
     for (const idfSetup of onlyValidIdfSetups) {
       pickItems.push({
         description: `ESP-IDF v${idfSetup.version}`,

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -113,7 +113,6 @@ export class IdfToolsManager {
       const packagesToInstall = this.allPackages.filter((pkg) => {
         return (
           pkg.install === "always" ||
-          pkg.name === "esp-clang" ||
           (onReqPkgs &&
             pkg.install === "on_request" &&
             onReqPkgs.indexOf(pkg.name) > -1)

--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -29,6 +29,7 @@ import {
 } from "../setup/existingIdfSetups";
 import { IdfSetup } from "../views/setup/types";
 import { getTargetsFromEspIdf, IdfTarget } from "../espIdf/setTarget/getTargets";
+import { getCurrentIdfSetup } from "../versionSwitcher";
 
 export interface INewProjectArgs {
   espIdfSetup: IdfSetup;
@@ -80,7 +81,8 @@ export async function getNewProjectArgs(
     );
     existingIdfSetups = [...existingIdfSetups, ...systemIdfSetups];
   }
-  let setupsToUse = [...idfSetups, ...existingIdfSetups];
+  const currentIdfSetup = await getCurrentIdfSetup(workspace);
+  let setupsToUse = [...idfSetups, ...existingIdfSetups, currentIdfSetup];
   setupsToUse = setupsToUse.filter(
     (setup, index, self) =>
       index ===

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -152,6 +152,7 @@ export async function getSetupInitialValues(
     pythonVersions,
     saveScope,
     workspaceFolder,
+    onReqPkgs: ["esp-clang"],
   } as ISetupInitArgs;
 
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,6 +89,9 @@ export class PreCheck {
       vscode.workspace.workspaceFolders.length > 0
     );
   }
+  public static isNotDockerContainer(): boolean {
+    return vscode.env.remoteName !== "dev-container";
+  }
   public static notUsingWebIde(): boolean {
     if (vscode.env.remoteName === "codespaces") {
       return false;

--- a/src/versionSwitcher/index.ts
+++ b/src/versionSwitcher/index.ts
@@ -44,7 +44,8 @@ export async function selectIdfSetup(
     );
     existingIdfSetups = [...existingIdfSetups, ...systemIdfSetups];
   }
-  let idfSetups = [...globalStateSetups, ...existingIdfSetups];
+  const currentIdfSetup = await getCurrentIdfSetup(workspaceFolder);
+  let idfSetups = [...globalStateSetups, ...existingIdfSetups, currentIdfSetup];
   idfSetups = idfSetups.filter(
     (setup, index, self) =>
       index ===


### PR DESCRIPTION
## Description

Fix `ESP-IDF: Show Examples` and `ESP-IDF: New Project` command to show current idf setup from Docker environment for example.

Fixes #1501

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open an ESP-IDF project in a docker container with `Reopen in container` command.  Make sure that the project doesn't have idf.espIdfPath or other settings from host machine to avoid issues in `<project-dir>/.vscode/settings.json`
2. Uninstall the existing ESP-IDF that is preinstall in the docker container (current version from marketplace) and delete `~/.vscode/extension/espressif-*` directory.
4. Install from VSIX using the artifact from this PR.
5. `ESP-IDF: Show Examples` and `ESP-IDF: New Project` command should show the docker environment ESP-IDF setup and you are able to create project from examples.

- Expected behaviour:

`ESP-IDF: Show Examples` and `ESP-IDF: New Project` command should show the docker environment ESP-IDF setup and you are able to create project from examples.

## How has this been tested?

Manual testing using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): Windows using Docker Container

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
