### PR TITLE
docs: Provide CN translation for heap-tracing.rst (resubmit)

### DIFF
--- a/docs_espressif/en/additionalfeatures/heap-tracing.rst
+++ b/docs_espressif/en/additionalfeatures/heap-tracing.rst
@@ -1,40 +1,47 @@
 Heap Tracing
-========================
+============
 
-Heap Tracing allows tracing of code which allocates/frees memory. More information in `Heap tracing documentation <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/heap_debug.html#heap-tracing>`_. Please also review `System behaviour analysis <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html#system-behavior-analysis-with-segger-systemview>`_ for systemView tracing configuration.
+:link_to_translation:`zh_CN:[中文]`
 
-Let's open a ESP-IDF project. For this tutorial we will use the ``system/sysview_tracing_heap_log`` example.
+Heap Tracing allows tracing of code that allocates or frees memory. More information is available in the `heap tracing documentation <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/heap_debug.html#heap-tracing>`_. Please also review `System Behavior Analysis <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html#system-behavior-analysis-with-segger-systemview>`_ for SystemView tracing configuration.
 
-- Navigate to **View** > **Command Palette**.
+Let's open an ESP-IDF project. For this tutorial, we will use the ``system/sysview_tracing_heap_log`` example.
 
-- Type **ESP-IDF: New Project**, select the command and choose ESP-IDF version to use.
+1.  Navigate to ``View`` > ``Command Palette``.
 
-If you don't see the option, please review the setup in :ref:`Install ESP-IDF and Tools <installation>`.
+2.  Type ``ESP-IDF: New Project``, select the command, and choose the ESP-IDF version to use.
 
-- A window will be open with settings to configure the project. Later you can choose from a list a ESP-IDF examples, go the **system** section and choose the ``sysview_tracing_heap_log``. You will see a **Create Project Using Example sysview_tracing_heap_log** button in the top and a description of the project below. Click the button and the project will be opened in a new window.
+    .. note::
 
-.. image:: ../../../media/tutorials/heap_trace/sysview_tracing_heap_log.png
+        If you don't see the option, please review the setup in :ref:`Install ESP-IDF and Tools <installation>`.
 
-For this example, the project has been already configured for application tracing purposes.
+3.  A window will open with settings to configure the project. You can later choose from a list of ESP-IDF examples. Go to the ``system`` section and choose ``sysview_tracing_heap_log``. You will see a ``Create Project Using Example sysview_tracing_heap_log`` button at the top and a description of the project below. Click the button, and the project will open in a new window.
 
-.. note::
-  * For more information please take a look at the `Application Level Tracing library documentation <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html>`_.
+    .. image:: ../../../media/tutorials/heap_trace/sysview_tracing_heap_log.png
 
-- Configure, build and flash your project as explained in the :ref:`Build the project <build the project>`.
+    In this example, the project is already configured for application tracing.
 
-.. note::
-  * The OpenOCD server output is shown in menu **View** > **Output** > **ESP-IDF**.
-  * Make sure that OpenOCD configuration files are properly configured with **ESP-IDF: Select OpenOCD Board Configuration** command.
+    .. note::
 
-- Click the ``ESP-IDF Explorer`` in the `Visual Studio Code Activity bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_ (1). On the ``ESP-IDF APP TRACER`` section, click the ``Start Heap Trace`` (2). This will execute the extension's OpenOCD server and send the corresponding tracing commands to generate a tracing log. You can see the generated tracing log in the ``APP TRACE ARCHIVES`` named with ``Heap Trace Log #1`` (3). Each time you execute ``Start Heap Trace`` a new tracing will be generated and shown in the archives list. You can also start tracing by running the **ESP-IDF: App Trace** command.
+        For more information, please refer to `Application Level Tracing Library <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html>`_.
 
-.. image:: ../../../media/tutorials/heap_trace/start_heap_tracing.png
+4.  Configure, build, and flash your project as explained in the :ref:`Build Your Project <build the project>`.
 
-- Click on ``Heap Trace Log #1`` and choose the ``Heap Tracing`` option for ``ESP-IDF Tracing`` report window. Click ``Show Report`` button to reload the visualization.
+    .. note::
+    
+        - The OpenOCD server output is shown in the menu ``View`` > ``Output`` > ``ESP-IDF``.
+        - Make sure that OpenOCD configuration files are properly set with the the ``ESP-IDF: Select OpenOCD Board Configuration`` command.
 
-.. image:: ../../../media/tutorials/heap_trace/heap_trace_report.png
+5.  First, click ``ESP-IDF Explorer`` in the `Visual Studio Code Activity Bar <https://code.visualstudio.com/docs/getstarted/userinterface>`_. Second, in the ``ESP-IDF APP TRACER`` section, click ``Start Heap Trace``. This will execute the extension's OpenOCD server and send the corresponding tracing commands to generate a tracing log. Third, you can see the generated tracing log in the ``APP TRACE ARCHIVES`` named ``Heap Trace Log #1``. 
 
-- Click on ``Heap Trace Log #1`` and choose the ``SystemView Tracing`` option for the ``ESP-IDF System View Report`` window.
+    Each time you execute ``Start Heap Trace``, a new trace will be generated and shown in the archives list. You can also start tracing by running the ``ESP-IDF: App Trace`` command.
 
-.. image:: ../../../media/tutorials/heap_trace/sysview_report.png
+    .. image:: ../../../media/tutorials/heap_trace/start_heap_tracing.png
 
+6.  Click ``Heap Trace Log #1`` and choose the ``Heap Tracing`` option for the ``ESP-IDF Tracing`` report window. Click the ``Show Report`` button to reload the visualization.
+
+    .. image:: ../../../media/tutorials/heap_trace/heap_trace_report.png
+
+7.  Click ``Heap Trace Log #1`` and choose the ``SystemView Tracing`` option for the ``ESP-IDF System View Report`` window.
+
+    .. image:: ../../../media/tutorials/heap_trace/sysview_report.png

--- a/docs_espressif/zh_CN/additionalfeatures/heap-tracing.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/heap-tracing.rst
@@ -1,1 +1,47 @@
-.. include:: ../../en/additionalfeatures/heap-tracing.rst
+堆跟踪
+======
+
+:link_to_translation:`en:[English]`
+
+堆跟踪允许跟踪分配或释放内存的代码。详情请参阅 `堆内存跟踪 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-reference/system/heap_debug.html#heap-tracing>`_ 。另请查阅 `系统行为分析 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/app_trace.html#segger-systemview>`_，以了解 SystemView 跟踪配置。
+
+让我们打开一个 ESP-IDF 项目。本教程将使用 ``system/sysview_tracing_heap_log`` 示例。
+
+1.  前往菜单栏 ``查看`` > ``命令面板``。
+
+2.  输入 ``ESP-IDF：新建项目`` ，选择该命令，然后选择要使用的 ESP-IDF 版本。
+
+    .. note::
+
+        如果未看到该选项，请检查当前的 ESP-IDF 设置，详见 :ref:`安装 ESP-IDF 和相关工具 <installation>`。
+
+3.  系统将弹出用于配置项目的窗口。从 ESP-IDF 示例列表中选择示例，在 ``system`` 部分选择 ``sysview_tracing_heap_log``。页面顶部会出现 ``Create Project Using Example sysview_tracing_heap_log`` 按钮，页面下方会出现项目描述，点击按钮，项目会在新窗口中打开。
+
+    .. image:: ../../../media/tutorials/heap_trace/sysview_tracing_heap_log.png
+
+    在此示例中，项目已配置应用程序跟踪。
+
+    .. note::
+
+        详情请参阅 `应用层跟踪库 <https://docs.espressif.com/projects/esp-idf/zh_CN/latest/esp32/api-guides/app_trace.html>`_。
+
+4.  按照 :ref:`构建项目 <build the project>` 中的说明来配置、构建并烧录项目。
+
+    .. note::
+    
+        - OpenOCD 服务器输出会显示在菜单栏 ``查看`` > ``输出`` > ``ESP-IDF`` 中。
+        - 请确保已使用 ``ESP-IDF：选择 OpenOCD 开发板配置`` 命令设置正确的 OpenOCD 配置文件。
+
+5.  首先，点击 `Visual Studio Code 活动栏 <https://code.visualstudio.com/docs/getstarted/userinterface>`_ 中的 ``ESP-IDF Explorer``。其次， 在 ``ESP-IDF APP TRACER`` 分区中，点击 ``Start Heap Trace``。这将启动该扩展的 OpenOCD 服务器并发送相应的跟踪命令以生成跟踪日志。最后，可以在 ``APP TRACE ARCHIVES`` 中查看生成的日志，名称为 ``Heap Trace Log #1``。
+
+    每次执行 ``Start Heap Trace`` 时，都会生成一个新的跟踪并显示在归档列表中。也可以通过运行 ``ESP-IDF：应用程序跟踪`` 命令进行跟踪。
+
+    .. image:: ../../../media/tutorials/heap_trace/start_heap_tracing.png
+
+6.  点击 ``Heap Trace Log #1`` ，并在 ``ESP-IDF Tracing`` 报告窗口中选择 ``Heap Tracing`` 选项。点击 ``Show Report`` 按钮，重新加载可视化界面。
+
+    .. image:: ../../../media/tutorials/heap_trace/heap_trace_report.png
+
+7.  点击 ``Heap Trace Log #1`` ，并在 ``ESP-IDF System View Report`` 窗口中选择 ``SystemView Tracing`` 选项。
+
+    .. image:: ../../../media/tutorials/heap_trace/sysview_report.png


### PR DESCRIPTION
This PR:

> note: Resubmits [#1649](https://github.com/espressif/vscode-esp-idf-extension/pull/1649) from my previous account, which is no longer accessible.

- Adjusts some format issues and unclear expressions for heap-tracing.rst based on Espressif Style Guide
- Provides CN translation for heap-tracing.rst
- TODO: Closes [DOC-12081](https://jira.espressif.com:8443/browse/DOC-12081) once merged