### PR TITLE
[VSC-1694] add function names in disassembly view

### DIFF
--- a/src/cdtDebugAdapter/adapter/GDBBackend.ts
+++ b/src/cdtDebugAdapter/adapter/GDBBackend.ts
@@ -295,7 +295,7 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendLoad(imageFileName: string, imageOffset: string | undefined) {
         return this.sendCommand(
-            `load ${this.standardEscape(imageFileName)} ${imageOffset || ''}`
+            `mon program_esp ${this.standardEscape(imageFileName)} ${imageOffset || ''}`
         );
     }
 

--- a/src/cdtDebugAdapter/adapter/util/disassembly.ts
+++ b/src/cdtDebugAdapter/adapter/util/disassembly.ts
@@ -143,8 +143,6 @@ export const getInstructions = async (
                 location,
                 line: line ? line - 1 : undefined, // Show it before the current line
               } as DebugProtocol.DisassembledInstruction;
-
-                          // Insert the function declaration before the current instruction
             list.push(funcDeclInstruction);
             globalInsertedFunctions.add(asmLine["func-name"]);
           } catch (error) {


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the disassembly functionality in the `cdtDebugAdapter` module, improves memory management by introducing a cache for function declarations in disassembly view, and updates the GDB command for loading programs.

### Enhancements to disassembly functionality:

* Introduced a global cache (`globalInsertedFunctions`) to track inserted function declarations, preventing duplicate entries across multiple disassembly calls in `disassembly.ts`.
* Updated the `getInstructions` function to insert function declarations dynamically by querying the function's start address using GDB commands. This ensures accurate and non-redundant function declarations in the disassembly output.
* Added a `clearInsertedFunctionsCache` method to reset the cache, ensuring consistency when the program state changes. This method is invoked before handling new disassembly requests in `GDBDebugSession`. [[1]](diffhunk://#diff-6aec59998a4705e7ec76129da216698e129e65d37e922f82ada0b342b1decc4aL11-R27) [[2]](diffhunk://#diff-1a43bf074c3371f341c37a2954b8a9a6d5ab0fb2332d6ea20456d270a9d28c26R1575-R1579)

### Updates to GDB command:

* Modified the `sendLoad` method in `GDBBackend` to use the `mon program_esp` command instead of `load`, aligning with the updated GDB command syntax for loading programs.

### Code cleanup and imports:

* Simplified import statements in `GDBDebugSession.ts` and `disassembly.ts` by consolidating multi-line imports into single lines and removing unused imports. [[1]](diffhunk://#diff-1a43bf074c3371f341c37a2954b8a9a6d5ab0fb2332d6ea20456d270a9d28c26L30-R35) [[2]](diffhunk://#diff-6aec59998a4705e7ec76129da216698e129e65d37e922f82ada0b342b1decc4aL11-R27)

Fixes #1564

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request


1. Start a debug session with an ESP-IDF project using Eclipse CDT Debug Adapter.
2.  Right click in the source code file and click Open disassembly View
3. Observe results. You should function names before `{` or the inner function code.

- Expected behaviour:

Functions declarations should be shown in disassembly view to mark beginning and end of function. Every inner code line also shows function name `; <function_name>` after assembly code.

- Expected output:

Something like

```
44: static void configure_led(void)
0x420061e8:  configure_led:
45: {
0x420061ea: 00 81 94 extui a8, a0, 1, 10  ; configure_led
```

## How has this been tested?

Manual steps as described above.

**Test Configuration**:
* ESP-IDF Version: 5.4.2
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
