### PR TITLE
fix set target preview targets

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -110,7 +110,10 @@ export class CDTDebugConfigurationProvider
           | "esp32c3"
           | "esp32c6"
           | "esp32h2"
-          | "esp32p4";
+          | "esp32p4"
+          | "esp32c4"
+          | "esp32c5"
+          | "esp32c61";
         // Mapping of idfTarget to corresponding CPU watchpoint numbers
         const idfTargetWatchpointMap: Record<IdfTarget, number> = {
           esp32: 2,
@@ -121,11 +124,14 @@ export class CDTDebugConfigurationProvider
           esp32c6: 4,
           esp32h2: 4,
           esp32p4: 3,
+          esp32c4: 2,
+          esp32c5: 4,
+          esp32c61: 4,
         };
         config.initCommands = config.initCommands.map((cmd: string) =>
           cmd.replace(
             "{IDF_TARGET_CPU_WATCHPOINT_NUM}",
-            idfTargetWatchpointMap[idfTarget]
+            idfTargetWatchpointMap[idfTarget] || 2
           )
         );
       }

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -34,7 +34,7 @@ import {
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
 import { selectOpenOcdConfigFiles } from "../openOcd/boardConfiguration";
-import { getTargetsFromEspIdf } from "./getTargets";
+import { getTargetsFromEspIdf, IdfTarget } from "./getTargets";
 import { setTargetInIDF } from "./setTargetInIdf";
 import { updateCurrentProfileIdfTarget } from "../../project-conf";
 import { DevkitsCommand } from "./DevkitsCommand";
@@ -81,7 +81,7 @@ export async function setIdfTarget(
           try {
             const devkitsCmd = new DevkitsCommand(workspaceFolder.uri);
             const scriptPath = await devkitsCmd.getScriptPath();
-            
+
             if (scriptPath) {
               const devkitsOutput = await devkitsCmd.runDevkitsScript();
               if (devkitsOutput) {
@@ -115,26 +115,31 @@ export async function setIdfTarget(
             "Connected ESP-IDF devkit detection is skipped while debugging. You can still select a target manually."
           );
         }
-        let quickPickItems: any[] = [];
-        if (connectedBoards.length > 0) {
-          quickPickItems = [
-            ...connectedBoards,
-            { kind: QuickPickItemKind.Separator, label: "Default Boards" },
-            ...targetsFromIdf.map((t) => ({
-              label: t.label,
-              target: t.target,
-              description: t.isPreview ? "Preview target" : undefined,
-              isConnected: false,
-            })),
-          ];
-        } else {
-          quickPickItems = targetsFromIdf.map((t) => ({
-            label: t.label,
-            target: t.target,
-            description: t.isPreview ? "Preview target" : undefined,
-            isConnected: false,
-          }));
-        }
+        let quickPickItems: {
+          label: string;
+          idfTarget: IdfTarget;
+          boardInfo?: {
+            location: string;
+            config_files: string[];
+          };
+          description?: string;
+          isConnected?: boolean;
+        }[] = [];
+        const defaultBoards = targetsFromIdf.map((t) => ({
+          label: t.label,
+          target: t,
+          description: t.isPreview ? "Preview target" : undefined,
+          isConnected: false,
+        }));
+
+        quickPickItems =
+          connectedBoards.length > 0
+            ? [
+                ...connectedBoards,
+                { kind: QuickPickItemKind.Separator, label: "Default Boards" },
+                ...defaultBoards,
+              ]
+            : defaultBoards;
         const selectedTarget = await window.showQuickPick(quickPickItems, {
           placeHolder: placeHolderMsg,
         });
@@ -171,16 +176,16 @@ export async function setIdfTarget(
         } else {
           await selectOpenOcdConfigFiles(
             workspaceFolder.uri,
-            selectedTarget.target
+            selectedTarget.idfTarget.target
           );
         }
 
-        await setTargetInIDF(workspaceFolder, selectedTarget);
+        await setTargetInIDF(workspaceFolder, selectedTarget.idfTarget);
         const customExtraVars = readParameter(
           "idf.customExtraVars",
           workspaceFolder
         ) as { [key: string]: string };
-        customExtraVars["IDF_TARGET"] = selectedTarget.target;
+        customExtraVars["IDF_TARGET"] = selectedTarget.idfTarget.target;
         await writeParameter(
           "idf.customExtraVars",
           customExtraVars,
@@ -188,7 +193,7 @@ export async function setIdfTarget(
           workspaceFolder.uri
         );
         await updateCurrentProfileIdfTarget(
-          selectedTarget.target,
+          selectedTarget.idfTarget.target,
           workspaceFolder.uri
         );
       } catch (err) {

--- a/src/statusBar/index.ts
+++ b/src/statusBar/index.ts
@@ -26,6 +26,7 @@ import {
   Uri,
   window,
   l10n,
+  ThemeIcon,
 } from "vscode";
 import { getCurrentIdfSetup } from "../versionSwitcher";
 import { readParameter } from "../idfConfiguration";
@@ -277,7 +278,9 @@ export function updateHintsStatusBarItem(hasHints: boolean) {
     statusBarItems["hints"].tooltip = l10n.t(
       "ESP-IDF: Hints available. Click to view."
     );
-    statusBarItems["hints"].backgroundColor = "statusBarItem.warningBackground";
+    statusBarItems["hints"].backgroundColor = new ThemeIcon(
+      "statusBarItem.warningBackground"
+    );
     statusBarItems["hints"].show();
   } else {
     statusBarItems["hints"].hide();


### PR DESCRIPTION
## Description

#1557 unfortunately introduced a bug, the IDFTarget class was not used in setTargetInIdf.ts so preview targets stopped working (like ESP32C5).

This pull request adds support for new ESP-IDF targets and improves type safety and consistency when selecting and handling targets throughout the codebase. Additionally, there is a minor update to the status bar item background color handling.

### ESP-IDF Target Support Improvements

* Added support for new targets `esp32c4`, `esp32c5`, and `esp32c61` to the `IdfTarget` type and mapped their CPU watchpoint numbers in `src/cdtDebugAdapter/debugConfProvider.ts`. [[1]](diffhunk://#diff-e2fa8de3075b5006c67694fcd088159136af77c6f12fdc3dbecf80de0485d0d1L113-R116) [[2]](diffhunk://#diff-e2fa8de3075b5006c67694fcd088159136af77c6f12fdc3dbecf80de0485d0d1R127-R134)

### Target Selection Refactoring

* Updated the type of quick pick items in `setIdfTarget` to use `IdfTarget` for improved type safety, and refactored how default boards and connected boards are handled when building the selection list in `src/espIdf/setTarget/index.ts`. [[1]](diffhunk://#diff-5f2885ac73a7b85685ca7145e3ee6f710d629d247f4666854dfec29bd5d16bcbL37-R37) [[2]](diffhunk://#diff-5f2885ac73a7b85685ca7145e3ee6f710d629d247f4666854dfec29bd5d16bcbL118-R142)
* Modified logic to consistently access the target via `selectedTarget.idfTarget.target` and ensure correct parameter updates when setting the target in the workspace and configuration.

### UI and Visual Improvements

* Changed the way the status bar item's background color is set for hints, using `ThemeIcon` for better integration with VSCode theming in `src/statusBar/index.ts`. [[1]](diffhunk://#diff-64b64522f212dcded965a6c2f9da2fd629245ae36d50f65857371b62ed8078bfR29) [[2]](diffhunk://#diff-64b64522f212dcded965a6c2f9da2fd629245ae36d50f65857371b62ed8078bfL280-R283)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request


1. Click on **ESP-IDF: Set Espressif Device Target** using a preview target from the list. The command should executed correctly and the new target should be applied to sdkconfig and idf.customExtraVars setting.
2. Execute action.
3. Observe results.

- Expected behaviour:
The command should executed correctly and the new target should be applied to sdkconfig and idf.customExtraVars setting.

- Expected output:
The command should executed correctly and the new target should be applied to sdkconfig and idf.customExtraVars setting.

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: 6.0.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
