### PR TITLE
[VSC-1672] fix: append Git and Pigweed paths to PATH instead of prepending

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1199,10 +1199,16 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     }
   }
 
-  if (pathToGitDir && !modifiedEnv[pathNameInEnv].split(path.delimiter).includes(pathToGitDir)) {
+  if (
+    pathToGitDir &&
+    !modifiedEnv[pathNameInEnv].split(path.delimiter).includes(pathToGitDir)
+  ) {
     modifiedEnv[pathNameInEnv] += path.delimiter + pathToGitDir;
   }
-  if (pathToPigweed && !modifiedEnv[pathNameInEnv].split(path.delimiter).includes(pathToPigweed)) {
+  if (
+    pathToPigweed &&
+    !modifiedEnv[pathNameInEnv].split(path.delimiter).includes(pathToPigweed)
+  ) {
     modifiedEnv[pathNameInEnv] += path.delimiter + pathToPigweed;
   }
 


### PR DESCRIPTION
## Description

Previously, the extension prepended the Git path (and Pigweed path, if present) to the PATH environment variable. This could override the Python interpreter from the ESP-IDF virtual environment and other critical tools, especially if the Git path points to a system directory like /usr/bin.

Now, both the Git and Pigweed paths are appended to PATH, ensuring that the ESP-IDF toolchain and Python venv remain the highest priority. This prevents accidental overrides and resolves issues where the wrong Python interpreter is used in the IDF terminal.

Fixes #1539

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Open the settings and change the git path to "/usr/bin/git"
<img width="946" height="339" alt="image (1)" src="https://github.com/user-attachments/assets/ded9d089-2988-4a8e-992b-7bb8bdefdc1b" />

The expected behavior is that the `/usr/bin` should not be before ESP-IDF toolchain or Python venv in the $PATH.

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: 6.0.0
* OS (Windows,Linux and macOS): WSL

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
