### PR TITLE
link README to EFuse Explorer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ Press <kbd>F1</kbd> or click menu `View` -> `Command Palette...` to show Visual 
         <tr>
             <td rowspan=2 align="center">eFuse</td>
             <td>Get eFuse Summary</td>
-            <td>Retrieve a list of eFuses and their corresponding values from the chip currently connected to the serial port.</td>
+            <td>Retrieve a list of eFuses and their corresponding values from the chip currently connected to the serial port and display in the <a href="https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/efuse.html">ESP Explorer EFUSEEXPLORER</a>.</td>
             <td></td>
             <td></td>
         </tr>
         <tr>
             <td>Clear eFuse Summary</td>
-            <td>Clear the eFuse Summary tree from ESP Explorer EFUSEEXPLORER.</td>
+            <td>Clear the eFuse Summary tree from <a href="https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/efuse.html">ESP Explorer EFUSEEXPLORER</a>.</td>
             <td></td>
             <td></td>
         </tr>


### PR DESCRIPTION
Include a link to the ESP EFuse Explorer documentation in the readme.

Improves ability to find where the ESP EFuse bits are displayed.

## Type of change

- Documentation Improvement

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Open README.md in markdown editor
2. Click the links under EFuse section
3. Observe results.

## How has this been tested?

I verified the links added work.

**Test Configuration**:
* ESP-IDF Version: 5.1.2
* OS (Windows,Linux and macOS): Windows 11

## Dependent components impacted by this PR:

None

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [X] Added Documentation
- [ ] Added Unit Test
- [X] Verified on all platforms - Windows,Linux and macOS
