### PR TITLE
[VSC-1639] add HOMEPATH to log file output in doctor command

### DIFF
--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -217,7 +217,7 @@ export async function writeTextReport(
   if (logFileExists) {
     const logFileContent = await readFile(logFile, "utf8");
     output += `----------------------------------------------------------- Logfile -----------------------------------------------------------------${EOL}`;
-    output += logFileContent + EOL + lineBreak;
+    output += replaceUserPathInStr(logFileContent) + EOL + lineBreak;
   }
   const resultFile = join(context.extensionPath, "report.txt");
   await writeFile(resultFile, output);
@@ -232,6 +232,12 @@ export function replaceUserPath(report: reportObj): reportObj {
   const strReport = JSON.stringify(report);
 
   // Replacing all home paths (based on OS) with '...' using es6 syntax. Can be replaced with one line using .replaceAll() when we will update the version of ECMAScript to 2021 or higher
+  const parsedReport = replaceUserPathInStr(strReport);
+
+  return JSON.parse(parsedReport);
+}
+
+function replaceUserPathInStr(strReport: string) {
   let re = new RegExp(process.env.HOME, "g");
   if (process.env.windir) {
     const reWin = new RegExp("\\\\", "g");
@@ -239,6 +245,5 @@ export function replaceUserPath(report: reportObj): reportObj {
     re = new RegExp(result, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");
-
-  return JSON.parse(parsedReport);
+  return parsedReport;
 }

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -244,8 +244,11 @@ function replaceUserPathInStr(strReport: string) {
       /[.*+?^${}()|[\]\\]/g,
       "\\$&"
     );
-    const PosixResult = escapedHomePath.replace(reWin, "/");
-    re = new RegExp(`(${escapedHomePath}|${PosixResult})`, "g");
+    const result = escapedHomePath.replace(reWin, "\\\\");
+    const PosixResult = escapedHomePath
+      .replace(reWin, "/")
+      .replace(/\/+/g, "/");
+    re = new RegExp(`(${result}|${PosixResult})`, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");
   return parsedReport;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -19,7 +19,6 @@ import { pathExists, readFile, writeFile, writeJson } from "fs-extra";
 import { EOL } from "os";
 import { join } from "path";
 import * as vscode from "vscode";
-import { Logger } from "../logger/logger";
 import { reportObj } from "./types";
 
 export async function writeTextReport(
@@ -241,8 +240,14 @@ function replaceUserPathInStr(strReport: string) {
   let re = new RegExp(process.env.HOME, "g");
   if (process.env.windir) {
     const reWin = new RegExp("\\\\", "g");
-    const result = process.env.HOMEPATH.replace(reWin, "\\\\\\\\");
-    const PosixResult = process.env.HOMEPATH.replace(reWin, "/");
+    const result = process.env.HOMEPATH.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    ).replace(reWin, "\\\\\\\\");
+    const PosixResult = process.env.HOMEPATH.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    ).replace(reWin, "/");
     re = new RegExp(`(${result}|${PosixResult})`, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -253,8 +253,9 @@ function replaceUserPathInStr(strReport: string) {
     const re = new RegExp(pattern, "g");
     return strReport.replace(re, "<HOMEPATH>");
   } else {
-    // For non-Windows systems, just replace the home directory
-    const re = new RegExp(process.env.HOME, "g");
+    // For non-Windows systems, escape HOME path for regex
+    const escapedHome = process.env.HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(escapedHome, "g");
     return strReport.replace(re, "<HOMEPATH>");
   }
 }

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -242,7 +242,8 @@ function replaceUserPathInStr(strReport: string) {
   if (process.env.windir) {
     const reWin = new RegExp("\\\\", "g");
     const result = process.env.HOMEPATH.replace(reWin, "\\\\\\\\");
-    re = new RegExp(result, "g");
+    const PosixResult = process.env.HOMEPATH.replace(reWin, "/");
+    re = new RegExp(`(${result}|${PosixResult})`, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");
   return parsedReport;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -244,9 +244,8 @@ function replaceUserPathInStr(strReport: string) {
       /[.*+?^${}()|[\]\\]/g,
       "\\$&"
     );
-    const result = escapedHomePath.replace(reWin, "\\\\\\\\");
     const PosixResult = escapedHomePath.replace(reWin, "/");
-    re = new RegExp(`(${result}|${PosixResult})`, "g");
+    re = new RegExp(`(${escapedHomePath}|${PosixResult})`, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");
   return parsedReport;

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -237,19 +237,17 @@ export function replaceUserPath(report: reportObj): reportObj {
 }
 
 function replaceUserPathInStr(strReport: string) {
-  let re = new RegExp(process.env.HOME, "g");
   if (process.env.windir) {
-    const reWin = new RegExp("\\\\", "g");
-    const escapedHomePath = process.env.HOMEPATH.replace(
-      /[.*+?^${}()|[\]\\]/g,
-      "\\$&"
-    );
-    const result = escapedHomePath.replace(reWin, "\\\\");
-    const PosixResult = escapedHomePath
-      .replace(reWin, "/")
-      .replace(/\/+/g, "/");
-    re = new RegExp(`(${result}|${PosixResult})`, "g");
+    const homePath = process.env.HOMEPATH;
+    const pattern = `(${homePath.replace(/\\/g, "\\\\\\\\")}|${homePath.replace(
+      /\\/g,
+      "/"
+    )})`;
+    const re = new RegExp(pattern, "g");
+    return strReport.replace(re, "<HOMEPATH>");
+  } else {
+    // For non-Windows systems, just replace the home directory
+    const re = new RegExp(process.env.HOME, "g");
+    return strReport.replace(re, "<HOMEPATH>");
   }
-  const parsedReport = strReport.replace(re, "<HOMEPATH>");
-  return parsedReport;
 }

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -239,10 +239,17 @@ export function replaceUserPath(report: reportObj): reportObj {
 function replaceUserPathInStr(strReport: string) {
   if (process.env.windir) {
     const homePath = process.env.HOMEPATH;
-    const pattern = `(${homePath.replace(/\\/g, "\\\\\\\\")}|${homePath.replace(
-      /\\/g,
-      "/"
-    )})`;
+    // Escape the path for regex, but keep backslashes as is
+    const escapedPath = homePath.replace(/[.*+?^${}()|[\]\\]/g, (match) => {
+      return match === "\\" ? "\\\\" : "\\" + match;
+    });
+    // Create pattern that matches both Windows and Posix style
+    const posixPath = homePath
+      .replace(/\\/g, "/")
+      .replace(/[.*+?^${}()|[\]\\]/g, (match) => {
+        return match === "/" ? "/" : "\\" + match;
+      });
+    const pattern = `(${escapedPath}|${posixPath})`;
     const re = new RegExp(pattern, "g");
     return strReport.replace(re, "<HOMEPATH>");
   } else {

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -240,14 +240,12 @@ function replaceUserPathInStr(strReport: string) {
   let re = new RegExp(process.env.HOME, "g");
   if (process.env.windir) {
     const reWin = new RegExp("\\\\", "g");
-    const result = process.env.HOMEPATH.replace(
+    const escapedHomePath = process.env.HOMEPATH.replace(
       /[.*+?^${}()|[\]\\]/g,
       "\\$&"
-    ).replace(reWin, "\\\\\\\\");
-    const PosixResult = process.env.HOMEPATH.replace(
-      /[.*+?^${}()|[\]\\]/g,
-      "\\$&"
-    ).replace(reWin, "/");
+    );
+    const result = escapedHomePath.replace(reWin, "\\\\\\\\");
+    const PosixResult = escapedHomePath.replace(reWin, "/");
     re = new RegExp(`(${result}|${PosixResult})`, "g");
   }
   const parsedReport = strReport.replace(re, "<HOMEPATH>");

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -241,7 +241,7 @@ function replaceUserPathInStr(strReport: string) {
     const homePath = process.env.HOMEPATH;
     // Escape the path for regex, but keep backslashes as is
     const escapedPath = homePath.replace(/[.*+?^${}()|[\]\\]/g, (match) => {
-      return match === "\\" ? "\\\\" : "\\" + match;
+      return match === "\\" ? "\\\\\\\\" : "\\" + match;
     });
     // Create pattern that matches both Windows and Posix style
     const posixPath = homePath


### PR DESCRIPTION
## Description

Replace user HOME path with <HOMEPATH> for doctor command log file output.

Fixes #1496

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Doctor Command" from command palette.
2. Execute action. 
3. Observe results. The log file section should show <HOMEPATH> instead of the user HOME path.

- Expected behaviour:
The log file section should show <HOMEPATH> instead of the user HOME path.

- Expected output:
The log file section should show <HOMEPATH> instead of the user HOME path.

## How has this been tested?

Steps as described above.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
