### PR TITLE
[VSC-1736] support loading binary before debug with 'imageAndSymbols' option in launch.json

### DIFF
--- a/src/cdtDebugAdapter/adapter/GDBBackend.ts
+++ b/src/cdtDebugAdapter/adapter/GDBBackend.ts
@@ -295,7 +295,7 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendLoad(imageFileName: string, imageOffset: string | undefined) {
         return this.sendCommand(
-            `load ${this.standardEscape(imageFileName)} ${imageOffset || ''}`
+            `mon program_esp ${this.standardEscape(imageFileName)} ${imageOffset || ''}`
         );
     }
 


### PR DESCRIPTION
## Description

setting the `imageAndSymbols` field in launch.json hasn't worked because the extension attempts to invoke the `load` gdb command, which isn't supported by openocd-esp32.
this changes it to use `mon program_esp`, [which is correctly supported and has the same arguments](https://github.com/espressif/openocd-esp32/issues/32#issuecomment-372866714).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

to a sample project `launch.json`, add:

```
"imageAndSymbols": {
  "imageFileName": "${workspaceFolder}/build/${command:espIdf.getProjectName}.bin",
  "imageOffset": "<insert firmware load address here>"
},
```

then debug with the default configuration.