### PR TITLE
add detect option auto assign serial port, show current selected port

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -135,6 +135,8 @@
   "Error encountered while calling idf_size.py": "Error encontrado al llamar a idf_size.py",
   "Select the available serial port where your device is connected.": "Seleccione el puerto serie disponible donde está conectado su dispositivo.",
   "Port has been updated to ": "El puerto ha sido actualizado a ",
+  "No serial port found for current IDF_TARGET: {0}": "No se encontró puerto serie para el IDF_TARGET actual: {0}",
+  "Detecting Espressif device serial port...": "Detectando puerto serie del dispositivo Espressif...",
   "{buildFile} doesn't exist. Build first.": "{buildFile} no existe. Compile primero.",
   "SDK Configuration editor": "Editor de configuración del SDK",
   "Save": "Ahorrar",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -135,6 +135,8 @@
   "Error encountered while calling idf_size.py": "Erro encontrado ao chamar idf_size.py",
   "Select the available serial port where your device is connected.": "Selecione a porta serial disponível onde seu dispositivo está conectado.",
   "Port has been updated to ": "A porta foi atualizada para ",
+  "No serial port found for current IDF_TARGET: {0}": "Nenhuma porta serial encontrada para o IDF_TARGET atual: {0}",
+  "Detecting Espressif device serial port...": "Detectando porta serial do dispositivo Espressif...",
   "{buildFile} doesn't exist. Build first.": "{buildFile} {buildFile} não existe. Crie primeiro.",
   "SDK Configuration editor": "Editor de configuração do SDK",
   "Save": "Salvar",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -135,6 +135,8 @@
   "Error encountered while calling idf_size.py": "Ошибка при вызове idf_size.py",
   "Select the available serial port where your device is connected.": "Выберите доступный последовательный порт, к которому подключено ваше устройство.",
   "Port has been updated to ": "Порт обновлен до ",
+  "No serial port found for current IDF_TARGET: {0}": "Последовательный порт не найден для текущего IDF_TARGET: {0}",
+  "Detecting Espressif device serial port...": "Обнаружение последовательного порта устройства Espressif...",
   "{buildFile} doesn't exist. Build first.": "{buildFile} не существует. Сначала выполните сборку.",
   "SDK Configuration editor": "Редактор конфигурации SDK",
   "Save": "Сохранить",

--- a/l10n/bundle.l10n.zh-CN.json
+++ b/l10n/bundle.l10n.zh-CN.json
@@ -135,6 +135,8 @@
   "Error encountered while calling idf_size.py": "调用 idf_size.py 时出错",
   "Select the available serial port where your device is connected.": "为设备选择可用的串口。",
   "Port has been updated to ": "端口已更新为 ",
+  "No serial port found for current IDF_TARGET: {0}": "未找到当前 IDF_TARGET 的串口：{0}",
+  "Detecting Espressif device serial port...": "正在检测 Espressif 设备串口...",
   "{buildFile} doesn't exist. Build first.": "{buildFile}不存在，请先进行生成。",
   "SDK Configuration editor": "SDK 配置编辑器",
   "Save": "保存",

--- a/src/component-manager/utils.ts
+++ b/src/component-manager/utils.ts
@@ -54,10 +54,8 @@ export async function addDependency(
       {
         cwd: workspace.fsPath,
         env: modifiedEnv,
+        cancelToken
       },
-      undefined,
-      undefined,
-      cancelToken
     );
     Logger.infoNotify(
       `Added dependency ${dependency} to the component "${component}"`

--- a/src/espIdf/serial/serialPort.ts
+++ b/src/espIdf/serial/serialPort.ts
@@ -25,8 +25,43 @@ import { SerialPortDetails } from "./serialPortDetails";
 import { OutputChannel } from "../../logger/outputChannel";
 import * as SerialPortLib from "serialport";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
+import { getIdfTargetFromSdkconfig } from "../../workspaceConfig";
 
 export class SerialPort {
+  /**
+   * Convert between TTY and CU port names on macOS
+   * @param portName The port name to convert
+   * @returns The converted port name (TTY to CU or CU to TTY)
+   */
+  private static convertPortName(portName: string): string {
+    if (portName.startsWith("/dev/tty.")) {
+      return portName.replace("/dev/tty.", "/dev/cu.");
+    } else if (portName.startsWith("/dev/cu.")) {
+      return portName.replace("/dev/cu.", "/dev/tty.");
+    }
+    return portName;
+  }
+
+  /**
+   * Check if two port names refer to the same physical device
+   * @param port1 First port name
+   * @param port2 Second port name
+   * @returns True if they refer to the same device
+   */
+  private static isSamePort(port1: string, port2: string): boolean {
+    if (port1 === port2) return true;
+
+    // Convert both to TTY format for comparison
+    const tty1 = port1.startsWith("/dev/tty.")
+      ? port1
+      : this.convertPortName(port1);
+    const tty2 = port2.startsWith("/dev/tty.")
+      ? port2
+      : this.convertPortName(port2);
+
+    return tty1 === tty2;
+  }
+
   public static shared(): SerialPort {
     if (!SerialPort.instance) {
       SerialPort.instance = new SerialPort();
@@ -41,6 +76,127 @@ export class SerialPort {
   ) {
     return SerialPort.shared().displayList(workspaceFolder, useMonitorPort);
   }
+
+  /**
+   * Detect the default serial port using esptool.py
+   * @param workspaceFolder The workspace folder
+   * @returns The detected port or undefined if no device found
+   */
+  public static async detectDefaultPort(
+    workspaceFolder: vscode.Uri
+  ): Promise<string | undefined> {
+    return vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: vscode.l10n.t("Detecting Espressif device serial port..."),
+        cancellable: false,
+      },
+      async (progress) => {
+        try {
+          const idfPath = idfConf.readParameter(
+            "idf.espIdfPath",
+            workspaceFolder
+          ) as string;
+          const pythonBinPath = await getVirtualEnvPythonPath(workspaceFolder);
+          const esptoolPath = join(
+            idfPath,
+            "components",
+            "esptool_py",
+            "esptool",
+            "esptool.py"
+          );
+
+          const targetMatch = await getIdfTargetFromSdkconfig(workspaceFolder);
+          const expectedTarget = targetMatch ? targetMatch : "esp32"; // fallback to esp32
+
+          // Use esptool.py to detect the default connected device
+          OutputChannel.show();
+          OutputChannel.appendLine(
+            `Detecting default port using esptool.py...`
+          );
+          const result = await spawn(pythonBinPath, [esptoolPath, "chip_id"], {
+            silent: false,
+            appendMode: "append",
+          });
+
+          const output = result.toString();
+          const lines = output.split("\n");
+
+          let currentPort: string | undefined;
+          let foundWorkingPort: string | undefined;
+          let portCount = 0;
+          let testedPorts = 0;
+
+          // Count total ports first
+          for (const line of lines) {
+            const portMatch = line.match(/Serial port\s+(\S+)/);
+            if (portMatch) {
+              portCount++;
+            }
+          }
+
+          // Parse the output to find the working port
+          for (const line of lines) {
+            // Look for "Serial port" lines to track which port is being tested
+            const portMatch = line.match(/Serial port\s+(\S+)/);
+            if (portMatch) {
+              currentPort = portMatch[1];
+              testedPorts++;
+              progress.report({
+                message: vscode.l10n.t(
+                  "Testing port {0} ({1}/{2})",
+                  currentPort,
+                  testedPorts,
+                  portCount
+                ),
+                increment: portCount > 0 ? 100 / portCount : 0,
+              });
+              continue;
+            }
+
+            // Look for "Chip is" lines to identify successful connections
+            const chipMatch = line.match(/Chip is\s+([^(]+)/);
+            if (chipMatch && currentPort) {
+              const chipType = chipMatch[1]
+                .trim()
+                .toLowerCase()
+                .replace(/-/g, "");
+
+              // Check if the chip type matches the expected target
+              if (chipType.includes(expectedTarget.toLowerCase())) {
+                foundWorkingPort = this.convertPortName(currentPort);
+                break;
+              }
+            }
+
+            // If we see a failure message, reset currentPort
+            if (
+              line.includes("failed to connect") ||
+              line.includes("No serial data received")
+            ) {
+              currentPort = undefined;
+            }
+          }
+
+          if (!foundWorkingPort) {
+            progress.report({
+              message: vscode.l10n.t("No compatible device found"),
+            });
+          }
+
+          return foundWorkingPort;
+        } catch (error) {
+          Logger.error(
+            "Failed to detect default serial port",
+            error,
+            "serialPort detectDefaultPort"
+          );
+          return undefined;
+        }
+      }
+    );
+  }
+
   private async displayList(
     workspaceFolder: vscode.Uri,
     useMonitorPort: boolean
@@ -51,21 +207,86 @@ export class SerialPort {
 
     try {
       let portList: SerialPortDetails[] = await this.list(workspaceFolder);
-      const chosen = await vscode.window.showQuickPick(
-        portList.map((l: SerialPortDetails) => {
-          return {
-            description: l.chipType || l.manufacturer,
-            label: l.comName,
-          };
-        }),
-        { placeHolder: msg }
+
+      // Get the currently selected port
+      const portSetting2Use = useMonitorPort ? "idf.monitorPort" : "idf.port";
+      const currentPort = idfConf.readParameter(
+        portSetting2Use,
+        workspaceFolder
+      ) as string;
+
+      // Add the "detect" option at the beginning of the list
+      const detectOption = {
+        description: vscode.l10n.t(
+          "Auto-detect port (let esptool.py find the device automatically)"
+        ),
+        label: "detect",
+        picked: false,
+      };
+
+      const portOptions = portList.map((l: SerialPortDetails) => {
+        return {
+          description: l.chipType || l.manufacturer,
+          label: l.comName,
+          picked: SerialPort.isSamePort(l.comName, currentPort),
+        };
+      });
+
+      const allOptions = [detectOption, ...portOptions];
+
+      // Create QuickPick and show currently selected port
+      const quickPick = vscode.window.createQuickPick<{
+        description: string;
+        label: string;
+        picked: boolean;
+      }>();
+      quickPick.placeholder = msg;
+      quickPick.items = allOptions;
+      quickPick.activeItems = quickPick.items.filter((item) => item.picked);
+
+      const chosen = await new Promise<vscode.QuickPickItem | undefined>(
+        (resolve) => {
+          quickPick.onDidAccept(() => {
+            resolve(quickPick.selectedItems[0]);
+          });
+          quickPick.onDidHide(() => {
+            resolve(undefined);
+          });
+          quickPick.show();
+        }
       );
+
+      quickPick.dispose();
+
       if (chosen && chosen.label) {
-        await this.updatePortListStatus(
-          chosen.label,
-          workspaceFolder,
-          useMonitorPort
-        );
+        if (chosen.label === "detect") {
+          const detectedPort = await SerialPort.detectDefaultPort(
+            workspaceFolder
+          );
+          if (detectedPort) {
+            await this.updatePortListStatus(
+              detectedPort,
+              workspaceFolder,
+              useMonitorPort
+            );
+          } else {
+            const targetMatch = await getIdfTargetFromSdkconfig(
+              workspaceFolder
+            );
+            const currentTarget = targetMatch ? targetMatch : "esp32";
+            const noPortFoundMsg = vscode.l10n.t(
+              "No serial port found for current IDF_TARGET: {0}",
+              currentTarget
+            );
+            Logger.infoNotify(noPortFoundMsg);
+          }
+        } else {
+          await this.updatePortListStatus(
+            chosen.label,
+            workspaceFolder,
+            useMonitorPort
+          );
+        }
       }
     } catch (error) {
       const msg = error.message
@@ -175,9 +396,7 @@ export class SerialPort {
             const chipIdBuffer = await spawn(
               pythonBinPath,
               [esptoolPath, "--port", serialPort.comName, "chip_id"],
-              {},
-              2000, // success is quick, failing takes too much time
-              true
+              { timeout: 2000, silent: true, appendMode: "append" }
             );
             const regexp = /Chip is(.*?)[\r]?\n/;
             const chipIdString = chipIdBuffer.toString().match(regexp);

--- a/src/espIdf/tracing/tools/xtensa/abstractXtensaTools.ts
+++ b/src/espIdf/tracing/tools/xtensa/abstractXtensaTools.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Thursday, 22nd August 2019 6:11:02 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,6 @@
  */
 
 import * as vscode from "vscode";
-import * as idfConf from "../../../../idfConfiguration";
 import { Logger } from "../../../../logger/logger";
 import { appendIdfAndToolsToPath, getToolchainToolName, spawn } from "../../../../utils";
 import { getIdfTargetFromSdkconfig } from "../../../../workspaceConfig";

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -153,8 +153,7 @@ export async function installPythonEnvFromIdfTools(
     pythonBinPath,
     [idfToolsPyPath, "install-python-env"],
     pyTracker,
-    { env: modifiedEnv, cwd: idfToolsDir },
-    cancelToken
+    { env: modifiedEnv, cwd: idfToolsDir, cancelToken }
   );
 
   const virtualEnvPython = await getPythonEnvPath(
@@ -170,8 +169,11 @@ export async function installExtensionPyReqs(
   espDir: string,
   idfToolsDir: string,
   pyTracker?: PyReqLog,
-  opts?: { env: NodeJS.ProcessEnv; cwd: string },
-  cancelToken?: CancellationToken
+  opts?: {
+    env: NodeJS.ProcessEnv;
+    cwd: string;
+    cancelToken?: CancellationToken;
+  }
 ) {
   const reqDoesNotExists = " doesn't exist. Make sure the path is correct.";
   const debugAdapterRequirements = join(
@@ -228,13 +230,7 @@ export async function installExtensionPyReqs(
     "--extra-index-url",
     "https://dl.espressif.com/pypi",
   ];
-  await execProcessWithLog(
-    virtualEnvPython,
-    args,
-    pyTracker,
-    opts,
-    cancelToken
-  );
+  await execProcessWithLog(virtualEnvPython, args, pyTracker, opts);
 }
 
 export async function installEspMatterPyReqs(
@@ -248,7 +244,7 @@ export async function installEspMatterPyReqs(
   const modifiedEnv: { [key: string]: string } = <{ [key: string]: string }>(
     Object.assign({}, process.env)
   );
-  const opts = { env: modifiedEnv, cwd: idfToolsDir };
+  const opts = { env: modifiedEnv, cwd: idfToolsDir, cancelToken };
   const virtualEnvPython = await getPythonEnvPath(
     espDir,
     idfToolsDir,
@@ -279,31 +275,20 @@ export async function installEspMatterPyReqs(
     "--extra-index-url",
     "https://dl.espressif.com/pypi",
   ];
-  await execProcessWithLog(
-    virtualEnvPython,
-    args,
-    pyTracker,
-    opts,
-    cancelToken
-  );
+  await execProcessWithLog(virtualEnvPython, args, pyTracker, opts);
   return virtualEnvPython;
 }
 export async function execProcessWithLog(
   cmd: string,
   args: string[],
   pyTracker?: PyReqLog,
-  opts?: { env: NodeJS.ProcessEnv; cwd: string },
-  cancelToken?: CancellationToken
+  opts?: {
+    env: NodeJS.ProcessEnv;
+    cwd: string;
+    cancelToken?: CancellationToken;
+  }
 ) {
-  const processResult = await utils.spawn(
-    cmd,
-    args,
-    opts,
-    undefined,
-    undefined,
-    cancelToken,
-    undefined
-  );
+  const processResult = await utils.spawn(cmd, args, opts);
   Logger.info(processResult + "\n");
   if (pyTracker) {
     pyTracker.Log = processResult + "\n";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,33 +144,48 @@ export class PreCheck {
   }
 }
 
+export interface ISpawnOptions extends childProcess.SpawnOptions {
+  /** Cancellation token to cancel the spawn */
+  cancelToken?: vscode.CancellationToken;
+  /** The maximum time in milliseconds to wait for the command to complete */
+  timeout?: number;
+  /** Whether to suppress output to the console */
+  silent?: boolean;
+  /** A string to return the output of the command */
+  outputString?: string;
+  /** Output append mode: 'appendLine', 'append', or undefined */
+  appendMode?: "appendLine" | "append";
+}
+
 export function spawn(
   command: string,
   args: string[] = [],
-  options: any = {},
-  timeout: number = 0,
-  silent: boolean = false, // this switches the output to console off the output is only returned, not printed,
-  cancelToken?: vscode.CancellationToken,
-  outputString?: string
+  options: ISpawnOptions = { outputString: "", silent: true }
 ): Promise<Buffer> {
   let buff = Buffer.alloc(0);
   const sendToOutputChannel = (data: Buffer) => {
     buff = Buffer.concat([buff, data]);
-    outputString += buff.toString();
-    !silent && OutputChannel.appendLine(data.toString());
+    options.outputString += buff.toString();
+    if (!options.silent) {
+      if (options.appendMode === "appendLine") {
+        OutputChannel.appendLine(data.toString());
+      } else if (options.appendMode === "append") {
+        OutputChannel.append(data.toString());
+      }
+    }
   };
   return new Promise((resolve, reject) => {
     options.cwd = options.cwd || path.resolve(path.join(__dirname, ".."));
     const child = childProcess.spawn(command, args, options);
     let timeoutHandler = undefined;
-    if (timeout > 0) {
+    if (options.timeout > 0) {
       timeoutHandler = setTimeout(() => {
         child.kill();
-      }, timeout);
+      }, options.timeout);
     }
 
-    if (cancelToken) {
-      cancelToken.onCancellationRequested((e) => {
+    if (options.cancelToken) {
+      options.cancelToken.onCancellationRequested((e) => {
         child.kill();
       });
     }


### PR DESCRIPTION
## Description

UX: Add "detect" option in `ESP-IDF: Select Port to Use` which will run esptool.py chip_id to find the serial port for the current IDF_TARGET. The value found will be saved in `idf.port` configuration setting.

This pull request introduces enhancements to serial port detection, refactors the `spawn` utility function, and updates localization files to support new messages. The most significant changes focus on improving the user experience for serial port selection and detection, as well as streamlining the codebase for better maintainability.

### Serial Port Enhancements:
* Added a new method `detectDefaultPort` in the `SerialPort` class to automatically detect the default serial port using `esptool.py`. This includes progress reporting and fallback logic for unsupported devices (`src/espIdf/serial/serialPort.ts`, [src/espIdf/serial/serialPort.tsR79-R199](diffhunk://#diff-af1e6226c220de04f494ef4caf2d9e56d0917d523496393cc975fa216c019cb2R79-R199)).
* Introduced a "detect" option in the serial port QuickPick UI to allow users to automatically find a compatible device. This includes logic to highlight the currently selected port (`src/espIdf/serial/serialPort.ts`, [src/espIdf/serial/serialPort.tsL54-R290](diffhunk://#diff-af1e6226c220de04f494ef4caf2d9e56d0917d523496393cc975fa216c019cb2L54-R290)).
* Added helper methods `convertPortName` and `isSamePort` to handle port name conversions and comparisons on macOS (`src/espIdf/serial/serialPort.ts`, [src/espIdf/serial/serialPort.tsR28-R64](diffhunk://#diff-af1e6226c220de04f494ef4caf2d9e56d0917d523496393cc975fa216c019cb2R28-R64)).

### Refactoring and Utility Improvements:
* Refactored the `spawn` function to use a new `ISpawnOptions` interface, consolidating parameters like `timeout`, `silent`, and `cancelToken`. This simplifies the function signature and improves flexibility (`src/utils.ts`, [src/utils.tsR147-R188](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R147-R188)).
* Updated multiple methods across the codebase to use the new `ISpawnOptions` interface, including Python environment setup and dependency installation (`src/pythonManager.ts`, [[1]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eL156-R156) [[2]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eL173-R176) [[3]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eL251-R247).

### Localization Updates:
* Added new localized strings for serial port detection messages in Spanish, Portuguese, Russian, and Chinese. These messages support the enhanced serial port detection functionality (`l10n/bundle.l10n.es.json`, [[1]](diffhunk://#diff-9b13db6e50bcc1146a3f5e27d797eb20f3a03edb7a414916e3b337c720473535R138-R139); `l10n/bundle.l10n.pt.json`, [[2]](diffhunk://#diff-1680aa1236ddfc509de87712e485c945d1720ac1c24832fcca8817a7ae514bf9R138-R139); `l10n/bundle.l10n.ru.json`, [[3]](diffhunk://#diff-f75f879fe95016ecc72cb955a106519147038462b83a621119d4a21490d65802R138-R139); `l10n/bundle.l10n.zh-CN.json`, [[4]](diffhunk://#diff-fe68d1be609edb077a2a319cf0e1ff561d05bc19a51aa80f558023656952cd3eR138-R139).

### Minor Changes:
* Removed unused imports and fixed formatting issues in `abstractXtensaTools.ts` (`src/espIdf/tracing/tools/xtensa/abstractXtensaTools.ts`, [[1]](diffhunk://#diff-29c1cf570981bab75ef195cdd9f63310d29312b5618f3078e538a2b0c34cabb9L5-R11) [[2]](diffhunk://#diff-29c1cf570981bab75ef195cdd9f63310d29312b5618f3078e538a2b0c34cabb9L20).
* Adjusted the `addDependency` function to remove redundant parameters (`src/component-manager/utils.ts`, [src/component-manager/utils.tsL57-R58](diffhunk://#diff-cec8244233de35e8894df4e35e69765a342ccb29d2952937122ec3ee9c3ea4edL57-R58)). 

These changes collectively improve the serial port handling experience, enhance code clarity, and ensure better localization support.

Fixes #1602

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Select Port to Use". 
2. Choose detect option. The ESP-IDF output channel will appear showing the progress output.
3. A information message is shown the serial port has been updated.
4. Click on "ESP-IDF: Select Port to Use". The current serial port is automatically selected from dropdown list.

- Expected behaviour:

- Expected output:

## How has this been tested?

Manual steps as described above.

**Test Configuration**:
* ESP-IDF Version: 5.4.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
