### PR TITLE
Fix openOCDRulesPath in addOpenOcdRules.ts

### DIFF
--- a/src/setup/addOpenOcdRules.ts
+++ b/src/setup/addOpenOcdRules.ts
@@ -30,7 +30,11 @@ export async function getOpenOcdRules(workspace: Uri) {
   if (!modifiedEnv.OPENOCD_SCRIPTS) {
     throw new Error("OPENOCD_SCRIPTS environment variables is not defined");
   }
-  const openOCDRulesPath = resolve(dirname(modifiedEnv.OPENOCD_SCRIPTS), "..", "contrib", "60-openocd.rules");
+  const openOCDRulesPath = resolve(
+    dirname(modifiedEnv.OPENOCD_SCRIPTS),
+    "contrib",
+    "60-openocd.rules",
+  );
   const doesRulesPathExists = await pathExists(openOCDRulesPath);
   if (!doesRulesPathExists) {
     throw new Error(`${openOCDRulesPath} doesn't exists.`);


### PR DESCRIPTION
## Description

On Linux, `dirname(modifiedEnv.OPENOCD_SCRIPTS)` returns `~/.espressif/tools/openocd-esp32/${openocd-esp32-version}/openocd-esp32/share/openocd`.

Therefore, the parameter  `".."` passed to the `resolve` function makes it return `~/.espressif/tools/openocd-esp32/${openocd-esp32-version}/openocd-esp32/share/contrib/60-openocd.rules`, which missing the `openocd` part between `share` and `contrib`.

At the end of the configuration, the message that prompt the user to add OpenOCD rules in `/etc/udev/rules.d` become an error instead: `"~/.espressif/tools/openocd-esp32/${openocd-esp32-version}/openocd-esp32/share/contrib/60-openocd.rules doesn't exists."`

Fix this issue by removing the `".."` parameter.

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Install the ESP-IDF Extension in VSCode on Linux.
2. Use the `ESP-IDF: Configure ESP-IDF Extension` to launch the setup wizard.
3. Complete the configuration.
4. Wait for a message that prompt the user to add OpenOCD rules in `/etc/udev/rules.d`.

- Expected behaviour:
A message will prompt the user to add OpenOCD rules in `/etc/udev/rules.d`.

**Test Configuration**:
* ESP-IDF Extension Version: Current `master` branch
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): Linux

## Dependent components impacted by this PR:

None

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
