### PR TITLE
[VSC-1577] Fix for cloning dev branches

### DIFF
--- a/src/setup/espIdfDownload.ts
+++ b/src/setup/espIdfDownload.ts
@@ -78,16 +78,17 @@ export async function downloadInstallIdfVersion(
   pkgProgress.Progress = `0.00%`;
 
   if (
-    idfVersion.filename === "master" ||
-    idfVersion.filename.startsWith("release")
+    idfVersion.version === "master" ||
+    idfVersion.version.startsWith("release")
+      || idfVersion.version.endsWith("-dev")
   ) {
-    const downloadByCloneMsg = `Downloading ESP-IDF ${idfVersion.filename} using git clone...\n`;
+    const downloadByCloneMsg = `Downloading ESP-IDF ${idfVersion.version} using git clone...\n`;
     OutputChannel.appendLine(downloadByCloneMsg);
     Logger.info(downloadByCloneMsg);
     if (progress) {
       progress.report({ message: downloadByCloneMsg });
     }
-    const espIdfCloning = new EspIdfCloning(idfVersion.filename, gitPath);
+    const espIdfCloning = new EspIdfCloning(idfVersion.version, gitPath);
     let cancelDisposable: Disposable;
     if (cancelToken) {
       cancelDisposable = cancelToken.onCancellationRequested(() => {


### PR DESCRIPTION
## Description

When installing an ESP-IDF version, our extension supports two primary methods:

1. **Downloading pre-packaged zip files** for stable, official releases (e.g., v5.0.9).
2. **Cloning the repository recursively** for active development branches (e.g., master or release/x.x).

This fix extends support to development branches ending in "-dev" (e.g., v5.5-dev). Prior to this change, the extension would incorrectly attempt a zip file download for these versions, which are not provided. Now, -dev branches will be correctly installed via repository cloning.

Fixes #1577 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Try to install the following version (make sure to have "Show all ESP-IDF Tags" ticked):
![image](https://github.com/user-attachments/assets/72a56caa-ce7e-4aaa-9a30-1755a55b0d69)

Should be tested for with stable and official releases as well.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 6.0
* OS (Windows,Linux and macOS): Windows

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
