### PR TITLE
debugPort for debug adapter server in debugger settings

### DIFF
--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -144,6 +144,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 
 Some additional arguments you might use are:
 
+- ``debugPort``: (Default: 43476) The port to launch the Eclipse CDT GDB Debug Adapter server. If not specified, it will use the default value of 43476.
 - ``runOpenOCD``: (Default: true). Run extension OpenOCD Server.
 - ``verifyAppBinBeforeDebug``: (Default: false) Verify that current ESP-IDF project binary is the same as binary in chip.
 - ``logFile``: Absolute path to the file to log interaction with gdb. Example: ${workspaceFolder}/gdb.log.

--- a/package.json
+++ b/package.json
@@ -1878,6 +1878,11 @@
                 "type": "string",
                 "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
               },
+              "debugPort": {
+                "type": "number",
+                "description": "Port for Debug Adapter server. Default: 43476",
+                "default": 43476
+              },
               "runOpenOCD": {
                 "type": "boolean",
                 "description": "Run OpenOCD Server",
@@ -2146,6 +2151,11 @@
               "cwd": {
                 "type": "string",
                 "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
+              },
+              "debugPort": {
+                "type": "number",
+                "description": "Port for Debug Adapter server. Default: 43476",
+                "default": 43476
               },
               "runOpenOCD": {
                 "type": "boolean",

--- a/src/cdtDebugAdapter/server.ts
+++ b/src/cdtDebugAdapter/server.ts
@@ -54,9 +54,21 @@ export class CDTDebugAdapterDescriptorFactory
     }
   }
 
+  checkCurrentPort(port: number): boolean {
+    if (!this.server) {
+      return false;
+    }
+    const address = this.server.address();
+    if (address && typeof address === "object" && address.port) {
+      return (<AddressInfo>address).port === port;
+    }
+    return false;
+  }
+
   dispose() {
     if (this.server) {
       this.server.close();
+      this.server = undefined;
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #1334

Add `debugPort` to Eclipse CDT GDB Debug configuration settings. Allow the user to customize the generated server for debug adapter and add validation if the server port doesn't exists.

Launch.json example. Change `47856` to whatever port to test. When is not set, 43476 will be used.
```JSON
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "gdbtarget",
      "request": "attach",
      "name": "Eclipse CDT GDB Adapter",
      "debugPort": 47856
    }
  ]
}
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Set debugPort to any port number (see JSON above). Click on "ESP-IDF:"
2. Check your computer ports in use. For example in Linux/MacOS `sudo lsof -nP -iTCP:<debugPort> -sTCP:LISTEN`, in Windows `netstat -ano | findstr :<debugPort>` Replace `<debugPort>` with the number.
3. Observe results. If you test with a port already in use, an error should be thrown.

- Expected behaviour:

The debug adapter will use the port defined in launch.json debugPort field as server port.  If you test with a port already in use, an error should be thrown.

- Expected output:

The debug adapter will use the port defined in launch.json debugPort field as server port.

## How has this been tested?

Manual test using steps above.

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS): Windows MacOS

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
