### PR TITLE
Update fileExists check in SetupPanel.ts to only require read and execute permissions

### DIFF
--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -23,6 +23,7 @@ import { ESP } from "../config";
 import * as idfConf from "../idfConfiguration";
 import { ensureDir } from "fs-extra";
 import path from "path";
+import * as fs from "fs";
 import {
   CancellationToken,
   ConfigurationTarget,
@@ -329,7 +330,8 @@ export class SetupPanel {
         case "canAccessFile":
           if (message.path) {
             const pathIdfPy = path.join(message.path, "tools", "idf.py");
-            const fileExists = await canAccessFile(pathIdfPy);
+            // Only require read and execute permissions
+            const fileExists = await canAccessFile(pathIdfPy, fs.constants.R_OK | fs.constants.X_OK);
             if (!fileExists) {
               this.panel.webview.postMessage({
                 command: "canAccessFileResponse",


### PR DESCRIPTION
…

## Description

This updates the setup wizard to only require read and execute access to idf.py. This enables it to work with ESP-IDF installations in readonly directories such as `/nix/store/

Fixes #1608

## Type of change

- Bug fix (non-breaking change which fixes an issue)