### PR TITLE
use latest instead of master in docs

### DIFF
--- a/docs_espressif/_static/docs_version.js
+++ b/docs_espressif/_static/docs_version.js
@@ -3,7 +3,7 @@ var DOCUMENTATION_VERSIONS = {
                 supported_targets: [ "esp32" ]
               },
     VERSIONS: [
-        { name: "master", old: false },
+        { name: "latest", old: false },
         { name: "release-v2.0", pre_release: true }
     ],
 };


### PR DESCRIPTION
## Description

This pull request updates the documentation versioning in the `docs_espressif/_static/docs_version.js` file to improve clarity and align with naming conventions.

* Updated the version name from `"master"` to `"latest"` in the `VERSIONS` array to reflect the current naming standard.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Steps to test this pull request

Open documentation and click on latest. It should work. Click release/v2.0 it should also work.

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
