### PR TITLE
[VSC-1773] Add double quotes around gdbinit file path

### DIFF
--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -175,7 +175,7 @@ export class GdbHeapTraceManager {
     workspaceFolder: string
   ) {
     let content = `set pagination off\nset confirm off\ntarget remote :3333\n\nmon reset halt\nflushregs\n\n`;
-    content += `tb heap_trace_start\ncommands\nmon esp sysview_mcore start ${traceFilePath}\n`;
+    content += `tb heap_trace_start\ncommands\nmon esp sysview_mcore start "${traceFilePath}"\n`;
     content += `c\nend\n\ntb heap_trace_stop\ncommands\nmon esp sysview_mcore stop\nend\n\nc`;
     const filePath = join(workspaceFolder, this.gdbinitFileName);
     await writeFile(filePath, content);


### PR DESCRIPTION
## Description

This change complements the change from [PR-1580](https://github.com/espressif/vscode-esp-idf-extension/pull/1580)
Adding double quotes to heap trace file path allowing the use of paths with space characters. 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Create a heap tracing example project on a path containing a space character.
2. Attempt to execute the command "Start Heap Trace"
3. Observe results.
4. Without this change it is expected that the command will fail.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Heap trace example project testes on Windows and Ubuntu on projects with and without space in the path.

**Test Configuration**:
* ESP-IDF Version: IDF5.4 and IDF5.5
* OS (Windows,Linux and macOS): Widows and Ubuntu

## Dependent components impacted by this PR:

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
