### PR TITLE
[VSC-1671]Bugfix/new project no workspace

### DIFF
--- a/src/espIdf/setTarget/getTargets.ts
+++ b/src/espIdf/setTarget/getTargets.ts
@@ -40,11 +40,16 @@ export async function getTargetsFromEspIdf(
   const pythonBinPath = await getVirtualEnvPythonPath(workspaceFolder);
   const resultTargetArray: IdfTarget[] = [];
 
+  const dirToUse =
+    workspaceFolder && workspaceFolder.fsPath
+      ? workspaceFolder.fsPath
+      : process.cwd();
+
   const listTargetsResult = await spawn(
     pythonBinPath,
     [idfPyPath, "--list-targets"],
     {
-      cwd: workspaceFolder.fsPath,
+      cwd: dirToUse,
       env: modifiedEnv,
     },
     undefined,
@@ -64,7 +69,7 @@ export async function getTargetsFromEspIdf(
     pythonBinPath,
     [idfPyPath, "--preview", "--list-targets"],
     {
-      cwd: workspaceFolder.fsPath,
+      cwd: dirToUse,
       env: modifiedEnv,
     },
     undefined,

--- a/src/espIdf/setTarget/getTargets.ts
+++ b/src/espIdf/setTarget/getTargets.ts
@@ -55,7 +55,15 @@ export async function getTargetsFromEspIdf(
     undefined,
     true
   );
-  const listTargetsArray = listTargetsResult.toString().trim().split(EOL);
+  const listTargetsArray = listTargetsResult
+    .toString()
+    .trim()
+    .split(EOL)
+    .filter(
+      (line) =>
+        !line.toUpperCase().startsWith("WARNING") &&
+        !line.toUpperCase().startsWith("ERROR")
+    );
 
   for (const supportedTarget of listTargetsArray) {
     resultTargetArray.push({
@@ -78,7 +86,12 @@ export async function getTargetsFromEspIdf(
   const listTargetsWithPreviewArray = listTargetsWithPreviewResult
     .toString()
     .trim()
-    .split(EOL);
+    .split(EOL)
+    .filter(
+      (line) =>
+        !line.toUpperCase().startsWith("WARNING") &&
+        !line.toUpperCase().startsWith("ERROR")
+    );
 
   const previewTargets = listTargetsWithPreviewArray.filter(
     (t) => listTargetsArray.indexOf(t) === -1

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -429,6 +429,7 @@ export async function activate(context: vscode.ExtensionContext) {
               workspaceRoot,
               false
             );
+            context.subscriptions.push(projectConfigManager);
             if (statusBarItems["currentIdfVersion"]) {
               statusBarItems["currentIdfVersion"].text = currentIdfSetup.isValid
                 ? `$(${
@@ -473,6 +474,16 @@ export async function activate(context: vscode.ExtensionContext) {
           workspace: workspaceRoot,
         } as IOpenOCDConfig;
         openOCDManager.configureServer(openOCDConfig);
+        if (projectConfigManager) {
+          projectConfigManager.dispose();
+          projectConfigManager = undefined;
+        }
+        projectConfigManager = new ProjectConfigurationManager(
+          workspaceRoot,
+          context,
+          statusBarItems
+        );
+        context.subscriptions.push(projectConfigManager);
       }
       ConfserverProcess.dispose();
     })
@@ -3733,12 +3744,14 @@ export async function activate(context: vscode.ExtensionContext) {
   // Remove ESP-IDF settings
   registerIDFCommand("espIdf.removeEspIdfSettings", asyncRemoveEspIdfSettings);
 
-  projectConfigManager = new ProjectConfigurationManager(
-    workspaceRoot,
-    context,
-    statusBarItems
-  );
-  context.subscriptions.push(projectConfigManager);
+  if (workspaceRoot && workspaceRoot.fsPath) {
+    projectConfigManager = new ProjectConfigurationManager(
+      workspaceRoot,
+      context,
+      statusBarItems
+    );
+    context.subscriptions.push(projectConfigManager);
+  }
 
   registerIDFCommand("espIdf.projectConf", () => {
     PreCheck.perform([openFolderCheck], async () => {

--- a/src/project-conf/ProjectConfigurationManager.ts
+++ b/src/project-conf/ProjectConfigurationManager.ts
@@ -27,22 +27,22 @@ export class ProjectConfigurationManager {
   private configVersions: string[] = [];
   private configWatcher: FileSystemWatcher;
   private statusBarItems: { [key: string]: StatusBarItem };
-  private workspaceRoot: Uri;
+  private workspaceUri: Uri;
   private context: ExtensionContext;
   private commandDictionary: any;
 
   constructor(
-    workspaceRoot: Uri,
+    workspaceUri: Uri,
     context: ExtensionContext,
     statusBarItems: { [key: string]: StatusBarItem }
   ) {
-    this.workspaceRoot = workspaceRoot;
+    this.workspaceUri = workspaceUri;
     this.context = context;
     this.statusBarItems = statusBarItems;
     this.commandDictionary = createCommandDictionary();
 
     this.configFilePath = Uri.joinPath(
-      workspaceRoot,
+      workspaceUri,
       ESP.ProjectConfiguration.PROJECT_CONFIGURATION_FILENAME
     ).fsPath;
 
@@ -332,7 +332,7 @@ export class ProjectConfigurationManager {
 
     // Update the configuration data with resolved paths for building
     const resolvedConfig = await getProjectConfigurationElements(
-      this.workspaceRoot,
+      this.workspaceUri,
       true // Resolve paths for building
     );
     ESP.ProjectConfiguration.store.set(configName, resolvedConfig[configName]);
@@ -355,10 +355,10 @@ export class ProjectConfigurationManager {
 
     // Update related configurations
     await getIdfTargetFromSdkconfig(
-      this.workspaceRoot,
+      this.workspaceUri,
       this.statusBarItems["target"]
     );
-    await setCCppPropertiesJsonCompileCommands(this.workspaceRoot);
+    await setCCppPropertiesJsonCompileCommands(this.workspaceUri);
     ConfserverProcess.dispose();
   }
 
@@ -368,7 +368,7 @@ export class ProjectConfigurationManager {
   public async selectProjectConfiguration(): Promise<void> {
     try {
       const projectConfigurations = await getProjectConfigurationElements(
-        this.workspaceRoot,
+        this.workspaceUri,
         false // Don't resolve paths for display
       );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -466,7 +466,10 @@ export async function getConfigValueFromSDKConfig(
   workspacePath: vscode.Uri
 ): Promise<string> {
   const sdkconfigFilePath = await getSDKConfigFilePath(workspacePath);
-  if (!canAccessFile(sdkconfigFilePath, fs.constants.R_OK)) {
+  if (
+    !sdkconfigFilePath ||
+    !canAccessFile(sdkconfigFilePath, fs.constants.R_OK)
+  ) {
     throw new Error("sdkconfig file doesn't exists or can't be read");
   }
   const configs = readFileSync(sdkconfigFilePath);


### PR DESCRIPTION
## Description

Bugfixes for Project Configuration Manager and New Project wizard when vscode is opened but no workspace folder is opened.

Fixes #1537

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: New Project" when no workspace folder is opened.
2. Execute action. No errors should be shown.
3. Observe results.

## How has this been tested?

Use steps above.

**Test Configuration**:
* ESP-IDF Version: 5.3.1
* OS (Windows,Linux and macOS): Windows MacOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
