### PR TITLE
Clang and OpenOCD binaries in PATH

### DIFF
--- a/src/clang/index.ts
+++ b/src/clang/index.ts
@@ -17,11 +17,7 @@
  */
 
 import { l10n, Uri, workspace } from "vscode";
-import {
-  appendIdfAndToolsToPath,
-  getToolchainPath,
-  isBinInPath,
-} from "../utils";
+import { appendIdfAndToolsToPath, isBinInPath } from "../utils";
 import { pathExists, writeJSON, writeFile } from "fs-extra";
 import { readParameter } from "../idfConfiguration";
 import { join } from "path";
@@ -32,10 +28,7 @@ import { EOL } from "os";
 export async function validateEspClangExists(workspaceFolder: Uri) {
   const modifiedEnv = await appendIdfAndToolsToPath(workspaceFolder);
 
-  const espClangdPath = await isBinInPath(
-    "clangd",
-    modifiedEnv
-  );
+  const espClangdPath = await isBinInPath("clangd", modifiedEnv, ["esp-clang"]);
   if (espClangdPath && espClangdPath.includes("esp-clang")) {
     return espClangdPath;
   }
@@ -62,11 +55,10 @@ export async function setClangSettings(
     return;
   }
   const buildPath = readParameter("idf.buildPath", workspaceFolder);
-  const gccPath = await getToolchainPath(workspaceFolder, "gcc");
   settingsJson["clangd.path"] = espClangPath;
   settingsJson["clangd.arguments"] = [
     "--background-index",
-    `--query-driver=${gccPath}`,
+    `--query-driver=**`,
     `--compile-commands-dir=${buildPath}`,
   ];
 }

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -61,10 +61,13 @@ export class OpenOCDManager extends EventEmitter {
 
   public async version(): Promise<string> {
     const modifiedEnv = await appendIdfAndToolsToPath(this.workspace);
-    if (!isBinInPath("openocd", modifiedEnv)) {
+    const openOcdPath = await isBinInPath("openocd", modifiedEnv, [
+      "openocd-esp32",
+    ]);
+    if (!openOcdPath) {
       return "";
     }
-    const resp = await sspawn("openocd", ["--version"], {
+    const resp = await sspawn(openOcdPath, ["--version"], {
       cwd: this.workspace.fsPath,
       env: modifiedEnv,
     });
@@ -157,7 +160,10 @@ export class OpenOCDManager extends EventEmitter {
       return;
     }
     const modifiedEnv = await appendIdfAndToolsToPath(this.workspace);
-    if (!isBinInPath("openocd", modifiedEnv)) {
+    const openOcdPath = await isBinInPath("openocd", modifiedEnv, [
+      "openocd-esp32",
+    ]);
+    if (!openOcdPath) {
       throw new Error(
         "Invalid OpenOCD bin path or access is denied for the user"
       );
@@ -208,7 +214,7 @@ export class OpenOCDManager extends EventEmitter {
       });
     }
 
-    this.server = spawn("openocd", openOcdArgs, {
+    this.server = spawn(openOcdPath, openOcdArgs, {
       cwd: this.workspace.fsPath,
       env: modifiedEnv,
     });
@@ -263,7 +269,7 @@ export class OpenOCDManager extends EventEmitter {
       }
       this.stop();
     });
-          this.updateStatusText("❇️ OpenOCD Server (Running)");
+    this.updateStatusText("❇️ OpenOCD Server (Running)");
     OutputChannel.show();
   }
 

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -305,7 +305,7 @@ export class NewProjectPanel {
             port,
             selectedIdfTarget,
             openOcdConfigs,
-            workspaceFolder || vscode.Uri.file(newProjectPath)
+            vscode.Uri.file(newProjectPath)
           );
           await createClangdFile(vscode.Uri.file(newProjectPath));
           await writeJSON(settingsJsonPath, settingsJson, {

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -451,44 +451,6 @@ export async function checkPythonExists(pythonBin: string, workingDir: string) {
   return false;
 }
 
-export async function checkPipExists(pyBinPath: string, workingDir: string) {
-  try {
-    const args = ["-m", "pip", "--version"];
-    const pipResult = await utils.execChildProcess(pyBinPath, args, workingDir);
-    if (pipResult) {
-      const match = pipResult.match(/pip\s\d+(.\d+)?(.\d+)?/g);
-      if (match && match.length > 0) {
-        return true;
-      }
-    }
-  } catch (error) {
-    const newErr =
-      error && error.message
-        ? error
-        : new Error("Pip is not found in current environment");
-    Logger.error(newErr.message, newErr, "pythonManager checkPipExists");
-  }
-  return false;
-}
-
-export async function checkVenvExists(pyBinPath: string, workingDir: string) {
-  try {
-    const pipResult = await utils.execChildProcess(
-      pyBinPath,
-      ["-c", "import venv"],
-      workingDir
-    );
-    return true;
-  } catch (error) {
-    const newErr =
-      error && error.message
-        ? error
-        : new Error("Venv is not found in current environment");
-    Logger.error(newErr.message, newErr, "pythonManager checkVenvExists");
-  }
-  return false;
-}
-
 export async function getPythonBinList(workingDir: string) {
   if (process.platform === "win32") {
     return [];

--- a/src/setup/espIdfDownloadStep.ts
+++ b/src/setup/espIdfDownloadStep.ts
@@ -15,14 +15,10 @@
 import { pathExists } from "fs-extra";
 import * as vscode from "vscode";
 import { ESP } from "../config";
-import { checkPythonExists, checkPipExists, checkVenvExists } from "../pythonManager";
+import { checkPythonExists } from "../pythonManager";
 import { SetupPanel } from "./SetupPanel";
 import * as utils from "../utils";
-import {
-  IEspIdfLink,
-  SetupMode,
-  StatusType,
-} from "../views/setup/types";
+import { IEspIdfLink, SetupMode, StatusType } from "../views/setup/types";
 import { downloadInstallIdfVersion } from "./espIdfDownload";
 import { Logger } from "../logger/logger";
 import { downloadIdfTools } from "./toolsDownloadStep";
@@ -50,18 +46,6 @@ export async function expressInstall(
   const doesPythonExists = await checkPythonExists(pyPath, __dirname);
   if (!(pyExists && doesPythonExists)) {
     const containerNotFoundMsg = `${pyPath} is not valid. (ERROR_INVALID_PYTHON)`;
-    Logger.infoNotify(containerNotFoundMsg);
-    throw new Error(containerNotFoundMsg);
-  }
-  const doesPipExists = await checkPipExists(pyPath, __dirname);
-  if (!doesPipExists) {
-    const containerNotFoundMsg = `"${pyPath} -m pip" is not valid. (ERROR_INVALID_PIP)`;
-    Logger.infoNotify(containerNotFoundMsg);
-    throw new Error(containerNotFoundMsg);
-  }
-  const doesVenvExists = await checkVenvExists(pyPath, __dirname);
-  if (!doesVenvExists) {
-    const containerNotFoundMsg = `"${pyPath} -m venv" is not valid. (ERROR_INVALID_VENV)`;
     Logger.infoNotify(containerNotFoundMsg);
     throw new Error(containerNotFoundMsg);
   }

--- a/src/setup/installPyReqs.ts
+++ b/src/setup/installPyReqs.ts
@@ -45,17 +45,6 @@ export async function installPyReqs(
     Logger.info(msg);
     return;
   }
-  const doesPipExists = await pythonManager.checkPipExists(
-    sysPyBinPath,
-    workingDir
-  );
-  if (!doesPipExists) {
-    const msg = "Pip have not been found in your environment.";
-    sendPyReqLog(msg);
-    OutputChannel.appendLine(msg);
-    Logger.info(msg);
-    return;
-  }
   const isNotVirtualEnv = await pythonManager.checkIfNotVirtualEnv(
     sysPyBinPath,
     workingDir

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1302,7 +1302,11 @@ export async function getAllBinPathInEnvPath(
   return foundBinaries;
 }
 
-export async function isBinInPath(binaryName: string, env: NodeJS.ProcessEnv) {
+export async function isBinInPath(
+  binaryName: string,
+  env: NodeJS.ProcessEnv,
+  containerDir?: string[]
+) {
   let pathNameInEnv: string = Object.keys(process.env).find(
     (k) => k.toUpperCase() == "PATH"
   );
@@ -1314,6 +1318,12 @@ export async function isBinInPath(binaryName: string, env: NodeJS.ProcessEnv) {
     }
     const doesPathExists = await pathExists(binaryPath);
     if (doesPathExists) {
+      if (containerDir && containerDir.length) {
+        const resultContainerPath = containerDir.join(path.sep);
+        if (binaryPath.indexOf(resultContainerPath) === -1) {
+          return "";
+        }
+      }
       const pathStats = await stat(binaryPath);
       if (pathStats.isFile() && canAccessFile(binaryPath, fs.constants.X_OK)) {
         return binaryPath;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1201,6 +1201,32 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
     }
   }
 
+  try {
+    const openOcdPath = await isBinInPath("openocd", modifiedEnv, [
+      "openocd-esp32",
+    ]);
+    if (openOcdPath) {
+      const openOcdDir = path.dirname(openOcdPath);
+      const openOcdScriptsPath = path.join(
+        openOcdDir,
+        "..",
+        "share",
+        "openocd",
+        "scripts"
+      );
+      const scriptsExists = await pathExists(openOcdScriptsPath);
+      if (scriptsExists && modifiedEnv.OPENOCD_SCRIPTS !== openOcdScriptsPath) {
+        modifiedEnv.OPENOCD_SCRIPTS = openOcdScriptsPath;
+      }
+    }
+  } catch (error) {
+    Logger.error(
+      `Error processing OPENOCD_SCRIPTS path: ${error.message}`,
+      error,
+      "appendIdfAndToolsToPath OPENOCD_SCRIPTS"
+    );
+  }
+
   if (
     pathToGitDir &&
     !modifiedEnv[pathNameInEnv].split(path.delimiter).includes(pathToGitDir)


### PR DESCRIPTION
Make sure esp-clang and openocd include esp-clang and openocd-esp32 in their resulting binary path.

Update clang query driver to ** 

Fix compile-commands-dir using the wrong workspace when using the new project wizard.

Make sure OPENOCD_SCRIPTS matches the same from openOCD in PATH.

Remove venv and pip validation on setup wizard

## Description

This pull request introduces several improvements and code cleanups related to binary detection and environment setup for ESP-IDF tools, especially around OpenOCD and Clangd integration. The changes enhance how the code locates tool binaries, sets up environment variables, and removes unnecessary Python environment checks.

**Binary detection and environment setup improvements:**

* Updated the `isBinInPath` utility to accept an optional `containerDir` parameter, allowing it to more precisely detect binaries within specific directories (e.g., "esp-clang" or "openocd-esp32") and return the correct path only if the binary is in the intended container. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L1305-R1335) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R1347-R1352)
* Enhanced `appendIdfAndToolsToPath` to automatically set the `OPENOCD_SCRIPTS` environment variable if the OpenOCD binary is found, improving script path configuration for debugging tools.

**OpenOCD and Clangd integration:**

* Refactored OpenOCD management to use the detected binary path from `isBinInPath` (with "openocd-esp32" as a container), ensuring the correct binary is used for version checks and server spawning. [[1]](diffhunk://#diff-52f3a37c5461f3a9923373871914ea79c5405c2d2f75b504bbf269642186fa53L64-R70) [[2]](diffhunk://#diff-52f3a37c5461f3a9923373871914ea79c5405c2d2f75b504bbf269642186fa53L160-R166) [[3]](diffhunk://#diff-52f3a37c5461f3a9923373871914ea79c5405c2d2f75b504bbf269642186fa53L211-R217)
* Improved Clangd detection by searching for "clangd" within the "esp-clang" container directory, and simplified Clangd settings by removing the specific GCC query driver path and using a wildcard instead. [[1]](diffhunk://#diff-e4819cc38a7ee073924286fa5c7615617ff05ffd9b788c682330d2582ebd37c4L35-R31) [[2]](diffhunk://#diff-e4819cc38a7ee073924286fa5c7615617ff05ffd9b788c682330d2582ebd37c4L65-R61)

**Python environment checks cleanup:**

* Removed redundant checks for `pip` and `venv` existence from both the Python manager and setup/install steps, streamlining the setup process and reducing unnecessary error handling. [[1]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eL454-L491) [[2]](diffhunk://#diff-17f1a1bd1e0769b887dd5ebd58d2f9657620b337ce7d641e88dc31844877627dL18-R21) [[3]](diffhunk://#diff-17f1a1bd1e0769b887dd5ebd58d2f9657620b337ce7d641e88dc31844877627dL56-L67) [[4]](diffhunk://#diff-104c92eb5de34178f6fe3a7952f54ee57d0b714fe1e7a2d56a7c40ee6ff61440L48-L58)

**Miscellaneous:**

* Minor code cleanups and parameter adjustments, such as removing unused imports and simplifying workspace folder handling in the new project panel. [[1]](diffhunk://#diff-e4819cc38a7ee073924286fa5c7615617ff05ffd9b788c682330d2582ebd37c4L20-R20) [[2]](diffhunk://#diff-e058176db28046591f012f5a63d2f35f76285b23286c12a61bf0263507047c86L308-R308)

These changes collectively make the ESP-IDF extension's toolchain setup more robust and maintainable, especially in environments with multiple tool versions or custom installations.

Fixes #1596 
Fixes #1661 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Having openocd in /usr/bin/openocd or /usr/bin/clangd in PATH, when running `OpenOCD server` or `ESP-IDF: Configure project for ESP-Clang`  it should use the executable from IDF_TOOLS_PATH instead of /usr/bin.

1. Click on "ESP-IDF: Configure project for ESP-Clang". Make sure no error about missing esp-clang.
2. Execute OpenOCD Server. Make sure it doesn't use system /usr/bin/openocd
3. From an existing ESP-IDF project, run the `ESP-IDF: New Project` wizard to create a new project.
4. Observe results. In newly created project .vscode/settings.json you should see `--query-driver=**` and `--compile-commands-dir=` pointing to the current esp-idf project build directory. Before it was pointing to directory used to run `ESP-IDF: New Project`.

- Expected behaviour:
Clang settings in vscode/settings.json are `--query-driver=**` and `--compile-commands-dir=` points to current project build directory 
OpenOCD and clangd are used from IDF_TOOLS_PATH instead of system (/usr/bin for example)

- Expected output:

## How has this been tested?

Manual testing using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
