### PR TITLE
fix: address JTAG acronym issues

### DIFF
--- a/src/flash/jtag.ts
+++ b/src/flash/jtag.ts
@@ -36,7 +36,7 @@ export class JTAGFlash {
           }
           if (response !== "0") {
             return reject(
-              `Failed to flash the device (JTag), please try again [got response: '${response}', expecting: '0']`
+              `Failed to flash the device (JTAG), please try again [got response: '${response}', expecting: '0']`
             );
           }
 
@@ -45,7 +45,7 @@ export class JTAGFlash {
         })
         .on("error", (err) => {
           reject(
-            "Failed to flash (via JTag), due to some unknown error in tcl, please try to relaunch open-ocd"
+            "Failed to flash (via JTAG), due to some unknown error in tcl, please try to relaunch open-ocd"
           );
         })
         .sendCommand(fullCommand);

--- a/src/flash/jtagCmd.ts
+++ b/src/flash/jtagCmd.ts
@@ -31,7 +31,7 @@ export async function jtagFlashCommand(workspace: Uri) {
   const isOpenOCDLaunched = await OpenOCDManager.init().promptUserToLaunchOpenOCDServer();
   if (!isOpenOCDLaunched) {
     const errStr =
-      "Can't perform JTag flash, because OpenOCD server is not running!";
+      "Can't perform JTAG flash, because OpenOCD server is not running!";
     OutputChannel.appendLineAndShow(errStr, "Flash");
     return Logger.warnNotify(errStr);
   }
@@ -78,7 +78,7 @@ export async function jtagFlashCommand(workspace: Uri) {
     );
     await customTask.addCustomTask(CustomTaskType.PostFlash);
     await customTask.runTasks(CustomTaskType.PostFlash);
-    const msg = "⚡️ Flashed Successfully (JTag)";
+    const msg = "⚡️ Flashed Successfully (JTAG)";
     OutputChannel.appendLineAndShow(msg, "Flash");
     Logger.infoNotify(msg);
   } catch (msg) {


### PR DESCRIPTION
## Description

Fix JTAG acronym issues — in the IDE, it was used as ‘JTag’ in a couple of places

Fixes [VSC-1722](https://jira.espressif.com:8443/browse/VSC-1722)

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Steps to test this pull request

NA

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
