### PR TITLE
Bugfix/open ocd args

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,9 +580,9 @@ Note that for OpenOCD tasks, you need to define `OpenOCD_SCRIPTS` in your system
 
 If something is not working, please check for any error on one of these:
 
-> **NOTE:** Use `idf.OpenOCDDebugLevel` configuration setting to 3 or more to show debug logging in OpenOCD server output.
+> **NOTE:** Set `idf.OpenOCDDebugLevel` configuration setting to 3 or more in your <project-directory>/.vscode/settings.json to show debug level logs of OpenOCD server  in `ESP-IDF` output.
 
-> **NOTE:** Use `logLevel` in your <project-directory>/.vscode/launch.json to 3 or more to show more debug adapter output.
+> **NOTE:** Set `verbose: true` in your <project-directory>/.vscode/launch.json for more detailed debug adapter output.
 
 1. In Visual Studio Code select menu **View** > **Output** > **ESP-IDF**. This output information is useful to know what is happening in the extension.
 2. In Visual Studio Code select menu **View** > **Command Palette...** and type `ESP-IDF: Doctor Command` to generate a report of your environment configuration and it will be copied in your clipboard to paste anywhere.
@@ -593,7 +593,18 @@ If something is not working, please check for any error on one of these:
 
 4. In Visual Studio Code, select menu **Help** > **Toggle Developer Tools** and copy any error in the Console tab related to this extension.
 
+5. In Visual Studio Code select menu **View** > **Output** > **Extension Host**. This output information is useful to know what is happening during the extensions activation. If no extension command work, you could share the output here to see the error stack.
+
 5. Visual Studio Code allows you to configure settings at different levels: **Global (User Settings)**, **Workspace** and **Workspace Folder**, so make sure your project has the right settings. The `ESP-IDF: Doctor command` result might give the values from user settings instead of the workspace folder settings.
+
+    - Workspace folder configuration settings are defined in ``${workspaceFolder}/.vscode/settings.json``
+    - Workspace configuration settings are defined in the workspace's ``<name>.code-workspace`` file
+    - User settings defined in ``settings.json``
+        - **Windows**: ``%APPDATA%\Code\User\settings.json``
+        - **MacOS**: ``$HOME/Library/Application Support/Code/User/settings.json``
+        - **Linux**: ``$HOME/.config/Code/User/settings.json``
+
+This extension uses the ``idf.saveScope`` configuration setting (which can only be defined in User Settings) to specify where to save settings for features such as the Setup Wizard. You can modify this using the ``ESP-IDF: Select where to Save Configuration Settings`` command.
 
 6. Refer to the [OpenOCD troubleshooting FAQ](https://github.com/espressif/OpenOCD-esp32/wiki/Troubleshooting-FAQ) for help with application tracing, debugging, or other OpenOCD-related issues that may appear in the OpenOCD output.
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -55,7 +55,7 @@ Debugging Process Overview
 
 1.  First, the OpenOCD server is launched in the background and the output appears under menu ``View`` > ``Output`` by selecting ``ESP-IDF`` from the dropdown menu.
 
-    By default, the OpenOCD server is launched on localhost, port ``4444`` for Telnet communication, port ``6666`` for TCL communication and port ``3333`` for GDB. You can change these settings by modifying ``openocd.tcl.host`` and ``openocd.tcl.port`` in your ``<project-directory>/.vscode/settings.json``. You can also adjust the verbosity of OpenOCD messages displayed in the ESP-IDF output by setting ``idf.openOcdDebugLevel``. The value can range from 0 to 4.
+    By default, the OpenOCD server is launched on localhost, port ``4444`` for Telnet communication, port ``6666`` for TCL communication and port ``3333`` for GDB. You can change these settings by modifying ``openocd.tcl.host`` and ``openocd.tcl.port`` in your ``<project-directory>/.vscode/settings.json``. You can also adjust the verbosity of OpenOCD messages displayed in the ESP-IDF output by setting ``idf.openOcdDebugLevel``. Values from 0 (error messages only) to 4 (Verbose low-level debug message).
 
 2.  Next, the `Eclipse CDT GDB Adapter <https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter>`_ is launched in the background, with its output shown in the ``Debug Console``. This adapter initiates the GDB debug session to connect to the device.
 
@@ -64,6 +64,23 @@ Debugging Process Overview
 .. note::
   * Use **idf.openOcdDebugLevel** configuration setting to 4 or more to show debug logging in OpenOCD server output.
   * Use **verbose** in your ``<project-directory>/.vscode/launch.json`` to true to show more debug adapter output.
+
+By default OpenOCD arguments are ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs}``. If you want to modify them, set ``idf.openOcdLaunchArgs``, an empty array by default, to override the default arguments. 
+
+For example, to add ``-c "init"`` to the OpenOCD command, set ``idf.openOcdLaunchArgs`` in your ``<project-directory>/.vscode/settings.json`` as follows:
+
+    .. code-block:: JSON
+
+        {
+            "idf.openOcdLaunchArgs": [
+                "-d${config:idf.openOcdDebugLevel}",
+                "${config:idf.openOcdConfigs,-f}"
+                "-c",
+                "init",
+                "-c",
+                "reset halt",
+            ]
+        }
 
 In Visual Studio Code select menu **View** > **Output** > **ESP-IDF**. This output information is useful to know what is happening in the extension. For example, ``OpenOCD`` communication is displayed in this output.
 
@@ -84,6 +101,8 @@ To update OpenOCD launch arguments, open the project's ``.vscode/settings.json``
 
     {
         "idf.openOcdLaunchArgs": [
+            "-d${config:idf.openOcdDebugLevel}",
+            "${config:idf.openOcdConfigs,-f}"
             "-c",
             "init",
             "-c",

--- a/docs_espressif/en/settings.rst
+++ b/docs_espressif/en/settings.rst
@@ -5,17 +5,27 @@ ESP-IDF Settings
 
 :link_to_translation:`zh_CN:[中文]`
 
+Visual Studio Code allows you to configure settings at different levels: **Global (User Settings)**, **Workspace** and **Workspace Folder**. Ensure your project uses the correct settings.
+
+1.  Workspace folder configuration settings are defined in ``${workspaceFolder}/.vscode/settings.json``
+2.  Workspace configuration settings are defined in the workspace's ``<name>.code-workspace`` file
+3.  User settings defined in ``settings.json``
+
+    - **Windows**: ``%APPDATA%\Code\User\settings.json``
+    - **MacOS**: ``$HOME/Library/Application Support/Code/User/settings.json``
+    - **Linux**: ``$HOME/.config/Code/User/settings.json``
+
+This extension uses the **idf.saveScope** configuration setting (which can only be defined in User Settings) to specify where to save settings for features such as the Setup Wizard. You can modify this using the ``ESP-IDF: Select where to Save Configuration Settings`` command.
+
 This extension contributes the following settings that can be later updated in ``settings.json`` or from VS Code Settings Preference Menu by:
 
 - Navigate to **View** > **Command Palette**.
 
-- Type **Preferences: Open Settings (UI)** and select the command to open the setting management window.
+- Search for **Preferences: Open User Settings (JSON)**, **Preferences: Open Workspace Settings (JSON)** or **Preferences: Open Settings (UI)** and select the command to open the setting management window.
 
 .. note::
 
     Please note that ``~``, ``%VARNAME%`` and ``$VARNAME`` are not recognized when set on ANY of this extension configuration settings. Instead, you can set any environment variable in the path using ``${env:VARNAME}``, such as ``${env:HOME}``, or refer to other configuration parameter path with ``${config:SETTINGID}``, such as ``${config:idf.espIdfPath}``.
-
-The **idf.saveScope** allows you to specify where to save settings when using commands such as **Set Espressif Device Target** and other commands. Possible values are Global (User Settings), Workspace and WorkspaceFolder. Use the **Select where to Save Configuration Settings** command to choose where to save settings when using this extension commands.
 
 .. note::
 
@@ -93,11 +103,11 @@ These settings are specific to the ESP32 Chip/Board.
     * - **idf.monitorBaudRate**
       - Monitor Baud Rate (Empty by default to use SDKConfig ``CONFIG_ESP_CONSOLE_UART_BAUDRATE``)
     * - **idf.openOcdConfigs**
-      - Configuration files for OpenOCD, relative to ``OPENOCD_SCRIPTS`` folder
+      - Configuration files for OpenOCD, relative to ``OPENOCD_SCRIPTS`` folder. If ``idf.openOcdLaunchArgs`` is defined this setting is ignored.
     * - **idf.openOcdLaunchArgs**
-      - Launch arguments for OpenOCD before ``idf.openOcdDebugLevel`` and ``idf.openOcdConfigs``
+      - Custom arguments for OpenOCD. If not defined, the resulting OpenOCD launch command will be: ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs}``.
     * - **idf.openOcdDebugLevel**
-      - Set OpenOCD Debug Level (0-4) Default: 2
+      - Set OpenOCD Debug Level (0-4) Default: 2. From 0 (error messages only) to 4 (Verbose low-level debug message). If ``idf.openOcdLaunchArgs`` is defined this setting is ignored.
     * - **idf.port**
       - Path of selected device port
     * - **idf.monitorPort**
@@ -105,17 +115,17 @@ These settings are specific to the ESP32 Chip/Board.
     * - **idf.portWin**
       - Path of selected device port in Windows
     * - **idf.enableSerialPortChipIdRequest**
-      - Enable detecting the chip ID and show on serial port selection list
+      - Enable detecting the chip ID and show on serial port selection list. Scope can only be **Global (User Settings)**.
     * - **idf.useSerialPortVendorProductFilter**
-      - Enable use of ``idf.usbSerialPortFilters`` list to filter serial port devices list
+      - Enable use of ``idf.usbSerialPortFilters`` list to filter serial port devices list. Scope can only be **Global (User Settings)**.
     * - **idf.usbSerialPortFilters**
-      - USB productID and vendorID list to filter known Espressif devices
+      - USB productID and vendorID list to filter known Espressif devices. Scope can only be **Global (User Settings)**.
     * - **openocd.jtag.command.force_unix_path_separator**
       - Forced to use ``/`` instead of ``\\`` as path separator for Win32 based OS
     * - **idf.svdFilePath**
       - SVD file absolute path to resolve chip debug peripheral tree view
     * - **idf.jtagFlashCommandExtraArgs**
-      - OpenOCD JTAG flash extra arguments. Default is ["verify", "reset"].
+      - OpenOCD JTAG flash extra arguments. Default is ``["verify", "reset"]``.
 
 This is how the extension uses them:
 
@@ -123,8 +133,8 @@ This is how the extension uses them:
 2. **idf.monitorBaudRate** is the ESP-IDF Monitor baud rate value and fallback from your project's sdkconfig ``CONFIG_ESPTOOLPY_MONITOR_BAUD`` (idf.py monitor' baud rate). You can override this value by setting the ``IDF_MONITOR_BAUD`` or ``MONITORBAUD`` environment variables, or by configuring it through **idf.customExtraVars** setting of the extension.
 3. **idf.openOcdConfigs** stores an string array of relative paths to OpenOCD script configuration files, which are used with OpenOCD server. (e.g.，``["interface/ftdi/esp32_devkitj_v1.cfg", "board/esp32-wrover.cfg"]``). More information can be found in `OpenOCD JTAG Target Configuration <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/tips-and-quirks.html#jtag-debugging-tip-openocd-configure-target>`_.
 4. **idf.port** (or **idf.portWin** in Windows) is used as the serial port value for the extension commands.
-5. **idf.openOcdDebugLevel** is the log level for OpenOCD server output from 0 to 4.
-6. **idf.openOcdLaunchArgs** is the launch arguments string array for OpenOCD. The resulting OpenOCD launch command looks like this: ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs} ${idf.openOcdLaunchArgs}``.
+5. **idf.openOcdDebugLevel** is the log level for OpenOCD server output from 0 (error messages only) to 4 (Verbose low-level debug message).
+6. **idf.openOcdLaunchArgs** is the launch arguments string array for OpenOCD. If not defined, the resulting OpenOCD launch command looks like this: ``openocd -d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs}``.
 7. **idf.jtagFlashCommandExtraArgs** is used for OpenOCD JTAG flash task. Please review `Upload application for debugging <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html#upload-application-for-debugging>`.
 
 .. note::
@@ -169,7 +179,7 @@ Extension Behaviour Settings
     * - **idf.enableUpdateSrcsToCMakeListsFile**
       - Enable updating source files in ``CMakeLists.txt`` (default ``true``)
     * - **idf.flashType**
-      - Preferred flash method. DFU, UART or JTAG
+      - Preferred flash method. ``DFU``, ``UART`` or ``JTAG``
     * - **idf.flashPartitionToUse**
       - Specifies the partition to flash during the build and flash process. (default ``all``)
     * - **idf.launchMonitorOnDebugSession**
@@ -179,7 +189,7 @@ Extension Behaviour Settings
     * - **idf.showOnboardingOnInit**
       - Show ESP-IDF configuration window on extension activation
     * - **idf.saveScope**
-      - Where to save extension settings
+      - Where to save extension settings. Scope can only be **Global (User Settings)**.
     * - **idf.saveBeforeBuild**
       - Save all the edited files before building (default ``true``)
     * - **idf.useIDFKconfigStyle**
@@ -292,9 +302,12 @@ These settings support additional frameworks together with ESP-IDF:
       - Path to create ESP-IDF SBOM report
 
 
-Use of Environment Variables in ESP-IDF ``settings.json`` and ``tasks.json``
-----------------------------------------------------------------------------
+Use of Environment Variables in ESP-IDF ``settings.json`` and using other ESP-IDF settings within ESP-IDF settings
+----------------------------------------------------------------------------------------------------------------------
 
 Environment (env) variables and other ESP-IDF settings (config) can be referenced in ESP-IDF settings using the syntax ``${env:VARNAME}`` and ``${config:ESPIDFSETTING}``, respectively.
+
+You can also prepend a string to the result of the other ESP-IDF settings (config) by using the syntax ``${config:ESPIDFSETTING:prefix}``. The prefix will be added to the beginning of the variable value. For example ``${config:idf.openOcdConfigs,-f}`` will add ``-f`` to the beginning of the each string value of **idf.openOcdConfigs**.
+If ``"idf.openOcdConfigs": ["interface/some.cfg", "target/some.cfg"]`` returns ``-f interface/some.cfg -f target/some.cfg``.
 
 For example, to use ``"~/esp/esp-idf"``, set the value of **idf.espIdfPath** to ``"${env:HOME}/esp/esp-idf"``.

--- a/docs_espressif/en/troubleshooting.rst
+++ b/docs_espressif/en/troubleshooting.rst
@@ -7,8 +7,8 @@ Troubleshooting
 
 .. note::
 
-    * Set ``idf.openOcdDebugLevel`` to 4 or higher to enable debug logging in the OpenOCD server output.
-    * Set ``logLevel`` in your ``<project-directory>/.vscode/launch.json`` to 3 or higher to display more debug adapter output.
+    * Set ``idf.openOcdDebugLevel`` to 4 or higher in your ``<project-directory>/.vscode/settings.json`` to enable debug level logs of OpenOCD server in ``ESP-IDF`` output.
+    * Set ``verbose: true`` in your ``<project-directory>/.vscode/launch.json`` to display more debug adapter output.
 
 In Visual Studio Code, go to ``View`` > ``Output`` and select ``ESP-IDF`` from the dropdown. This output provides useful information about the extension's activity.
 
@@ -21,7 +21,19 @@ Check the log file located at:
 
 In Visual Studio Code, go to ``Help`` > ``Toggle Developer Tools`` and copy any errors from the Console tab related to this extension.
 
+In Visual Studio Code select menu ``View`` > ``Output`` > ``Extension Host``. This output information is useful to know what is happening during the extensions activation. If no extension command work, you could share the output here to see the error stack.
+
 Visual Studio Code allows you to configure settings at different levels: **Global (User Settings)**, **Workspace** and **Workspace Folder**. Ensure your project uses the correct settings. The output from ``ESP-IDF: Doctor command`` will show the settings currently in use.
+
+1.  Workspace folder configuration settings are defined in ``${workspaceFolder}/.vscode/settings.json``
+2.  Workspace configuration settings are defined in the workspace's ``<name>.code-workspace`` file
+3.  User settings defined in ``settings.json``
+
+    - **Windows**: ``%APPDATA%\Code\User\settings.json``
+    - **MacOS**: ``$HOME/Library/Application Support/Code/User/settings.json``
+    - **Linux**: ``$HOME/.config/Code/User/settings.json``
+
+This extension uses the ``idf.saveScope`` configuration setting (which can only be defined in User Settings) to specify where to save settings for features such as the Setup Wizard. You can modify this using the ``ESP-IDF: Select where to Save Configuration Settings`` command.
 
 Review `OpenOCD Troubleshooting FAQ <https://github.com/espressif/openocd-esp32/wiki/Troubleshooting-FAQ>`_ for information related to OpenOCD output, application tracing, debugging, or any OpenOCD issues.
 

--- a/src/espIdf/setTarget/getTargets.ts
+++ b/src/espIdf/setTarget/getTargets.ts
@@ -59,11 +59,7 @@ export async function getTargetsFromEspIdf(
     .toString()
     .trim()
     .split(EOL)
-    .filter(
-      (line) =>
-        !line.toUpperCase().startsWith("WARNING") &&
-        !line.toUpperCase().startsWith("ERROR")
-    );
+    .filter((line) => line.startsWith("esp") || line.startsWith("linux"));
 
   for (const supportedTarget of listTargetsArray) {
     resultTargetArray.push({
@@ -87,11 +83,7 @@ export async function getTargetsFromEspIdf(
     .toString()
     .trim()
     .split(EOL)
-    .filter(
-      (line) =>
-        !line.toUpperCase().startsWith("WARNING") &&
-        !line.toUpperCase().startsWith("ERROR")
-    );
+    .filter((line) => line.startsWith("esp") || line.startsWith("linux"));
 
   const previewTargets = listTargetsWithPreviewArray.filter(
     (t) => listTargetsArray.indexOf(t) === -1

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,10 @@ import {
 } from "./cmdTreeView/cmdStore";
 import { IdfSetup } from "./views/setup/types";
 import { asyncRemoveEspIdfSettings } from "./uninstall";
-import { ProjectConfigurationManager } from "./project-conf/ProjectConfigurationManager";
+import {
+  clearSelectedProjectConfiguration,
+  ProjectConfigurationManager,
+} from "./project-conf/ProjectConfigurationManager";
 import { readPartition } from "./espIdf/partition-table/partitionReader";
 import { getTargetsFromEspIdf } from "./espIdf/setTarget/getTargets";
 import {
@@ -256,6 +259,9 @@ let projectConfigManager: ProjectConfigurationManager | undefined;
 export async function activate(context: vscode.ExtensionContext) {
   // Always load Logger first
   Logger.init(context);
+  ESP.GlobalConfiguration.store = ExtensionConfigStore.init(context);
+  ESP.ProjectConfiguration.store = ProjectConfigStore.init(context);
+  clearSelectedProjectConfiguration();
   Telemetry.init(idfConf.readParameter("idf.telemetry") || false);
   utils.setExtensionContext(context);
   ChangelogViewer.showChangeLogAndUpdateVersion(context);
@@ -279,9 +285,6 @@ export async function activate(context: vscode.ExtensionContext) {
   };
   // init rainmaker cache store
   ESP.Rainmaker.store = RainmakerStore.init(context);
-
-  ESP.GlobalConfiguration.store = ExtensionConfigStore.init(context);
-  ESP.ProjectConfiguration.store = ProjectConfigStore.init(context);
 
   // Create Kconfig Language Server Client
   KconfigLangClient.startKconfigLangServer(context);

--- a/src/idfToolsManager.ts
+++ b/src/idfToolsManager.ts
@@ -242,7 +242,7 @@ export class IdfToolsManager {
       const regexResult = binVersionResponse
         .toString()
         .match(pkg.version_regex);
-      if (regexResult.length > 0) {
+      if (regexResult && regexResult.length > 0) {
         if (pkg.version_regex_replace) {
           let replaceRegexResult = pkg.version_regex_replace;
           for (let i = 0; i < regexResult.length; i++) {

--- a/src/project-conf/ProjectConfigurationManager.ts
+++ b/src/project-conf/ProjectConfigurationManager.ts
@@ -23,6 +23,20 @@ import { Logger } from "../logger/logger";
 import { getProjectConfigurationElements } from "./index";
 import { configureClangSettings } from "../clang";
 
+export function clearSelectedProjectConfiguration(): void {
+  if (ESP.ProjectConfiguration.store) {
+    const currentSelectedConfig = ESP.ProjectConfiguration.store.get<string>(
+      ESP.ProjectConfiguration.SELECTED_CONFIG
+    );
+    if (currentSelectedConfig) {
+      ESP.ProjectConfiguration.store.clear(currentSelectedConfig);
+      ESP.ProjectConfiguration.store.clear(
+        ESP.ProjectConfiguration.SELECTED_CONFIG
+      );
+    }
+  }
+}
+
 export class ProjectConfigurationManager {
   private readonly configFilePath: string;
   private configVersions: string[] = [];


### PR DESCRIPTION
## Description

1. Use `-d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs}` as default argument for OpenOCD. To customize, define `idf.openOcdLaunchArgs` which will override former arguments. If user still wants to use previous settings in idf.openOCdLaunchArgs it can be done as:

```json
{
   "idf.openOcdLaunchArgs": [
      "-d${config:idf.openOcdDebugLevel}",
      "${config:idf.openOcdConfigs,-f}"
      "-c",
      "init",
      "-c",
      "reset halt"
   ]
}
```

2. Selected project configuration profile is clear first thing when the extension is activated.
3. Add validation for current project configuration profile when reading extension settings. This is for example, to make sure that a profile like this:

```
{
  "profile1": {
    "build": {
      "compileArgs": [],
      "ninjaArgs": [],
      "buildDirectoryPath": "${workspaceFolder}/buildProfile",
      "sdkconfigDefaults": [
        "sdkconfig.defaults",
        "sdkconfig.debug"
      ],
      "sdkconfigFilePath": "${workspaceFolder}/buildProfile/sdkconfig"
    },
    "env": {},
    "flashBaudRate": "",
    "monitorBaudRate": "",
    "openOCD": {
      "debugLevel": 0,
      "configs": [],
      "args": []
    },
    "tasks": {
      "preBuild": "",
      "preFlash": "",
      "postBuild": "",
      "postFlash": ""
    }
  },
  "profile2": {
    "build": {
      "compileArgs": [],
      "ninjaArgs": [],
      "buildDirectoryPath": "${workspaceFolder}/buildProfile",
      "sdkconfigDefaults": [
        "sdkconfig.defaults",
        "sdkconfig.debug"
      ],
      "sdkconfigFilePath": "${workspaceFolder}/buildProfile/sdkconfig"
    },
    "flashBaudRate": "",
    "monitorBaudRate": "",
    "openOCD": {
      "debugLevel": 0,
      "configs": [],
      "args": []
    },
    "tasks": {
      "preBuild": "",
      "preFlash": "",
      "postBuild": "",
      "postFlash": ""
    }
  }
```
 works as expected. This happened because `resolveConfigPaths` returns undefined when `resolveConfigPaths(workspaceFolder, openOCDConfig?.configs, resolvePaths)` and `openOCDConfig?.configs` is [].

Fixes #1549
Fixes #1547
Fixes #1546
Fixes #1541
Fixes #1533

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "[OpenOCD Server]" in the status bar icon. OpenOCD should be launched with `-d${idf.openOcdDebugLevel} -f ${idf.openOcdConfigs}`. 
2. Set `idf.openOcdLaunchArgs` to some custom value (maybe like the one in the description. OpenOCD should ignore default arguments (those in step 1) and use `idf.openOcdLaunchArgs`  exclusively.
5. Use a project configuration profile that has `openOCD.configs` to an empty array (see description #3). There should no errors when launching openOCD.
6. Use a profile without explicit defined `env` (like profile 2 in description #3) and select as current profile. Close vscode and open it again. No errors should happen on extension activation.
7. The select project configuration command should work without problem.
8. OpenOCD board message is updated to `OpenOCD board files set to ${0}` where ${0} is the selected board file.

- Expected behaviour:

- Expected output:

## How has this been tested?

Following steps above manually.

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
