### PR TITLE
isBinInPath remove use of which where

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@ esp_debug_adapter/
 external/
 test-resources/
 docs_espressif/
+profiles

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -86,12 +86,10 @@ export class BuildTask {
     };
     const canAccessCMake = await isBinInPath(
       "cmake",
-      this.currentWorkspace.fsPath,
       modifiedEnv
     );
     const canAccessNinja = await isBinInPath(
       "ninja",
-      this.currentWorkspace.fsPath,
       modifiedEnv
     );
 

--- a/src/clang/index.ts
+++ b/src/clang/index.ts
@@ -34,7 +34,6 @@ export async function validateEspClangExists(workspaceFolder: Uri) {
 
   const espClangdPath = await isBinInPath(
     "clangd",
-    workspaceFolder.fsPath,
     modifiedEnv
   );
   if (espClangdPath && espClangdPath.includes("esp-clang")) {

--- a/src/espIdf/debugAdapter/debugAdapterManager.ts
+++ b/src/espIdf/debugAdapter/debugAdapterManager.ts
@@ -90,7 +90,7 @@ export class DebugAdapterManager extends EventEmitter {
       if (this.isRunning()) {
         return;
       }
-      if (!isBinInPath("openocd", this.currentWorkspace.fsPath, this.env)) {
+      if (!isBinInPath("openocd", this.env)) {
         return reject(
           new Error("Invalid OpenOCD bin path or access is denied for the user")
         );

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -61,7 +61,7 @@ export class OpenOCDManager extends EventEmitter {
 
   public async version(): Promise<string> {
     const modifiedEnv = await appendIdfAndToolsToPath(this.workspace);
-    if (!isBinInPath("openocd", this.workspace.fsPath, modifiedEnv)) {
+    if (!isBinInPath("openocd", modifiedEnv)) {
       return "";
     }
     const resp = await sspawn("openocd", ["--version"], {
@@ -157,7 +157,7 @@ export class OpenOCDManager extends EventEmitter {
       return;
     }
     const modifiedEnv = await appendIdfAndToolsToPath(this.workspace);
-    if (!isBinInPath("openocd", this.workspace.fsPath, modifiedEnv)) {
+    if (!isBinInPath("openocd", modifiedEnv)) {
       throw new Error(
         "Invalid OpenOCD bin path or access is denied for the user"
       );

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -68,7 +68,6 @@ export class GdbHeapTraceManager {
         const gdbTool = getToolchainToolName(idfTarget, "gdb");
         const isGdbToolInPath = await isBinInPath(
           gdbTool,
-          workspace.fsPath,
           modifiedEnv
         );
         if (!isGdbToolInPath) {

--- a/src/qemu/qemuManager.ts
+++ b/src/qemu/qemuManager.ts
@@ -184,7 +184,6 @@ export class QemuManager extends EventEmitter {
     }
     const isQemuBinInPath = await isBinInPath(
       qemuExecutable,
-      workspaceFolder.fsPath,
       modifiedEnv
     );
     if (!isQemuBinInPath) {

--- a/src/setup/espIdfJson.ts
+++ b/src/setup/espIdfJson.ts
@@ -93,7 +93,7 @@ export async function addIdfPath(
   espIdfObj["idfSelectedId"] = idfId;
   if (!espIdfObj.gitPath) {
     if (gitPath === "git") {
-      gitPath = await isBinInPath(gitPath, idfPath, process.env);
+      gitPath = await isBinInPath(gitPath, process.env);
     }
     espIdfObj.gitPath = gitPath;
   }

--- a/src/setup/setupInit.ts
+++ b/src/setup/setupInit.ts
@@ -171,7 +171,6 @@ export async function getSetupInitialValues(
 
       const canAccessCMake = await utils.isBinInPath(
         "cmake",
-        extensionPath,
         process.env
       );
 
@@ -183,7 +182,6 @@ export async function getSetupInitialValues(
 
       const canAccessNinja = await utils.isBinInPath(
         "ninja",
-        extensionPath,
         process.env
       );
 
@@ -246,7 +244,6 @@ export async function isCurrentInstallValid(workspaceFolder: Uri) {
   if (process.platform !== "win32") {
     const canAccessCMake = await utils.isBinInPath(
       "cmake",
-      containerPath,
       process.env
     );
     if (!canAccessCMake) {
@@ -254,7 +251,6 @@ export async function isCurrentInstallValid(workspaceFolder: Uri) {
     }
     const canAccessNinja = await utils.isBinInPath(
       "ninja",
-      containerPath,
       process.env
     );
     if (!canAccessNinja) {

--- a/src/test/project.test.ts
+++ b/src/test/project.test.ts
@@ -76,7 +76,6 @@ suite("Project tests", () => {
     );
     const compilerAbsolutePath = await isBinInPath(
       "xtensa-esp32-elf-gcc",
-      targetFolder,
       process.env
     );
     let compilerRelativePath = compilerAbsolutePath.split(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,6 +24,7 @@ import {
   readdir,
   readFile,
   readJSON,
+  stat,
   writeFile,
   writeJSON,
 } from "fs-extra";
@@ -266,11 +267,7 @@ export async function setCCppPropertiesJsonCompilerPath(
   const modifiedEnv = await appendIdfAndToolsToPath(curWorkspaceFsPath);
   const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
   const gccTool = getToolchainToolName(idfTarget, "gcc");
-  const compilerAbsolutePath = await isBinInPath(
-    gccTool,
-    curWorkspaceFsPath.fsPath,
-    modifiedEnv
-  );
+  const compilerAbsolutePath = await isBinInPath(gccTool, modifiedEnv);
   if (!compilerAbsolutePath) {
     return;
   }
@@ -339,7 +336,7 @@ export async function getToolchainPath(
   const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
   const gccTool = getToolchainToolName(idfTarget, tool);
   try {
-    return await isBinInPath(gccTool, workspaceUri.fsPath, modifiedEnv);
+    return await isBinInPath(gccTool, modifiedEnv);
   } catch (error) {
     Logger.errorNotify(
       `${tool} is not found in idf.toolsPath`,
@@ -852,7 +849,7 @@ export async function checkGitExists(workingDir: string, gitPath: string) {
   try {
     const gitBinariesExists = await pathExists(gitPath);
     if (!gitBinariesExists) {
-      const gitInPath = await isBinInPath("git", workingDir, process.env);
+      const gitInPath = await isBinInPath("git", process.env);
       if (!gitInPath) {
         return "Not found";
       }
@@ -1264,35 +1261,21 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
   return modifiedEnv;
 }
 
-export async function isBinInPath(
-  binaryName: string,
-  workDirectory: string,
-  env: NodeJS.ProcessEnv
-) {
-  const cmd = process.platform === "win32" ? "where" : "which";
-  try {
-    const result = await spawn(cmd, [binaryName], { cwd: workDirectory, env });
-    if (
-      result.toString() === "" ||
-      result.toString().indexOf("Could not find files") < 0
-    ) {
-      // Sometimes multiple paths can be returned. They are separated by new lines, get only the first one
-      const selectedResult = result.toString().split("\n")[0].trim();
-      return binaryName.localeCompare(selectedResult) === 0
-        ? ""
-        : selectedResult;
+export async function isBinInPath(binaryName: string, env: NodeJS.ProcessEnv) {
+  let pathNameInEnv: string = Object.keys(process.env).find(
+    (k) => k.toUpperCase() == "PATH"
+  );
+  const pathDirs = env[pathNameInEnv].split(path.delimiter);
+  for (const pathDir of pathDirs) {
+    let binaryPath = path.join(pathDir, binaryName);
+    if (process.platform === "win32" && !binaryName.endsWith(".exe")) {
+      binaryPath = `${binaryName}.exe`;
     }
-  } catch (error) {
-    let pathNameInEnv: string = Object.keys(process.env).find(
-      (k) => k.toUpperCase() == "PATH"
-    );
-    Logger.error(
-      `Cannot access binary filePath: ${binaryName}`,
-      error,
-      "src utils isBinInPath",
-      { envPath: pathNameInEnv ? env[pathNameInEnv] : undefined },
-      false
-    );
+    const doesPathExists = await pathExists(binaryPath);
+    const pathStats = await stat(binaryPath);
+    if (doesPathExists && pathStats.isFile()) {
+      return binaryPath;
+    }
   }
   return "";
 }


### PR DESCRIPTION
## Description

The binary in env variable Path will now just test for path existing and being a file instead of relying of which where command. This solve the issue of some environment not working for which and where and also remove dependency for which in arch linux.

Fixes #1144
Fixes #1550

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

Set this value to test the problematic path

```JSON
{
   "idf.customExtraVars': {
      "Path": "C:\Program Files (x86)\Klocwork\Command Line 22.1\bin;C:\Program Files\Common Files\Siemens\Automation\Simatic OAM\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;%SYSTEMROOT%\System32\OpenSSH\;C:\Program Files\Git\cmd;C:\Program Files\TortoiseGit\bin;C:\Program Files\dotnet\;C:\Program Files (x86)\IVI Foundation\VISA\WinNT\Bin\;C:\Users\DYSHENGH\AppData\Local\Microsoft\WindowsApps;C:\Users\DYSHENGH\AppData\Local\Programs\Microsoft VS Code\bin"
}
}
```

1. Click on "ESP-IDF: Build your project". 
2. Make your environment variable Path (or PATH in Linux/MacOS) weird by setting `idf.customExtraVars` variable `Path` (or `PATH`) to value above.
5. Observe results. The build should work. If you test on current master adding the value above, it will fail to build the project with message `"Something went wrong while trying to build the project","stack":"Error: CMake or Ninja executables not found...`

- Expected behaviour:

Weird paths in environment variable PATH should not give the `CMake or Ninja executables not found` error when building the project.

- Expected output:

Build works as normal even with paths such as the example above.

## How has this been tested?

Manual testing above.

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
