### PR TITLE
Extend default jtag flash arguments 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1250,6 +1250,8 @@
             "scope": "resource",
             "default": [
               "verify",
+              "compress",
+              "skip_loaded",
               "reset"
             ],
             "items": {


### PR DESCRIPTION
## Description

The current JTAG flash process doesn't optimize for transfer speed and efficiency, potentially leading to unnecessary data transfers during flashing.

Added  two new default arguments to the JTAG flash process:
1. `compress`: Reduces the amount of data that needs to be transferred during flashing
2. `skip_loaded`: Verifies flash content first and skips loading sections that already match

