### PR TITLE
[VSC-1759] add idf.sourceDirectoryPath setting and update doctor command report

### DIFF
--- a/docs_espressif/en/settings.rst
+++ b/docs_espressif/en/settings.rst
@@ -46,6 +46,8 @@ These are the configuration settings that ESP-IDF extension contributes to your 
       - Custom build directory name for extension commands (Default: \${workspaceFolder}/build)
     * - idf.buildPathWin
       - Custom build directory name for extension commands in Windows (Default: \${workspaceFolder}\\build)
+    * - idf.sourceDirectoryPath
+      - Source directory path for CMake -S flag (Default: \${workspaceFolder})
     * - idf.sdkconfigFilePath
       - Absolute path for the sdkconfig file
     * - idf.sdkconfigDefaults

--- a/docs_espressif/zh_CN/settings.rst
+++ b/docs_espressif/zh_CN/settings.rst
@@ -36,6 +36,8 @@ ESP-IDF 相关设置
       - 扩展命令的自定义构建目录名称（默认值：\${workspaceFolder}/build）
     * - idf.buildPathWin
       - Windows 系统中扩展命令的自定义构建目录名称（默认值：\${workspaceFolder}\\build）
+    * - idf.sourceDirectoryPath
+      - CMake -S 标志的源目录路径（默认值：\${workspaceFolder}）
     * - idf.sdkconfigFilePath
       - sdkconfig 文件的绝对路径
     * - idf.sdkconfigDefaults

--- a/package.json
+++ b/package.json
@@ -1295,6 +1295,12 @@
             "default": 60,
             "scope": "resource",
             "description": "%param.serialPortDetectionTimeout%"
+          },
+          "idf.sourceDirectoryPath": {
+            "type": "string",
+            "default": "${workspaceFolder}",
+            "description": "%param.sourceDirectoryPath%",
+            "scope": "resource"
           }
         }
       }

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -188,6 +188,7 @@
 	"param.unitTestFilePattern.title": "Patrón glob para descubrir archivos de prueba unitaria",
 	"param.pyTestEmbeddedServices.title": "Lista de servicios integrados para la ejecución de pytest",
 	"param.serialPortDetectionTimeout": "Tiempo de espera en segundos para la detección del puerto serie usando esptool.py",
+	"param.sourceDirectoryPath": "Ruta del directorio fuente para la bandera -S de CMake (por defecto: carpeta del espacio de trabajo)",
 	"trace.poll_period.description": "poll_period se establecerá para el rastreo de la aplicación",
 	"trace.skip_size.description": "skip_size se establecerá para el rastreo de la aplicación",
 	"trace.stop_tmo.description": "stop_tmo se establecerá para el rastreo de la aplicación",

--- a/package.nls.json
+++ b/package.nls.json
@@ -189,6 +189,7 @@
   "param.unitTestFilePattern.title": "Glob pattern for unit test files to discover",
   "param.pyTestEmbeddedServices.title": "List of embedded services for pytest execution",
   "param.serialPortDetectionTimeout": "Timeout in seconds for serial port detection using esptool.py",
+  "param.sourceDirectoryPath": "Source directory path for CMake -S flag (defaults to workspace folder)",
   "trace.poll_period.description": "poll_period will be set for the apptrace",
   "trace.skip_size.description": "skip_size will be set for the apptrace",
   "trace.stop_tmo.description": "stop_tmo will be set for the apptrace",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -187,6 +187,7 @@
 	"param.unitTestFilePattern.title": "Padrão glob para descobrir arquivos de teste unitário",
 	"param.pyTestEmbeddedServices.title": "Lista de serviços incorporados para execução do pytest",
 	"param.serialPortDetectionTimeout": "Tempo limite em segundos para detecção de porta serial usando esptool.py",
+	"param.sourceDirectoryPath": "Caminho do diretório de origem para a flag -S do CMake (padrão: pasta do espaço de trabalho)",
 	"trace.poll_period.description": "poll_period será definido para o apptrace",
 	"trace.skip_size.description": "skip_size será definido para o apptrace",
 	"trace.stop_tmo.description": "stop_tmo será definido para o apptrace",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -188,6 +188,7 @@
 	"param.unitTestFilePattern.title": "Шаблон glob для обнаружения файлов модульных тестов",
 	"param.pyTestEmbeddedServices.title": "Список встроенных сервисов для выполнения pytest",
 	"param.serialPortDetectionTimeout": "Тайм-аут в секундах для обнаружения последовательного порта с помощью esptool.py",
+	"param.sourceDirectoryPath": "Путь к исходному каталогу для флага -S CMake (по умолчанию: папка рабочей области)",
 	"trace.poll_period.description": "для apptrace будет установлен параметр poll_ period",
 	"trace.skip_size.description": "для apptrace будет установлен параметр skip_size",
 	"trace.stop_tmo.description": "для apptrace будет установлен параметр stop_tmo",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -189,6 +189,7 @@
 	"param.unitTestFilePattern.title": "用于发现单元测试文件的 glob 模式",
 	"param.pyTestEmbeddedServices.title": "pytest 执行的内嵌服务列表",
 	"param.serialPortDetectionTimeout": "使用 esptool.py 检测串口时的超时时间（秒）",
+	"param.sourceDirectoryPath": "CMake -S 标志的源目录路径（默认为工作区文件夹）",
 	"trace.poll_period.description": "设置 apptrace 的 poll_period 参数",
 	"trace.skip_size.description": "设置 apptrace 的 skip_size 参数",
 	"trace.stop_tmo.description": "设置 apptrace 的 stop_tmo 参数",

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -142,7 +142,11 @@ export class BuildTask {
       }
       compilerArgs.push("-B", this.buildDirPath);
       if (compilerArgs.indexOf("-S") === -1) {
-        compilerArgs.push("-S", this.currentWorkspace.fsPath);
+        const sourceDirectoryPath = idfConf.readParameter(
+          "idf.sourceDirectoryPath",
+          this.currentWorkspace
+        ) as string;
+        compilerArgs.push("-S", sourceDirectoryPath);
       }
 
       const sdkconfigFile = await getSDKConfigFilePath(this.currentWorkspace);

--- a/src/support/configurationAccess.ts
+++ b/src/support/configurationAccess.ts
@@ -26,6 +26,26 @@ export async function getConfigurationAccess(
   reportedResult: reportObj,
   context: vscode.ExtensionContext
 ) {
+  reportedResult.configurationAccess.buildPath = canAccessFile(
+    reportedResult.configurationSettings.buildPath,
+    constants.R_OK
+  );
+  reportedResult.configurationAccess.sourceDirPath = canAccessFile(
+    reportedResult.configurationSettings.sourceDirPath,
+    constants.R_OK
+  );
+  reportedResult.configurationAccess.sdkconfigPath = canAccessFile(
+    reportedResult.configurationSettings.sdkconfigPath,
+    constants.R_OK
+  );
+  reportedResult.configurationAccess.toolsPath = canAccessFile(
+    reportedResult.configurationSettings.toolsPath,
+    constants.R_OK
+  );
+  reportedResult.configurationAccess.toolsPath = canAccessFile(
+    reportedResult.configurationSettings.toolsPath,
+    constants.R_OK
+  );
   reportedResult.configurationAccess.toolsPath = canAccessFile(
     reportedResult.configurationSettings.toolsPath,
     constants.R_OK

--- a/src/support/configurationSettings.ts
+++ b/src/support/configurationSettings.ts
@@ -94,5 +94,8 @@ export async function getConfigurationSettings(
       process.platform === "win32" ? process.env.Path : process.env.PATH,
     sysPythonBinPath: conf.get("idf.pythonInstallPath"),
     gitPath: conf.get("idf.gitPath" + winFlag),
+    buildPath: conf.get("idf.buildPath" + winFlag),
+    sourceDirPath: conf.get("idf.sourceDirectoryPath"),
+    sdkconfigPath: conf.get("idf.sdkconfigFilePath"),
   };
 }

--- a/src/support/initReportObj.ts
+++ b/src/support/initReportObj.ts
@@ -43,6 +43,9 @@ export function initializeReportObject() {
     openOcdLaunchArgs: undefined,
     toolsPath: undefined,
     gitPath: undefined,
+    buildPath: undefined,
+    sourceDirPath: undefined,
+    sdkconfigPath: undefined,
   };
   report.cCppPropertiesJson = undefined;
   report.configurationAccess = {
@@ -57,6 +60,9 @@ export function initializeReportObject() {
     ninjaInEnv: undefined,
     toolsPath: undefined,
     sysPythonBinPath: undefined,
+    buildPath: undefined,
+    sourceDirPath: undefined,
+    sdkconfigPath: undefined,
   };
   report.configurationSpacesValidation = {
     customExtraPaths: undefined,

--- a/src/support/types.ts
+++ b/src/support/types.ts
@@ -30,6 +30,9 @@ export class ConfigurationAccess {
   ninjaInEnv: boolean;
   toolsPath: boolean;
   sysPythonBinPath: boolean;
+  buildPath: boolean;
+  sourceDirPath: boolean;
+  sdkconfigPath: boolean;
 }
 export class Configuration {
   systemEnvPath: string;
@@ -55,6 +58,9 @@ export class Configuration {
   gitPath: string;
   customTerminalExecutable: string;
   customTerminalExecutableArgs: string[];
+  buildPath: string;
+  sourceDirPath: string;
+  sdkconfigPath: string;
 }
 
 export class ConfigurationSpacesValidation {

--- a/src/support/writeReport.ts
+++ b/src/support/writeReport.ts
@@ -66,6 +66,9 @@ export async function writeTextReport(
     }
   }
   output += `System python Path (idf.pythonInstallPath) ${reportedResult.configurationSettings.sysPythonBinPath}${EOL}`;
+  output += `Build Directory Path (idf.buildPath) ${reportedResult.configurationSettings.buildPath}${EOL}`;
+  output += `Source directory Path (idf.sourceDirectoryPath) ${reportedResult.configurationSettings.sourceDirPath}${EOL}`;
+  output += `SDKConfig file Path (idf.sdkconfigFilePath) ${reportedResult.configurationSettings.sdkconfigPath}${EOL}`;
   output += `Virtual environment Python path (computed) ${reportedResult.configurationSettings.pythonBinPath}${EOL}`;
   output += `Serial port (idf.port) ${reportedResult.configurationSettings.serialPort}${EOL}`;
   output += `OpenOCD Configs (idf.openOcdConfigs) ${reportedResult.configurationSettings.openOcdConfigs}${EOL}`;
@@ -100,6 +103,9 @@ export async function writeTextReport(
   output += `Access to CMake in environment PATH ${reportedResult.configurationAccess.cmakeInEnv}${EOL}`;
   output += `Access to Ninja in environment PATH ${reportedResult.configurationAccess.ninjaInEnv}${EOL}`;
   output += `Access to ESP-IDF Tools Path (idf.toolsPath) ${reportedResult.configurationAccess.toolsPath}${EOL}`;
+  output += `Access to Build Directory Path (idf.buildPath) ${reportedResult.configurationAccess.buildPath}${EOL}`;
+  output += `Access to Source directory Path (idf.sourceDirectoryPath) ${reportedResult.configurationAccess.sourceDirPath}${EOL}`;
+  output += `Access to SDKConfig file Path (idf.sdkconfigFilePath) ${reportedResult.configurationAccess.sdkconfigPath}${EOL}`;
   output += `-------------------------------------------------------- Configurations has spaces -------------------------------------------------------------${EOL}`;
   output += `Spaces in system environment Path ${reportedResult.configurationSpacesValidation.systemEnvPath}${EOL}`;
   output += `Spaces in ESP-ADF Path (idf.espAdfPath) ${reportedResult.configurationSpacesValidation.espAdfPath}${EOL}`;

--- a/src/test/doctor.test.ts
+++ b/src/test/doctor.test.ts
@@ -300,6 +300,9 @@ suite("Doctor Command tests", () => {
       }
     }
     expectedOutput += `System python Path (idf.pythonInstallPath) ${reportObj.configurationSettings.sysPythonBinPath}${os.EOL}`;
+    expectedOutput += `Build Directory Path (idf.buildPath) ${reportObj.configurationSettings.buildPath}${os.EOL}`;
+    expectedOutput += `Source directory Path (idf.sourceDirectoryPath) ${reportObj.configurationSettings.sourceDirPath}${os.EOL}`;
+    expectedOutput += `SDKConfig file Path (idf.sdkconfigFilePath) ${reportObj.configurationSettings.sdkconfigPath}${os.EOL}`;
     expectedOutput += `Virtual environment Python path (computed) ${
       process.env.IDF_PYTHON_ENV_PATH + "/bin/python"
     }${os.EOL}`;


### PR DESCRIPTION
## Description

Add `idf.sourceDirectoryPath` to describe the source directory for the build command.

Update doctor command report to add buildPath, sourceDirectoryPath and sdkconfigFilePath.

This pull request introduces a new configuration setting, `idf.sourceDirectoryPath`, which allows users to specify the source directory path for the CMake `-S` flag. The change is reflected throughout the extension, including documentation, configuration handling, reporting, and localization files. It also updates the diagnostic/reporting logic to include access checks and reporting for this new setting, alongside similar checks for `idf.buildPath` and `idf.sdkconfigFilePath`.

**Configuration and Build System Enhancements:**

* Added the `idf.sourceDirectoryPath` configuration setting to `package.json`, enabling users to set a custom source directory for CMake builds.
* Updated the build logic in `buildTask.ts` to use the `idf.sourceDirectoryPath` setting for the CMake `-S` flag, instead of always defaulting to the workspace folder.

**Documentation Updates:**

* Documented the new `idf.sourceDirectoryPath` setting in both English and Chinese configuration documentation files (`settings.rst`). [[1]](diffhunk://#diff-5a8ad6f9594585f97cf365ac395a8591d1048adf48d7eb34e0527297db0870f9R49-R50) [[2]](diffhunk://#diff-ab0c769b5563c6d26514e2db99920653bf78ff6befd4bdb4bb7f0b8ad62be6adR39-R40)

**Reporting and Diagnostics:**

* Extended the report object and related logic to handle and display `idf.sourceDirectoryPath`, `idf.buildPath`, and `idf.sdkconfigFilePath` in diagnostic reports, including access checks for these paths. [[1]](diffhunk://#diff-fbe7837799fa358af1ea613281b07da4f17db5332d6b38c4056a414ac107b128R46-R48) [[2]](diffhunk://#diff-fbe7837799fa358af1ea613281b07da4f17db5332d6b38c4056a414ac107b128R63-R65) [[3]](diffhunk://#diff-4d74d58646f0be3303ed5a75d84d5cef7f87875ff5dbe0e906b2f074738dbd1cR97-R99) [[4]](diffhunk://#diff-4b9ed5b6ca5c756cc498e43e6915cfece49d6432ddcae4e5799b30d9c75507c2R29-R48) [[5]](diffhunk://#diff-0cc0702e14b5cdcfdf44d3455d0660de4afacf67ff07fb56e8b7d547e70e2ed0R33-R35) [[6]](diffhunk://#diff-0cc0702e14b5cdcfdf44d3455d0660de4afacf67ff07fb56e8b7d547e70e2ed0R61-R63) [[7]](diffhunk://#diff-929d645b9e7586a8db16eb510276a5b361da0f759d1f323e2b27a8fb51656ce1R69-R71) [[8]](diffhunk://#diff-929d645b9e7586a8db16eb510276a5b361da0f759d1f323e2b27a8fb51656ce1R106-R108) [[9]](diffhunk://#diff-76adab581b6ff0d5673c601250d4b4c2ec29f1cd0c6965872888eb1530c440c2R303-R305)

**Localization:**

* Added localized descriptions for the new `idf.sourceDirectoryPath` configuration in Spanish, Portuguese, Russian, and Chinese translation files. [[1]](diffhunk://#diff-05e7789d19575297c332034d9d8993d3f73ee4200fb42a8386d5d1fc8f42d850R191) [[2]](diffhunk://#diff-b7cd2145452d0277a88ebb656ae2ad8406bde631693fcc376b9e88f6dafa2d2cR190) [[3]](diffhunk://#diff-60887a0b1e67bd4774a39137bebc5094abcb77d952d45d576cb8738a3c8af844R191) [[4]](diffhunk://#diff-f7bf43016f75ff20cad4dab3e06b9a95b740bbcf154f95fe2c6168c75cb78931R192)

Fixes #1650

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Build your Project" command. The command should work as before.
2. Change `idf.sourceDirectoryPath` in settings.json to another value (default is `${workspaceFolder}`). For example you can point to another ESP-IDF project.
3. Click on "ESP-IDF: Build your Project" command. The command should build using the given source directory.

- Expected behaviour:

idf.sourceDirectoryPath determine what source directory to use for building.

- Expected output:

## How has this been tested?

Manual testing as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
