### PR TITLE
[VSC-1763] prefer gdbinit prefix_map with fallback to prefix_map_gdbinit

### DIFF
--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -89,9 +89,23 @@ export class CDTDebugConfigurationProvider
         );
         if (isAppReproducibleBuildEnabled === "y") {
           const buildDirPath = readParameter("idf.buildPath", folder) as string;
-          config.initCommands.push(
-            `source ${join(buildDirPath, "prefix_map_gdbinit")}`
-          );
+          const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
+          const gdbinitPrefixMapExists = await pathExists(gdbinitPrefixMap);
+          if (gdbinitPrefixMapExists) {
+            config.initCommands.push(`source ${gdbinitPrefixMap}`);
+          } else {
+            const prefix_map_gdbinit = join(buildDirPath, "prefix_map_gdbinit");
+            const prefix_map_gdbinitExists = await pathExists(
+              prefix_map_gdbinit
+            );
+            if (prefix_map_gdbinitExists) {
+              config.initCommands.push(`source ${prefix_map_gdbinit}`);
+            } else {
+              window.showInformationMessage(
+                `CONFIG_APP_REPRODUCIBLE_BUILD is enabled but no gdbinit prefix map was found.`
+              );
+            }
+          }
         }
         if (typeof config.initialBreakpoint === "undefined") {
           config.initCommands.push(`thb app_main`);


### PR DESCRIPTION
## Description

Support the new `<build_dir>/gdbinit/prefix_map` with fallback to `prefix_map_gdbinit ` for configurable builds.

About this feature: https://github.com/espressif/esp-idf/blob/master/docs/en/api-guides/reproducible-builds.rst#reproducible-builds-and-debugging

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Start a debug session for a project that has `CONFIG_APP_REPRODUCIBLE_BUILD` enabled in SDK Configuration Editor.
2. Execute debug session (F5).
3. Observe results.

- Expected behaviour:

Debug session should work as expected when configurable build are enabled.

- Expected output:

Debug session should work as expected when configurable build are enabled.

## How has this been tested?

Follow steps above

**Test Configuration**:
* ESP-IDF Version: 6.0.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
