### PR TITLE
add status bar item names

### DIFF
--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -290,7 +290,7 @@ export class OpenOCDManager extends EventEmitter {
       vscode.StatusBarAlignment.Right,
       1000
     );
-    this.statusBar.text = "[ESP-IDF: OpenOCD Server]";
+    this.statusBar.name = this.statusBar.text = "[ESP-IDF: OpenOCD Server]";
     const commandDictionary = createCommandDictionary();
     this.statusBar.tooltip = commandDictionary[CommandKeys.OpenOCD].tooltip;
     this.statusBar.command = CommandKeys.OpenOCD;

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -113,7 +113,10 @@ export class QemuManager extends EventEmitter {
       "idf.qemuExtraArgs",
       workspaceFolder
     ) as string[];
-    const idfPathDir = readParameter("idf.espIdfPath", workspaceFolder) as string;
+    const idfPathDir = readParameter(
+      "idf.espIdfPath",
+      workspaceFolder
+    ) as string;
     const idfPy = join(idfPathDir, "tools", "idf.py");
     let launchArgs = [idfPy, "-B", buildPath, "qemu"];
 
@@ -123,7 +126,10 @@ export class QemuManager extends EventEmitter {
     if (extraArgs && Array.isArray(extraArgs) && extraArgs.length > 0) {
       launchArgs.push(...extraArgs);
     }
-    if (mode === QemuLaunchMode.Monitor || mode === QemuLaunchMode.DebugMonitor) {
+    if (
+      mode === QemuLaunchMode.Monitor ||
+      mode === QemuLaunchMode.DebugMonitor
+    ) {
       launchArgs.push("monitor");
     }
     return launchArgs;
@@ -235,7 +241,7 @@ export class QemuManager extends EventEmitter {
         StatusBarAlignment.Right,
         1005
       );
-      this._statusBarItem.text = "[ESP-IDF: QEMU]";
+      this._statusBarItem.name = this._statusBarItem.text = "[ESP-IDF: QEMU]";
       const commandDictionary = createCommandDictionary();
       this._statusBarItem.tooltip =
         commandDictionary[CommandKeys.QemuServer].tooltip;

--- a/src/statusBar/index.ts
+++ b/src/statusBar/index.ts
@@ -127,12 +127,13 @@ export async function createCmdsStatusBarItems(workspaceFolder: Uri) {
     }
   }
 
-   // Only create the project configuration status bar item if the configuration file exists
-   if (projectConfExists) {
+  // Only create the project configuration status bar item if the configuration file exists
+  if (projectConfExists) {
     if (!projectConf) {
       // No configuration selected but file exists with configurations
       let statusBarItemName = "No Configuration Selected";
-      let statusBarItemTooltip = "No project configuration selected. Click to select one";
+      let statusBarItemTooltip =
+        "No project configuration selected. Click to select one";
       statusBarItems["projectConf"] = createStatusBarItem(
         `$(${
           commandDictionary[CommandKeys.SelectProjectConfiguration].iconId
@@ -246,6 +247,7 @@ export function createStatusBarItem(
 ) {
   const alignment: StatusBarAlignment = StatusBarAlignment.Left;
   const statusBarItem = window.createStatusBarItem(cmd, alignment, priority);
+  statusBarItem.name = tooltip;
   statusBarItem.text = icon;
   statusBarItem.tooltip = tooltip;
   statusBarItem.command = cmd;


### PR DESCRIPTION
## Description

Status bar items when you click right them should show the name of the command they will execute. Before was only as described in tooltip.

Fixes #1512

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Right click an status bar item from this extension
2. The tooltip text should be shown in the list of status bar items shown.

![Screenshot 2025-04-18 at 09 36 32](https://github.com/user-attachments/assets/b48370e1-7ed6-40c3-9207-d5ac49a2914b)


- Expected behaviour:

Status bar item should show meaningful text for right click (to enable disable status bar item).

- Expected output:

## How has this been tested?

Manual testing as described above

**Test Configuration**:
* ESP-IDF Version: Doesn't matter
* OS (Windows,Linux and macOS): Doesn't matter.

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
