### PR TITLE
docs: Provide CN translation for two additional features docs (resubmit)

### DIFF
--- a/docs_espressif/en/additionalfeatures/app-tracing.rst
+++ b/docs_espressif/en/additionalfeatures/app-tracing.rst
@@ -1,57 +1,41 @@
 Application Tracing
-=========================
+===================
 
-This feature allows to transfer arbitrary data between host and ESP32 via JTAG interface with small overhead on program execution.
+This feature allows transferring arbitrary data between the host and ESP32 via the JTAG interface with small overhead on program execution.
 
-Developers can use this library to send application specific state of execution to the host and receive commands or other type of info in the opposite direction at runtime.
+Developers can use this library to send application-specific state of execution to the host and receive commands or other types of information in the opposite direction at runtime.
 
-Let's open a ESP-IDF project. For this tutorial we will use the `system/app_trace_basic <https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_basic>`_ example.
+Let's open an ESP-IDF project. For this tutorial, we will use the `system/app_trace_to_host <https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host>`_ example.
 
-- Navigate to **View** > **Command Palette**.
+1.  Navigate to ``View`` > ``Command Palette``.
 
-- Type **ESP-IDF: New Project**, select the command and choose ESP-IDF version to use.
+2.  Type ``ESP-IDF: New Project``, select the command, and choose the ESP-IDF version to use.
 
-If you don't see the option, please review the setup in :ref:`Install ESP-IDF and Tools <installation>`.
+    .. note::
 
-- A window will be open with settings to configure the project. Later you can choose from the ESP-IDF examples, go the **system** section and choose the ``app_trace_basic``. You will see a **Create Project Using Example app_trace_basic project** button in the top and a description of the project below. Click the button and the project will be opened in a new window.
+        If you don't see the option, please review the setup in :ref:`Install ESP-IDF and Tools <installation>`.
 
-.. image:: ../../../media/tutorials/app_trace/app_tracing.png
+3.  A window will open with settings to configure the project. You can later choose from a list of ESP-IDF examples. Go to the ``system`` section and choose ``app_trace_to_host``. You will see a ``Create Project Using Example app_trace_to_host`` button at the top and a description of the project below. Click the button, and the project will open in a new window.
 
-For this example, the project has been already configured for application tracing purposes. On other projects you need to enable ``CONFIG_APPTRACE_DEST_JTAG`` and ``CONFIG_APPTRACE_ENABLE`` with the **ESP-IDF: SDK Configuration Editor** command.
+    .. image:: ../../../media/tutorials/app_trace/app_tracing.png
 
-.. note::
-  For the ``app_trace_basic`` example to work properly, you need to add the following settings to your project's ``.vscode/settings.json`` file:
+    For this example, the project is already configured for application tracing purposes. In other projects, you need to enable ``CONFIG_APPTRACE_DEST_TRAX`` and ``CONFIG_APPTRACE_ENABLE`` with the ``ESP-IDF: SDK Configuration Editor`` command.
 
-  .. code-block:: json
+4.  Configure, build, and flash your project as explained in the :ref:`Build the project <build the project>`.
 
-    {
-      "trace.poll_period": 0,
-      "trace.trace_size": 2048,
-      "trace.stop_tmo": 3,
-      "trace.wait4halt": 0,
-      "trace.skip_size": 0
-    }
+5.  First, click ``ESP-IDF Explorer`` in the `Visual Studio Code Activity bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_. Second, in the ``IDF APP TRACER`` section, click ``Start App Trace``. This will execute the extension's OpenOCD server and send the corresponding tracing commands to generate a tracing log. Third, you can see the generated tracing log in the ``APP TRACE ARCHIVES`` named ``Trace Log #1``. 
 
-  These settings ensure the same tracing behavior as demonstrated in the example.
+    Each time you execute ``Start App Trace``, a new tracing is generated and shown in the archives list. You can also start tracing by running the ``ESP-IDF: App Trace`` command.
 
-- Configure, build and flash your project as explained in the :ref:`Build the project <build the project>`.
+    .. note::
 
-- Click the ``ESP-IDF Explorer`` in the `Visual Studio Code Activity bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_.
+        * The OpenOCD server output is shown in menu ``View`` > ``Output`` > ``ESP-IDF``.
+        * Ensure that OpenOCD configuration files are properly configured with the ``ESP-IDF: Select OpenOCD Board Configuration`` command.
 
-1. On the ``IDF APP TRACER`` section, click the ``Start App Trace``. This will execute the extension's OpenOCD server and send the corresponding tracing commands to generate a tracing log.
+    .. image:: ../../../media/tutorials/app_trace/start_tracing.png
 
-2. You can see the generated tracing log in the ``APP TRACE ARCHIVES`` named with ``Trace Log #1``.
+6.  Click ``Trace Log #1`` to open a window with the trace report. Click the ``Show Report`` button to see the trace output.
 
-3. Each time you execute ``Start App Trace`` a new tracing will be generated and shown in the archives list. You can also start tracing by running the **ESP-IDF: App Trace** command.
+    .. image:: ../../../media/tutorials/app_trace/trace_report.png
 
-.. note::
-  * The OpenOCD server output is shown in menu **View** > **Output** > **ESP-IDF**.
-  * Make sure that OpenOCD configuration files are properly configured with **ESP-IDF: Select OpenOCD Board Configuration** command.
-
-.. image:: ../../../media/tutorials/app_trace/start_tracing.png
-
-- Click on ``Trace Log #1`` to open the trace file directly in the editor.
-
-.. image:: ../../../media/tutorials/app_trace/trace_report.png
-
-For more information please take a look at the `Application Level Tracing library Documentation <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html>`_.
+For more information, please refer to `Application Level Tracing Library <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html>`_.

--- a/docs_espressif/en/additionalfeatures/esp-terminal.rst
+++ b/docs_espressif/en/additionalfeatures/esp-terminal.rst
@@ -1,10 +1,8 @@
 ESP-IDF Terminal
-===============================
+================
 
-Navigate to **View** > **Command Palette**.
+1.  Navigate to ``View`` > ``Command Palette``.
+2.  Type ``ESP-IDF: Open ESP-IDF Terminal`` and select the command. This will launch a system terminal with ESP-IDF, ESP-IDF Tools, and ESP-IDF Python Virtual Environment loaded as environment variables.
+3.  Type ``idf.py`` or ``python -m esptool`` to execute scripts from ESP-IDF and additional frameworks.
 
-- Type **ESP-IDF: Open ESP-IDF Terminal** and select the command. 
-- This will launch a system terminal with ESP-IDF, ESP-IDF Tools and ESP-IDF Python Virtual Environment loaded as environment variables.
-- Just typing ``idf.py`` or ``python -m esptool`` should work to execute scripts from ESP-IDF and additional frameworks.
-
-.. image:: ../../../media/tutorials/features/idf-terminal.png
+    .. image:: ../../../media/tutorials/features/idf-terminal.png

--- a/docs_espressif/zh_CN/additionalfeatures.rst
+++ b/docs_espressif/zh_CN/additionalfeatures.rst
@@ -9,7 +9,7 @@
     :maxdepth: 1
 
     应用程序大小分析<additionalfeatures/application-size-analysis>
-    应用跟踪<additionalfeatures/app-tracing>
+    应用程序跟踪<additionalfeatures/app-tracing>
     CMakeLists.txt 编辑器<additionalfeatures/cmakelists-editor>
     代码覆盖率<additionalfeatures/coverage>
     通过 USB 升级设备固件<additionalfeatures/dfu>

--- a/docs_espressif/zh_CN/additionalfeatures/app-tracing.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/app-tracing.rst
@@ -1,1 +1,41 @@
-.. include:: ../../en/additionalfeatures/app-tracing.rst
+应用程序跟踪
+============
+
+应用程序跟踪功能可以通过 JTAG 接口在主机和 ESP32 之间传输任意数据，且程序的执行开销较小。
+
+开发者可以使用该库在运行时将应用程序特定的执行状态发送至主机，并接收来自主机的命令或其他类型的信息。
+
+打开一个 ESP-IDF 项目，本教程以 `system/app_trace_to_host <https://github.com/espressif/esp-idf/tree/master/examples/system/app_trace_to_host>`_ 示例为例。
+
+1.  前往菜单栏 ``查看`` > ``命令面板``。
+
+2.  输入 ``ESP-IDF：新建项目``，选择该命令，并选择要使用的 ESP-IDF 版本。
+
+    .. note::
+
+        如果未看到该选项，请检查当前的 ESP-IDF 设置，详见 :ref:`安装 ESP-IDF 和相关工具 <installation>`。
+
+3.  系统将弹出用于配置项目的窗口。从 ESP-IDF 示例列表中选择示例，在 ``system`` 部分选择 ``app_trace_to_host``。页面顶部会出现 ``Create Project Using Example app_trace_to_host`` 按钮，页面下方会出现项目描述，点击按钮，项目会在新窗口中打开。
+
+    .. image:: ../../../media/tutorials/app_trace/app_tracing.png
+
+    在此示例中，项目已配置应用程序跟踪。在其他项目中，请使用 ``ESP-IDF：SDK 配置编辑器`` 命令启用 ``CONFIG_APPTRACE_DEST_TRAX`` 和 ``CONFIG_APPTRACE_ENABLE``。
+
+4.  按照 :ref:`构建项目 <build the project>` 中的说明，配置、构建并烧录项目。
+
+5.  首先，点击 `Visual Studio Code 活动栏 <https://code.visualstudio.com/docs/getstarted/userinterface>`_ 中的 ``ESP-IDF Explorer``。其次，在 ``IDF APP TRACER`` 分区中，点击 ``Start App Trace``。这将启动扩展的 OpenOCD 服务器并发送相应的跟踪命令以生成跟踪日志。最后，可以在 ``APP TRACE ARCHIVES`` 中查看生成的日志，名称为 ``Trace Log #1``。
+
+    每次执行 ``Start App Trace`` 时，都会生成一个新的跟踪并显示在归档列表中。也可以通过运行 ``ESP-IDF：应用程序跟踪`` 命令启动跟踪。
+
+    .. note::
+
+        * OpenOCD 服务器输出会显示在菜单栏 ``查看`` > ``输出`` > ``ESP-IDF`` 中。
+        * 请确保已使用 ``ESP-IDF：选择 OpenOCD 开发板配置`` 命令设置正确的 OpenOCD 配置文件。
+
+    .. image:: ../../../media/tutorials/app_trace/start_tracing.png
+
+6.  点击 ``Trace Log #1`` 打开包含跟踪报告的窗口。点击 ``Show Report`` 按钮查看跟踪输出。
+
+    .. image:: ../../../media/tutorials/app_trace/trace_report.png
+
+更多关于本功能的信息，请参阅 `应用层跟踪库 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/app_trace.html>`_。

--- a/docs_espressif/zh_CN/additionalfeatures/esp-terminal.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/esp-terminal.rst
@@ -1,1 +1,8 @@
-.. include:: ../../en/additionalfeatures/esp-terminal.rst
+ESP-IDF 终端
+================
+
+1.  前往菜单栏 ``查看`` > ``命令面板``。
+2.  输入 ``ESP-IDF：打开 ESP-IDF 终端`` 并选中该命令。这将启动系统终端，并将 ESP-IDF、ESP-IDF 工具以及 ESP-IDF Python 虚拟环境作为环境变量加载。
+3.  输入 ``idf.py`` 或 ``python -m esptool`` 即可运行 ESP-IDF 及其他附加框架的脚本。
+
+    .. image:: ../../../media/tutorials/features/idf-terminal.png


### PR DESCRIPTION
This PR:

> note: Resubmits https://github.com/espressif/vscode-esp-idf-extension/pull/1655 from my previous account, which is no longer accessible.

- Adjusts some format issues and unclear expressions for esp-terminal.rst & app-tracing.rst based on Espressif Style Guide
- Provides CN translation for esp-terminal.rst & app-tracing.rst
- TODO: Closes [DOC-12159](https://jira.espressif.com:8443/browse/DOC-12159) once merged