### PR TITLE
close openOCD after jtag flash end

### DIFF
--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -81,6 +81,9 @@ export async function jtagFlashCommand(workspace: Uri) {
     const msg = "⚡️ Flashed Successfully (JTag)";
     OutputChannel.appendLineAndShow(msg, "Flash");
     Logger.infoNotify(msg);
+    const closingOpenOCDMsg = "Closing OpenOCD server connection...";
+    OutputChannel.appendLineAndShow(closingOpenOCDMsg, "Flash");
+    OpenOCDManager.init().stop();
   } catch (msg) {
     OpenOCDManager.init().showOutputChannel(true);
     OutputChannel.appendLine(msg, "Flash");


### PR DESCRIPTION
## Description

After JTAG flash finish, close openOCD server.

Fixes #1589

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Flash (with JTag)" to flash a ESP-IDF project with jttag.
2. Execute action. If OpenOCD is not launched a prompt will be ask to launch it.
3. Observe results. After flash end, the openOCD server connection will end.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual steps as described above

**Test Configuration**:
* ESP-IDF Version: 5.4.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
