### PR TITLE
Fix/sysview commands

### DIFF
--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -62,7 +62,15 @@ export class GdbHeapTraceManager {
           /\\/g,
           "/"
         )}/htrace_${new Date().getTime()}.svdat`;
-        await this.createGdbinitFile(fileName, workspace.fsPath);
+        const buildDirPath = readParameter(
+          "idf.buildPath",
+          workspace
+        ) as string;
+        const buildExists = await pathExists(buildDirPath);
+        if (!buildExists) {
+          throw new Error(`${buildDirPath} doesn't exist. Build first.`);
+        }
+        await this.createGdbinitFile(fileName, buildDirPath);
         const modifiedEnv = await appendIdfAndToolsToPath(workspace);
         const idfTarget = modifiedEnv.IDF_TARGET || "esp32";
         const gdbTool = getToolchainToolName(idfTarget, "gdb");
@@ -73,14 +81,6 @@ export class GdbHeapTraceManager {
         );
         if (!isGdbToolInPath) {
           throw new Error(`${gdbTool} is not available in PATH.`);
-        }
-        const buildDirPath = readParameter(
-          "idf.buildPath",
-          workspace
-        ) as string;
-        const buildExists = await pathExists(buildDirPath);
-        if (!buildExists) {
-          throw new Error(`${buildDirPath} doesn't exist. Build first.`);
         }
         const projectName = await getProjectName(buildDirPath);
         const elfFilePath = join(buildDirPath, `${projectName}.elf`);

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -172,8 +172,8 @@ export class GdbHeapTraceManager {
     workspaceFolder: string
   ) {
     let content = `set pagination off\ntarget remote :3333\n\nmon reset halt\nflushregs\n\n`;
-    content += `tb heap_trace_start\ncommands\nmon esp sysview start ${traceFilePath}\n`;
-    content += `c\nend\n\ntb heap_trace_stop\ncommands\nmon esp sysview stop\nend\n\nc`;
+    content += `tb heap_trace_start\ncommands\nmon esp sysview_mcore start ${traceFilePath}\n`;
+    content += `c\nend\n\ntb heap_trace_stop\ncommands\nmon esp sysview_mcore stop\nend\n\nc`;
     const filePath = join(workspaceFolder, this.gdbinitFileName);
     await writeFile(filePath, content);
   }

--- a/src/espIdf/tracing/tools/sysviewTraceProc.ts
+++ b/src/espIdf/tracing/tools/sysviewTraceProc.ts
@@ -43,7 +43,7 @@ export class SysviewTraceProc extends AbstractTracingToolManager {
     }
     return await this.parseInternal(
       "python",
-      ["sysviewtrace_proc.py", "-j", `file://${this.traceFilePath}`],
+      ["sysviewtrace_proc.py", "-j", "-b", `file://${this.elfFilePath}`, `file://${this.traceFilePath}`],
       {
         cwd: this.appTraceToolsPath(),
       }


### PR DESCRIPTION
## Description

- The gdbinit file was being created in the workspace root but GDB was looking for it in the build directory. This caused the "No such file or directory" error when trying to start heap tracing. 
- Changed sysview to sysview_mcore in the GDB commands
- Added the -b flag with ELF file path to the sysviewtrace_proc.py command

Fixes #1573 

Tested with ESP32 and ESP32C6