### PR TITLE
[VSC-1587] Enhance/validation before burning efuses

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -228,6 +228,11 @@
   "Could not find Encryption Key for {0}": "No se pudo encontrar la clave de cifrado para {0}",
   "eFuse check cancelled by user": "Verificación de eFuse cancelada por el usuario",
   "Error during flash encryption check: {0}": "Error durante la verificación del cifrado de flash: {0}",
-  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Escriba \"BURN\" para confirmar el cifrado de flash (esto es irreversible)",
-  "Please type \"BURN\" exactly to confirm": "Por favor escriba \"BURN\" exactamente para confirmar"
+  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Escriba \"{0}\" para confirmar el cifrado de flash (esto es irreversible)",
+  "Please type \"BURN\" exactly to confirm": "Por favor escriba \"{0}\" exactamente para confirmar",
+  "WARNING: You are attempting to switch from Development Mode to Release Mode.\n\nThis is an irreversible operation that will permanently disable plaintext flashing.\nMake sure you have a backup of your encryption key and understand the implications.\n\nType 'SWITCH' to confirm this operation.": "ADVERTENCIA: Está intentando cambiar del Modo Desarrollo al Modo Release.\n\nEsta es una operación irreversible que deshabilitará permanentemente el flash en texto plano.\nAsegúrese de tener una copia de seguridad de su clave de cifrado y comprender las implicaciones.\n\nEscriba 'SWITCH' para confirmar esta operación.",
+  "Type 'SWITCH' to confirm switching to Release Mode": "Escriba 'SWITCH' para confirmar el cambio al Modo Release",
+  "Please type 'SWITCH' exactly to confirm": "Por favor escriba 'SWITCH' exactamente para confirmar",
+  "Switching to Release Mode cancelled by user": "Cambio al Modo Release cancelado por el usuario",
+  "User confirmed switching to Release Mode. Proceeding with flash encryption.": "Usuario confirmó el cambio al Modo Release. Procediendo con el cifrado de flash."
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -228,6 +228,11 @@
   "Could not find Encryption Key for {0}": "Não foi possível encontrar a chave de criptografia para {0}",
   "eFuse check cancelled by user": "Verificação de eFuse cancelada pelo usuário",
   "Error during flash encryption check: {0}": "Erro durante verificação de criptografia de flash: {0}",
-  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Digite \"BURN\" para confirmar a criptografia de flash (isto é irreversível)",
-  "Please type \"BURN\" exactly to confirm": "Por favor, digite exatamente \"BURN\" para confirmar"
+  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Digite \"{0}\" para confirmar a criptografia da flash (isso é irreversível)",
+  "Please type \"BURN\" exactly to confirm": "Por favor, digite \"{0}\" exatamente para confirmar",
+  "WARNING: You are attempting to switch from Development Mode to Release Mode.\n\nThis is an irreversible operation that will permanently disable plaintext flashing.\nMake sure you have a backup of your encryption key and understand the implications.\n\nType 'SWITCH' to confirm this operation.": "AVISO: Você está tentando mudar do Modo de Desenvolvimento para o Modo de Release.\n\nEsta é uma operação irreversível que desabilitará permanentemente o flash em texto plano.\nCertifique-se de ter um backup da sua chave de criptografia e entender as implicações.\n\nDigite 'SWITCH' para confirmar esta operação.",
+  "Type 'SWITCH' to confirm switching to Release Mode": "Digite 'SWITCH' para confirmar a mudança para o Modo de Release",
+  "Please type 'SWITCH' exactly to confirm": "Por favor, digite 'SWITCH' exatamente para confirmar",
+  "Switching to Release Mode cancelled by user": "Mudança para o Modo de Release cancelada pelo usuário",
+  "User confirmed switching to Release Mode. Proceeding with flash encryption.": "Usuário confirmou a mudança para o Modo de Release. Prosseguindo com a criptografia flash."
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -228,6 +228,11 @@
   "Could not find Encryption Key for {0}": "Не удалось найти ключ шифрования для {0}",
   "eFuse check cancelled by user": "Проверка eFuse отменена пользователем",
   "Error during flash encryption check: {0}": "Ошибка при проверке шифрования flash: {0}",
-  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Введите \"BURN\" для подтверждения шифрования flash (это необратимо)",
-  "Please type \"BURN\" exactly to confirm": "Пожалуйста, введите точно \"BURN\" для подтверждения"
+  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "Введите \"{0}\" для подтверждения шифрования флеш-памяти (это необратимо)",
+  "Please type \"BURN\" exactly to confirm": "Пожалуйста, введите \"{0}\" точно для подтверждения",
+  "WARNING: You are attempting to switch from Development Mode to Release Mode.\n\nThis is an irreversible operation that will permanently disable plaintext flashing.\nMake sure you have a backup of your encryption key and understand the implications.\n\nType 'SWITCH' to confirm this operation.": "ПРЕДУПРЕЖДЕНИЕ: Вы пытаетесь переключиться из Режима Разработки в Режим Релиза.\n\nЭто необратимая операция, которая навсегда отключит запись в открытом виде.\nУбедитесь, что у вас есть резервная копия ключа шифрования и вы понимаете последствия.\n\nВведите 'SWITCH' для подтверждения этой операции.",
+  "Type 'SWITCH' to confirm switching to Release Mode": "Введите 'SWITCH' для подтверждения переключения в Режим Релиза",
+  "Please type 'SWITCH' exactly to confirm": "Пожалуйста, введите точно 'SWITCH' для подтверждения",
+  "Switching to Release Mode cancelled by user": "Переключение в Режим Релиза отменено пользователем",
+  "User confirmed switching to Release Mode. Proceeding with flash encryption.": "Пользователь подтвердил переключение в Режим Релиза. Продолжаем шифрование флеш-памяти."
 }

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -228,6 +228,11 @@
   "Could not find Encryption Key for {0}": "找不到 {0} 的加密密钥",
   "eFuse check cancelled by user": "用户取消了 eFuse 检查",
   "Error during flash encryption check: {0}": "闪存加密检查过程中出错：{0}",
-  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "请输入 \"BURN\" 以确认闪存加密（此操作不可逆）",
-  "Please type \"BURN\" exactly to confirm": "请准确输入 \"BURN\" 以确认"
+  "Type \"BURN\" to confirm flash encryption (this is irreversible)": "输入 \"{0}\" 确认闪存加密（此操作不可逆）",
+  "Please type \"BURN\" exactly to confirm": "请准确输入 \"{0}\" 以确认",
+  "WARNING: You are attempting to switch from Development Mode to Release Mode.\n\nThis is an irreversible operation that will permanently disable plaintext flashing.\nMake sure you have a backup of your encryption key and understand the implications.\n\nType 'SWITCH' to confirm this operation.": "警告：您正在尝试从开发模式切换到发布模式。\n\n这是一个不可逆的操作，将永久禁用明文烧录。\n请确保您已备份加密密钥并了解其影响。\n\n输入 'SWITCH' 确认此操作。",
+  "Type 'SWITCH' to confirm switching to Release Mode": "输入 'SWITCH' 确认切换到发布模式",
+  "Please type 'SWITCH' exactly to confirm": "请准确输入 'SWITCH' 以确认",
+  "Switching to Release Mode cancelled by user": "用户取消了切换到发布模式",
+  "User confirmed switching to Release Mode. Proceeding with flash encryption.": "用户确认切换到发布模式。继续进行闪存加密。"
 }


### PR DESCRIPTION
## Description

Added validation, which asks for user to confirm enabling flash encryption by typing "BURN".
Also, improved overall user experience around enabling flash encryption, mostly by outputting extra text inside output channel.

Fixes #1423 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Inside an esp-idf project like "flash_encryption" example:
1. Open SDK Configuration Editor
2. Search and enable "Flash Encryption on boot". Should be tested for both "development" and "release" modes. If you are using a different example than "flash_encryption" project and depending on the board you are using, you might need to increase offset of partition table from inside SDK Configuration edit. I suggest testing with "0x10000" instead of default "0x8000".
3. Build the project
4. Try to flash the project

>Warning 1: If you enable flash encryption on a board, JTAG port will not work anymore in the future. You will still be able to flash the board with new firmware, as long as you make sure flash encryption is enabled in sdk configuration. 
>Warning 2: If you enable flash encryption in release mode, you will not be able to flash new firmware via UART.

- Expected output:

Here are some validations:
1. If you enabled flash encryption in the sdk configuration editor, but you don't rebuild the project, you should receive notification asking you to re-build the project
2. If you enable flash encryption for the first time, you should be asked to confirm by typing "BURN DEV" or "BURN RELEASE" based on the flash encryption mode. You will also receive in the output channel some explanation of the process and what are the next steps you need to take, as well as the flash encryption mode that you've selected (Development/Release)
3. If you have flash encryption enabled on the board in development mode and you switch it to release mode, you will have to confirm burning the efuse for release mode by typing "SWITCH"

## How has this been tested?

As described above.

**Test Configuration**:
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
