### PR TITLE
[chore][setup]: misleading idf.py not found error (VSC-1761)

### DIFF
--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -282,9 +282,8 @@ export class SetupPanel {
             });
             SetupPanel.postMessage({
               command: "setEspIdfErrorStatus",
-              errorMsg: `ESP-IDF is installed in ${
-                setupArgs.existingIdfSetups[message.selectedIdfSetup].idfPath
-              }`,
+              errorMsg: `ESP-IDF is installed in ${setupArgs.existingIdfSetups[message.selectedIdfSetup].idfPath
+                }`,
             });
             this.panel.webview.postMessage({
               command: "updateEspIdfToolsStatus",
@@ -325,40 +324,44 @@ export class SetupPanel {
           await commands.executeCommand("esp.component-manager.ui.show");
           break;
         case "canAccessFile":
-          if (message.path) {
-            const pathIdfPy = path.join(message.path, "tools", "idf.py");
-            // Only require read and execute permissions
-            const fileExists = await canAccessFile(pathIdfPy, fs.constants.R_OK | fs.constants.X_OK);
-            if (!fileExists) {
-              this.panel.webview.postMessage({
-                command: "canAccessFileResponse",
-                path: message.path,
-                exists: fileExists,
-              });
-            } else {
-              let versionEspIdf;
-              if (
-                message.currentVersion &&
-                typeof message.currentVersion === "string"
-              ) {
-                versionEspIdf = message.currentVersion;
-              } else {
-                versionEspIdf = await getEspIdfFromCMake(message.path);
-              }
-              // compareVersion returns a negative value if versionEspIdf is less than "5.0"
-              const noWhiteSpaceSupport =
-                compareVersion(versionEspIdf, "5.0") < 0;
-              const hasWhitespace = /\s/.test(message.path);
-              this.panel.webview.postMessage({
-                command: "canAccessFileResponse",
-                path: message.path,
-                exists: fileExists,
-                noWhiteSpaceSupport,
-                hasWhitespace,
-              });
-            }
+          if (!message.path) {
+            break;
           }
+
+          const pathIdfPy = path.join(message.path, "tools", "idf.py");
+          // Only require read and execute permissions
+          const fileExists = await canAccessFile(pathIdfPy, fs.constants.R_OK | fs.constants.X_OK);
+          if (!fileExists) {
+            this.panel.webview.postMessage({
+              command: "canAccessFileResponse",
+              path: pathIdfPy,
+              exists: fileExists,
+            });
+            break;
+          }
+
+          let versionEspIdf: string;
+          if (
+            message.currentVersion &&
+            typeof message.currentVersion === "string"
+          ) {
+            versionEspIdf = message.currentVersion;
+          } else {
+            versionEspIdf = await getEspIdfFromCMake(message.path);
+          }
+          // compareVersion returns a negative value if versionEspIdf is less than "5.0"
+          const noWhiteSpaceSupport =
+            compareVersion(versionEspIdf, "5.0") < 0;
+          const hasWhitespace = /\s/.test(message.path);
+          this.panel.webview.postMessage({
+            command: "canAccessFileResponse",
+            path: pathIdfPy,
+            exists: fileExists,
+            noWhiteSpaceSupport,
+            hasWhitespace,
+          });
           break;
+
         default:
           break;
       }
@@ -425,7 +428,7 @@ export class SetupPanel {
     ) as string;
     const progressLocation =
       notificationMode === idfConf.NotificationMode.All ||
-      notificationMode === idfConf.NotificationMode.Notifications
+        notificationMode === idfConf.NotificationMode.Notifications
         ? ProgressLocation.Notification
         : ProgressLocation.Window;
     return await window.withProgress(
@@ -559,7 +562,7 @@ export class SetupPanel {
     ) as string;
     const progressLocation =
       notificationMode === idfConf.NotificationMode.All ||
-      notificationMode === idfConf.NotificationMode.Notifications
+        notificationMode === idfConf.NotificationMode.Notifications
         ? ProgressLocation.Notification
         : ProgressLocation.Window;
     return await window.withProgress(
@@ -629,7 +632,7 @@ export class SetupPanel {
     ) as string;
     const progressLocation =
       notificationMode === idfConf.NotificationMode.All ||
-      notificationMode === idfConf.NotificationMode.Notifications
+        notificationMode === idfConf.NotificationMode.Notifications
         ? ProgressLocation.Notification
         : ProgressLocation.Window;
     return await window.withProgress(

--- a/src/views/setup/main.ts
+++ b/src/views/setup/main.ts
@@ -276,7 +276,7 @@ window.addEventListener("message", (event) => {
     case "canAccessFileResponse":
       if (!msg.exists) {
         store.setIdfPathError(
-          "The path for ESP-IDF is not valid: /tools/idf.py not found."
+          `The path for ESP-IDF is not valid: ${msg.path} not found.`
         );
       } else if (msg.noWhiteSpaceSupport && msg.hasWhitespace) {
         store.setIdfPathError(

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -167,7 +167,7 @@ export const useSetupStore = defineStore("setup", () => {
     if (message.command === "canAccessFileResponse") {
       if (!message.exists) {
         setIdfPathError(
-          "The path for ESP-IDF is not valid: /tools/idf.py not found."
+          `The path for ESP-IDF is not valid: ${message.path} not found.`
         );
       } else {
         setIdfPathError("");


### PR DESCRIPTION
The original error message posting `/tools/idf.py` not found, meanwhile the extension don't search this directory, which is misleading.

This PR corrects those messages.

---

BTW, I ought to find out why this extension cannot detect my esp-idf installed with this [ArchLinux AUR repo](https://aur.archlinux.org/packages/esp-idf-git). The repo installs esp-idf to `/opt/esp-idf`, surely there is `./tools/idf.py` or `./tools/export.sh`.

Even I was sure of the existence of `/opt/esp-idf/tools/idf.py`, the extension still keeps yelling `/tools/idf.py` not found. Which I don't reproduce on the master branch. So it's assumed to be fixed and I'll just update the error message here.

---

Feel free to edit this PR, busy working recently.

---

## Description

Please include a summary of the change and which issue is fixed.

Fixes... I hate summaries, here is what *Copilot* concludes:

This pull request improves the handling and reporting of ESP-IDF path validation in the setup flow. The main changes focus on more accurate error messaging and streamlining file access checks.

**Error Messaging Improvements:**

* Updated error messages in both `main.ts` and `store.ts` to display the actual path checked for ESP-IDF validity, making it clearer to users which path is problematic. [[1]](diffhunk://#diff-2fa745df3680502727692fdd70d494a52cc308c4291da679c52b517f93203040L279-R279) [[2]](diffhunk://#diff-8ae1e2219b212e728a7570af4aa7641aec2b3f8cd6ad6f2edead63976198e25aL170-R170)

**File Access Check Logic:**

* Refactored the logic in `SetupPanel.ts` to ensure the file access check only proceeds when a path is provided, and to consistently use the full path to `tools/idf.py` in responses. This prevents unnecessary checks and improves accuracy in reporting. [[1]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL328-R343) [[2]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL354-R364)

**Code Formatting:**

* Minor formatting adjustment to the error message construction in `SetupPanel.ts` for consistency.

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Just opened `configure extension`, select `existing toolchains`, and type in an incorrect ESP-IDF's path like `/booger/aids` to see if it reminds path `/booger/aids/tools/idf.py` not found.

## Dependent components impacted by this PR:

None.

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
