### PR TITLE
[VSC-1661] use createQuickPick for openocd board to show currently active item.

### DIFF
--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -176,7 +176,8 @@ export async function selectOpenOcdConfigFiles(
         await writeParameter(
           "idf.openOcdConfigs",
           selectedBoard.target.configFiles,
-          ConfigurationTarget.WorkspaceFolder
+          ConfigurationTarget.WorkspaceFolder,
+          workspaceFolder
         );
         Logger.infoNotify(
           l10n.t("OpenOCD Board configuration files are updated.")

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -23,7 +23,6 @@ import {
   WorkspaceFolder,
   window,
   l10n,
-  QuickPickItem,
 } from "vscode";
 import {
   NotificationMode,
@@ -32,11 +31,7 @@ import {
 } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
-import {
-  getBoards,
-  getOpenOcdScripts,
-  IdfBoard,
-} from "../openOcd/boardConfiguration";
+import { selectOpenOcdConfigFiles } from "../openOcd/boardConfiguration";
 import { getTargetsFromEspIdf } from "./getTargets";
 import { setTargetInIDF } from "./setTargetInIdf";
 import { updateCurrentProfileIdfTarget } from "../../project-conf";
@@ -79,72 +74,11 @@ export async function setIdfTarget(
         if (!selectedTarget) {
           return;
         }
-        const openOcdScriptsPath = await getOpenOcdScripts(workspaceFolder.uri);
-        const boards = await getBoards(
-          openOcdScriptsPath,
+        await selectOpenOcdConfigFiles(
+          workspaceFolder.uri,
           selectedTarget.target
         );
-        const currentOpenOcdConfigs = readParameter(
-          "idf.openOcdConfigs",
-          workspaceFolder.uri
-        ) as string[];
-        const choices = boards.map((b) => {
-          return {
-            description: `${b.description} (${b.configFiles})`,
-            label: b.name,
-            target: b,
-            picked: currentOpenOcdConfigs
-              .join(",")
-              .includes(b.configFiles.join(",")),
-          };
-        });
-        const selectOpenOCdConfigsMsg = l10n.t(
-          "Enter OpenOCD Configuration File Paths list"
-        );
 
-        const boardQuickPick = window.createQuickPick<{
-          description: string;
-          label: string;
-          target: IdfBoard;
-          picked: boolean;
-        }>();
-        boardQuickPick.items = choices;
-        boardQuickPick.placeholder = selectOpenOCdConfigsMsg;
-        boardQuickPick.onDidHide(() => {
-          boardQuickPick.dispose();
-        });
-        boardQuickPick.activeItems = boardQuickPick.items.filter(
-          (item) => item.picked
-        );
-
-        boardQuickPick.onDidAccept(async () => {
-          const selectedBoard = boardQuickPick.selectedItems[0];
-          if (!selectedBoard) {
-            Logger.infoNotify(
-              `ESP-IDF board not selected. Remember to set the configuration files for OpenOCD with idf.openOcdConfigs`
-            );
-          } else if (selectedBoard && selectedBoard.target) {
-            if (selectedBoard.label.indexOf("Custom board") !== -1) {
-              const inputBoard = await window.showInputBox({
-                placeHolder: "Enter comma-separated configuration files",
-                value: selectedBoard.target.configFiles.join(","),
-              });
-              if (inputBoard) {
-                selectedBoard.target.configFiles = inputBoard.split(",");
-              }
-            }
-            await writeParameter(
-              "idf.openOcdConfigs",
-              selectedBoard.target.configFiles,
-              ConfigurationTarget.WorkspaceFolder
-            );
-            Logger.infoNotify(
-              l10n.t("OpenOCD Board configuration files are updated.")
-            );
-          }
-          boardQuickPick.hide();
-        });
-        boardQuickPick.show();
         await setTargetInIDF(workspaceFolder, selectedTarget);
         const customExtraVars = readParameter(
           "idf.customExtraVars",


### PR DESCRIPTION
## Description

Add quick pick functionality with currently selected option.

Fixes #1524
Fixes #1543

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Select OpenOCD Configuration"
2. Execute action. The currently selected OpenOCD board should be highlighted.
3. Observe results.

- Expected behaviour:
The currently selected OpenOCD board should be highlighted.

- Expected output:

## How has this been tested?

Manual testing with steps above.

**Test Configuration**:
* ESP-IDF Version: 5.1.6
* OS (Windows,Linux and macOS): macOS


## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
