### PR TITLE
[VSC-1706] Fix for idfTarget resolving multi-config's paths

### DIFF
--- a/src/project-conf/index.ts
+++ b/src/project-conf/index.ts
@@ -62,7 +62,7 @@ export async function updateCurrentProfileIdfTarget(
 
   const projectConfJson = await getProjectConfigurationElements(
     workspaceFolder,
-    true
+    false
   );
 
   if (!projectConfJson[selectedConfig]) {


### PR DESCRIPTION
## Description

Before this fix, if you had a project configured for multiple configurations, when setting an idf target, the relative paths inside `esp_idf_project_configuration.json` would get resolved to absolute paths.

Example of `esp_idf_project_configuration.json` can be seen in #1575.

Fixes #1575 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1) Create `multi-config` esp-idf example. 
2) Create the following "esp_idf_project_configuration.json" file at the root level of the project:
```
{
  "prod1": {
    "build": {
      "compileArgs": [],
      "ninjaArgs": [],
      "buildDirectoryPath": "build_prod1",
      "sdkconfigDefaults": [
        "sdkconfig.prod_common",
        "sdkconfig.prod1"
      ]
    },
    "env": {},
    "idfTarget": "",
    "flashBaudRate": "",
    "monitorBaudRate": "",
    "openOCD": {
      "debugLevel": -1,
      "configs": [],
      "args": []
    },
    "tasks": {
      "preBuild": "",
      "preFlash": "",
      "postBuild": "",
      "postFlash": ""
    }
  }
}
```
3)  Select "prod1" profile from status bar or by using the command **"ESP-IDF: Select Project Configuration"**
4) Set IDF target from status bar or by using the command **"ESP-IDF: Set Espressif Device Target"**

Setting the device target should not change the relative paths inside `esp_idf_project_configuration.json` to absolute paths.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 5.4
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
