### PR TITLE
add python git github mirrors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -97,14 +97,17 @@ export namespace ESP {
     export namespace IDF_EMBED_GIT {
       export const VERSION = "2.39.2";
       export const IDF_EMBED_GIT_URL = `https://dl.espressif.com/dl/idf-git/idf-git-${VERSION}-win64.zip`;
+      export const GITHUB_EMBED_GIT_URL = `https://github.com/git-for-windows/git/releases/download/v${VERSION}.windows.1/MinGit-${VERSION}-64-bit.zip`;
     }
     export namespace OLD_IDF_EMBED_PYTHON {
       export const VERSION = "3.8.7";
       export const IDF_EMBED_PYTHON_URL = `https://dl.espressif.com/dl/idf-python/idf-python-${VERSION}-embed-win64.zip`;
+      export const GITHUB_EMBED_PYTHON_URL = `https://github.com/espressif/idf-python/releases/download/v${VERSION}/idf-python-${VERSION}-embed-win64.zip`;
     }
     export namespace IDF_EMBED_PYTHON {
       export const VERSION = "3.11.2";
       export const IDF_EMBED_PYTHON_URL = `https://dl.espressif.com/dl/idf-python/idf-python-${VERSION}-embed-win64.zip`;
+      export const GITHUB_EMBED_PYTHON_URL = `https://github.com/espressif/idf-python/releases/download/v${VERSION}/idf-python-${VERSION}-embed-win64.zip`;
     }
     export const GithubRepository =
       "https://github.com/espressif/vscode-esp-idf-extension";

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -466,6 +466,7 @@ export class SetupPanel {
             const embedPaths = await this.installEmbedPyGit(
               toolsPath,
               idfVersion,
+              mirror,
               progress,
               cancelToken
             );
@@ -585,6 +586,7 @@ export class SetupPanel {
             const embedPaths = await this.installEmbedPyGit(
               toolsPath,
               idfVersion,
+              mirror,
               progress,
               cancelToken
             );
@@ -669,10 +671,16 @@ export class SetupPanel {
   private async installEmbedPyGit(
     toolsPath: string,
     idfVersion: string,
+    mirror: ESP.IdfMirror,
     progress: Progress<{ message: string; increment?: number }>,
     cancelToken: CancellationToken
   ) {
-    const idfGitPath = await installIdfGit(toolsPath, progress, cancelToken);
+    const idfGitPath = await installIdfGit(
+      toolsPath,
+      mirror,
+      progress,
+      cancelToken
+    );
     SetupPanel.postMessage({
       command: "updateIdfGitStatus",
       status: StatusType.installed,
@@ -680,6 +688,7 @@ export class SetupPanel {
     const idfPythonPath = await installIdfPython(
       toolsPath,
       idfVersion,
+      mirror,
       progress,
       cancelToken
     );

--- a/src/setup/embedGitPy.ts
+++ b/src/setup/embedGitPy.ts
@@ -36,15 +36,20 @@ import { Logger } from "../logger/logger";
 
 export async function installIdfGit(
   idfToolsDir: string,
+  mirror: ESP.IdfMirror,
   progress?: Progress<{ message: string; increment?: number }>,
   cancelToken?: CancellationToken
 ) {
   const downloadManager = new DownloadManager(idfToolsDir);
   const installManager = new InstallManager(idfToolsDir);
+  let gitURLToUse =
+    mirror === ESP.IdfMirror.Github
+      ? ESP.URL.IDF_EMBED_GIT.GITHUB_EMBED_GIT_URL
+      : ESP.URL.IDF_EMBED_GIT.IDF_EMBED_GIT_URL;
   const idfGitZipPath = join(
     idfToolsDir,
     "dist",
-    basename(ESP.URL.IDF_EMBED_GIT.IDF_EMBED_GIT_URL)
+    basename(gitURLToUse)
   );
   const idfGitDestPath = join(
     idfToolsDir,
@@ -54,7 +59,7 @@ export async function installIdfGit(
   );
   const resultGitPath = join(idfGitDestPath, "cmd", "git.exe");
   const pkgProgress = new PackageProgress(
-    basename(ESP.URL.IDF_EMBED_GIT.IDF_EMBED_GIT_URL),
+    basename(gitURLToUse),
     sendIdfGitDownloadProgress,
     null,
     sendIdfGitDownloadDetail,
@@ -84,7 +89,7 @@ export async function installIdfGit(
     OutputChannel.appendLine(msgDownload);
     Logger.info(msgDownload);
     await downloadManager.downloadWithRetries(
-      ESP.URL.IDF_EMBED_GIT.IDF_EMBED_GIT_URL,
+      gitURLToUse,
       join(idfToolsDir, "dist"),
       pkgProgress,
       cancelToken
@@ -113,15 +118,24 @@ export async function installIdfGit(
 export async function installIdfPython(
   idfToolsDir: string,
   idfVersion: string,
+  mirror: ESP.IdfMirror,
   progress?: Progress<{ message: string; increment?: number }>,
   cancelToken?: CancellationToken
 ) {
   const downloadManager = new DownloadManager(idfToolsDir);
   const installManager = new InstallManager(idfToolsDir);
-  const pythonURLToUse =
-    idfVersion >= "5.0"
-      ? ESP.URL.IDF_EMBED_PYTHON.IDF_EMBED_PYTHON_URL
-      : ESP.URL.OLD_IDF_EMBED_PYTHON.IDF_EMBED_PYTHON_URL;
+  let pythonURLToUse: string;
+  if (idfVersion >= "5.0") {
+    pythonURLToUse =
+      mirror === ESP.IdfMirror.Github
+        ? ESP.URL.IDF_EMBED_PYTHON.GITHUB_EMBED_PYTHON_URL
+        : ESP.URL.IDF_EMBED_PYTHON.IDF_EMBED_PYTHON_URL;
+  } else {
+    pythonURLToUse =
+      mirror === ESP.IdfMirror.Github
+        ? ESP.URL.OLD_IDF_EMBED_PYTHON.GITHUB_EMBED_PYTHON_URL
+        : ESP.URL.OLD_IDF_EMBED_PYTHON.IDF_EMBED_PYTHON_URL;
+  }
   const idfPyZipPath = join(idfToolsDir, "dist", basename(pythonURLToUse));
   const pkgProgress = new PackageProgress(
     basename(pythonURLToUse),


### PR DESCRIPTION
## Description

Add Idf-git and idf-python GitHub mirrors.

Fixes #1552

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Configure ESP-IDF extension"
2. Install from GitHub mirror. idf-git and idf-python should be downloaded from Github instead of Espressif DL servers.
3. Observe results.

- Expected behaviour:

idf-git and idf-python should be downloaded from Github instead of Espressif DL servers when Github mirror is selected.

- Expected output:

idf-git and idf-python should be downloaded from Github instead of Espressif DL servers when Github mirror is selected.

## How has this been tested?

Manual test using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): Windows

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
