### PR TITLE
Provide CN translation for cmakelists-editor.rst (resubmit)

### DIFF
--- a/docs_espressif/en/additionalfeatures/cmakelists-editor.rst
+++ b/docs_espressif/en/additionalfeatures/cmakelists-editor.rst
@@ -1,66 +1,70 @@
 CMakeLists.txt Editor
-==============================
+=====================
+
+:link_to_translation:`zh_CN:[中文]`
 
 .. warning::
-  * This will override any existing code in the file with the one generated in the editor. If you have any code not included in the schema (or single line comments) use a regular text editor instead.
 
-When you right click on any CMakeLists.txt file this extension provides a custom CMakeLists.txt Editor to fill an ESP-IDF Project and Component Registration as specified in:
+    This will override any existing code in the file with the one generated in the editor. If you have any code not included in the schema (or single line comments), use a regular text editor instead.
 
-- `ESP-IDF Project CMakeLists.txt <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#project-cmakelists-file>`_
-- `ESP-IDF Component CMakeLists.txt Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_
+When you right-click any ``CMakeLists.txt`` file, this extension provides a custom ``CMakeLists.txt`` editor to fill an ESP-IDF project and component registration as specified in:
 
-You need to choose which kind of CMakeLists.txt file (project or component) to edit. There is 2 types of input, one is a simple string and another is an array of strings, such as Component Sources (SRCS).
+- `Project CMakeLists File <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#project-cmakelists-file>`_
+- `Component CMakeLists Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_
 
-.. note::
-  * All inputs are described in the `CMakeLists.txt schema <https://github.com/espressif/vscode-esp-idf-extension/blob/master/cmakeListsSchema.json>`_
-  * This editor doesn't support all CMake functions and syntaxes. This editor should only be used for simple CMakeLists.txt options such as component registration (using idf_component_register) and basic project elements. If you need more customization or advanced CMakeLists.txt, consider reviewing `ESP-IDF Build System <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html>`_. Also review **CMakeLists.txt editor schema** for a list of supported code.
-
-
-For this tutorial we will use the get-started's blink example.
-
-1. Right click the ``<project_path>/blink/CMakeLists.txt``, click on **ESP-IDF: CMakeLists.txt Editor** and select ``Project CMakeLists.txt``.
-
-.. image:: ../../../media/tutorials/cmakelists_editor/cmakelists_editor.png
-
-2. We can add new elements by selecting them from the ``New Element`` dropdown and clicking the ``Add`` button. For simplicity we will just change the project name and save changes with the ``Save`` button.
-
-We can observe when we re-open the file in a regular text-editor changes are reflected.
-
-3. Now let's create a new ESP-IDF component in this project to modify its ``CMakeLists.txt``. Click menu **View** > **Command Palette** and type **ESP-IDF: Create New ESP-IDF Component** and enter the new component name.
-
-4. A new component will be created in ``<project_path>/blink/components/<component_name>``. Opening in the regular text editor, you will see an ``idf_component_register`` method with:
-
-.. code-block:: C
-
-  idf_component_register(SRCS "my_component.c"
-                         INCLUDE_DIRS "include")
-
-Right click on ``<project_path>/blink/components/<component_name>/CMakeLists.txt``, click on **ESP-IDF: CMakeLists.txt Editor** and select ``Component CMakeLists.txt``.
-
-.. image:: ../../../media/tutorials/cmakelists_editor/components_editor.png
-
-5. Observe that some fields are of array types such as **Component Sources (SRCS)** since we can add several paths while other are just string input fields (as described in cmakeListsSchema.json).
+You need to choose which kind of ``CMakeLists.txt`` file (project or component) to edit. There are two types of input: a simple string and an array of strings, such as Component Sources (SRCS).
 
 .. note::
-  While using this extension, source files are added and deleted automatically from the same directory where CMakeLists.txt is located without user intervention.
 
-6. Add a new element ``Public Component Requirements for the Component (REQUIRES)`` and click the ``Add`` button. A new array field will appear.
+    * All inputs are described in the `CMakeLists.txt schema <https://github.com/espressif/vscode-esp-idf-extension/blob/master/cmakeListsSchema.json>`_.
+    * This editor doesn't support all CMake functions and syntax. Use it only for simple ``CMakeLists.txt`` options, such as component registration (using ``idf_component_register``) and basic project elements. For more customization or advanced ``CMakeLists.txt``, review `ESP-IDF Build System <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html>`_. You may also refer to **CMakeLists.txt editor schema** for a list of supported code.
 
-7. As described in `ESP-IDF Component CMakeLists.txt Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_, ``REQUIRES`` is used to list the component dependencies. Type ``mbedtls`` and click the ``+`` button (can also press enter on typing).
+For this tutorial we will use the blink example.
 
-8. Click on ``Save`` button and close the CMakeLists.txt editor. If you open ``<project_path>/blink/components/<component_name>/CMakeLists.txt`` on a regular text editor, you will see:
+1.  Right-click the ``<project_path>/blink/CMakeLists.txt``, click ``ESP-IDF: CMakeLists.txt Editor`` and select ``Project CMakeLists.txt``.
 
-.. code-block:: C
+    .. image:: ../../../media/tutorials/cmakelists_editor/cmakelists_editor.png
+
+2.  Add new elements by selecting them from the ``New Element`` dropdown and clicking the ``Add`` button. For simplicity, change the project name and save changes with the ``Save`` button.
+
+    When re-opening the file in a regular text editor, changes are reflected.
+
+3.  Create a new ESP-IDF component in this project to modify its ``CMakeLists.txt``. Go to menu ``View`` > ``Command Palette``, type ``ESP-IDF: Create New ESP-IDF Component``, and enter the new component name.
+
+4.  A new component will be created in ``<project_path>/blink/components/<component_name>``. Open ``CMakeLists.txt`` in the regular text editor, you will see an ``idf_component_register`` method with:
+
+    .. code-block:: C
+
+        idf_component_register(SRCS "my_component.c"
+                               INCLUDE_DIRS "include")
+
+    Right-click ``<project_path>/blink/components/<component_name>/CMakeLists.txt``, click ``ESP-IDF: CMakeLists.txt Editor`` and select ``Component CMakeLists.txt``.
+
+    .. image:: ../../../media/tutorials/cmakelists_editor/components_editor.png
+
+5.  Observe that some fields are of array types such as **Component Sources (SRCS)** since you can add several paths, while others are just string input fields (as described in ``cmakeListsSchema.json``).
+
+    .. note::
+
+        While using this extension, source files are added and deleted automatically from the same directory where ``CMakeLists.txt`` is located without user intervention.
+
+6.  Add a new element ``Public Component Requirements for the Component (REQUIRES)`` and click the ``Add`` button. A new array field will appear.
+
+7.  As described in `Component CMakeLists Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_, ``REQUIRES`` is used to list the component dependencies. Type ``mbedtls`` and click the ``+`` button (you can also press enter after typing).
+
+8.  Click the ``Save`` button and close the ``CMakeLists.txt`` editor. If you open ``<project_path>/blink/components/<component_name>/CMakeLists.txt`` in a regular text editor, you will see:
+
+    .. code-block:: C
   
-  idf_component_register(SRCS "my_component.c"
-                         INCLUDE_DIRS "include"
-                         REQUIRES "mbedtls")
+        idf_component_register(SRCS "my_component.c"
+                               INCLUDE_DIRS "include"
+                               REQUIRES "mbedtls")
 
-Reference links
------------------------
+Reference Links
+---------------
 
-To review all fields used in the CMakeLists.txt editor go to:
+To review all fields used in the ``CMakeLists.txt`` editor, go to:
 
-1. `ESP-IDF Project CMakeLists.txt <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#project-cmakelists-file>`_  
+- `ESP-IDF Project CMakeLists Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#project-cmakelists-file>`_ 
 
-2. `ESP-IDF Component CMakeLists.txt Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_
+- `ESP-IDF Component CMakeLists Files <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html#component-cmakelists-files>`_

--- a/docs_espressif/zh_CN/additionalfeatures/cmakelists-editor.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/cmakelists-editor.rst
@@ -1,1 +1,70 @@
-.. include:: ../../en/additionalfeatures/cmakelists-editor.rst
+CMakeLists.txt 编辑器
+=====================
+
+:link_to_translation:`en:[English]`
+
+.. warning::
+
+    该操作会用编辑器生成的内容覆盖文件中现有的代码。如果文件中有未包含在 schema 中的代码（或单行注释），请使用常规文本编辑器。
+
+右键点击任意 ``CMakeLists.txt`` 文件时，该扩展会提供一个自定义的 ``CMakeLists.txt`` 编辑器，用于填写 ESP-IDF 项目和组件注册，具体参考：
+
+- `项目 CMakeLists 文件 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#cmakelists>`_
+- `组件 CMakeLists 文件 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#component-directories>`_
+
+需要选择要编辑哪种类型的 ``CMakeLists.txt`` 文件（项目或组件），共有两种类型：简单字符串和字符串数组，例如 Component Sources (SRCS)。
+
+.. note::
+
+    * 所有输入项都在 `CMakeLists.txt schema <https://github.com/espressif/vscode-esp-idf-extension/blob/master/cmakeListsSchema.json>`_ 中有描述。
+    * 该编辑器并不支持所有 CMake 函数和语法，仅用于简单的 ``CMakeLists.txt`` 配置，例如组件注册（使用 ``idf_component_register``）和基础项目元素。如需自定义或进行高级的 ``CMakeLists.txt`` 配置，请参考 `ESP-IDF 构建系统 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html>`_。此外，可查看 **CMakeLists.txt 编辑器 schema** 以获取支持的代码列表。
+
+本教程将使用 blink 示例项目。
+
+1.  右键点击 ``<project_path>/blink/CMakeLists.txt``，选择 ``ESP-IDF：CMakeLists.txt 编辑器``，然后选择 ``Project CMakeLists.txt``。
+
+    .. image:: ../../../media/tutorials/cmakelists_editor/cmakelists_editor.png
+
+2.  从 ``New Element`` 下拉菜单中选择新元素，然后点击 ``Add`` 按钮添加。为简单起见，可以修改项目名称，然后点击 ``Save`` 保存更改。
+
+    在常规文本编辑器中重新打开文件，可以看到修改后的内容。
+
+3.  在该项目中创建一个新的 ESP-IDF 组件，以便修改其 ``CMakeLists.txt``。前往菜单栏 ``查看`` > ``命令面板``，输入 ``ESP-IDF：创建新 ESP-IDF 组件``，并输入新组件名称。
+
+4.  新组件将创建在 ``<project_path>/blink/components/<component_name>`` 目录下。在常规文本编辑器中打开 ``CMakeLists.txt``，可以看到一个 ``idf_component_register`` 方法，如下：
+
+    .. code-block:: C
+
+        idf_component_register(SRCS "my_component.c"
+                               INCLUDE_DIRS "include")
+
+    右键点击 ``<project_path>/blink/components/<component_name>/CMakeLists.txt``，选择 ``ESP-IDF：CMakeLists.txt 编辑器``，然后选择 ``Component CMakeLists.txt``。
+
+    .. image:: ../../../media/tutorials/cmakelists_editor/components_editor.png
+
+5.  注意，某些字段是数组类型，例如 **Component Sources (SRCS)**，你可以添加多个路径，而其他字段仅是字符串输入（如 ``cmakeListsSchema.json`` 所述）。
+
+    .. note::
+
+        使用该扩展时，源文件会在 ``CMakeLists.txt`` 所在目录自动添加或删除，无需用户手动操作。
+
+6.  添加新元素 ``Public Component Requirements for the Component (REQUIRES)``，点击 ``Add`` 按钮。将出现新的数组字段。
+
+7.  如 `组件 CMakeLists 文件 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#component-directories>`_ 中所述，``REQUIRES`` 用于列出组件依赖项。输入 ``mbedtls`` 并点击 ``+`` 按钮（也可在输入后按 Enter 键）。
+
+8.  点击 ``Save`` 按钮并关闭 ``CMakeLists.txt`` 编辑器。在常规文本编辑器中打开 ``<project_path>/blink/components/<component_name>/CMakeLists.txt``，你将看到如下内容：
+
+    .. code-block:: C
+  
+        idf_component_register(SRCS "my_component.c"
+                               INCLUDE_DIRS "include"
+                               REQUIRES "mbedtls")
+
+参考链接
+--------
+
+要查看 ``CMakeLists.txt`` 编辑器中使用的所有字段，请访问：
+
+- `ESP-IDF 项目 CMakeLists 文件 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#cmakelists>`_
+
+- `ESP-IDF 组件 CMakeLists 文件 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/build-system.html#component-directories>`_


### PR DESCRIPTION
This PR:

> note: Resubmits https://github.com/espressif/vscode-esp-idf-extension/pull/1653 from my previous account, which is no longer accessible.

- Adjusts some format issues and unclear expressions for cmakelists-editor.rstbased on Espressif Style Guide
- Provides CN translation for cmakelists-editor.rst
- TODO: Closes [DOC-12123](https://jira.espressif.com:8443/browse/DOC-12123) once merged