### PR TITLE
Espressif mirror now uses Espressif cn PyPI registry for python packages

### DIFF
--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -115,8 +115,8 @@ export async function installPythonEnvFromIdfTools(
   pythonBinPath: string,
   gitPath: string,
   context: ExtensionContext,
-  mirror: ESP.IdfMirror,
-  cancelToken?: CancellationToken
+  cancelToken?: CancellationToken,
+  pypiIndexUrl?: string
 ) {
   const idfToolsPyPath = join(espDir, "tools", "idf_tools.py");
   const modifiedEnv: { [key: string]: string } = <{ [key: string]: string }>(
@@ -124,8 +124,8 @@ export async function installPythonEnvFromIdfTools(
   );
   modifiedEnv.IDF_TOOLS_PATH = idfToolsDir;
   modifiedEnv.IDF_PATH = espDir;
-  if (mirror === ESP.IdfMirror.Espressif) {
-    modifiedEnv.PIP_EXTRA_INDEX_URL = "https://dl.espressif.cn/pypi";
+  if (pypiIndexUrl) {
+    modifiedEnv.PIP_INDEX_URL = pypiIndexUrl;
   }
   if (process.platform === "win32") {
     let pathToGitDir: string;

--- a/src/setup/SetupPanel.ts
+++ b/src/setup/SetupPanel.ts
@@ -164,7 +164,8 @@ export class SetupPanel {
               context,
               setupArgs.espIdfStatusBar,
               setupArgs.workspaceFolder,
-              setupArgs.onReqPkgs
+              setupArgs.onReqPkgs,
+              message.pypiIndex
             );
           }
           break;
@@ -186,7 +187,8 @@ export class SetupPanel {
               setupArgs.workspaceFolder,
               context,
               setupArgs.espIdfStatusBar,
-              setupArgs.onReqPkgs
+              setupArgs.onReqPkgs,
+              message.pypiIndex
             );
           }
           break;
@@ -260,7 +262,8 @@ export class SetupPanel {
               context,
               setupArgs.workspaceFolder,
               setupArgs.espIdfStatusBar,
-              message.mirror
+              message.mirror,
+              message.pypiIndex
             );
           }
           break;
@@ -425,7 +428,8 @@ export class SetupPanel {
     context: ExtensionContext,
     espIdfStatusBar: StatusBarItem,
     workspaceFolderUri: Uri,
-    onReqPkgs?: string[]
+    onReqPkgs?: string[],
+    pypiIndex?: string
   ) {
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode"
@@ -503,7 +507,8 @@ export class SetupPanel {
             idfGitPath,
             progress,
             cancelToken,
-            onReqPkgs
+            onReqPkgs,
+            pypiIndex
           );
         } catch (error) {
           this.setupErrHandler(error);
@@ -559,7 +564,8 @@ export class SetupPanel {
     workspaceFolderUri: Uri,
     context: ExtensionContext,
     espIdfStatusBar: StatusBarItem,
-    onReqPkgs?: string[]
+    onReqPkgs?: string[],
+    pypiIndex?: string
   ) {
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode"
@@ -612,7 +618,8 @@ export class SetupPanel {
             espIdfStatusBar,
             progress,
             cancelToken,
-            onReqPkgs
+            onReqPkgs,
+            pypiIndex
           );
         } catch (error) {
           this.setupErrHandler(error);
@@ -630,7 +637,8 @@ export class SetupPanel {
     context: ExtensionContext,
     workspaceFolderUri: Uri,
     espIdfStatusBar: StatusBarItem,
-    mirror: ESP.IdfMirror
+    mirror: ESP.IdfMirror,
+    pypiIndex?: string
   ) {
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode"
@@ -667,7 +675,7 @@ export class SetupPanel {
             cancelToken,
             workspaceFolderUri,
             espIdfStatusBar,
-            mirror
+            pypiIndex
           );
         } catch (error) {
           this.setupErrHandler(error);

--- a/src/setup/espIdfDownloadStep.ts
+++ b/src/setup/espIdfDownloadStep.ts
@@ -40,7 +40,8 @@ export async function expressInstall(
   gitPath?: string,
   progress?: vscode.Progress<{ message: string; increment?: number }>,
   cancelToken?: vscode.CancellationToken,
-  onReqPkgs?: string[]
+  onReqPkgs?: string[],
+  pypiIndexUrl?: string
 ) {
   const pyExists = pyPath === "python" ? true : await pathExists(pyPath);
   const doesPythonExists = await checkPythonExists(pyPath, __dirname);
@@ -118,6 +119,7 @@ export async function expressInstall(
     espIdfStatusBar,
     progress,
     cancelToken,
-    onReqPkgs
+    onReqPkgs,
+    pypiIndexUrl
   );
 }

--- a/src/setup/installPyReqs.ts
+++ b/src/setup/installPyReqs.ts
@@ -19,7 +19,6 @@ import { OutputChannel } from "../logger/outputChannel";
 import { PyReqLog } from "../PyReqLog";
 import { CancellationToken, ExtensionContext, Progress } from "vscode";
 import { Logger } from "../logger/logger";
-import { ESP } from "../config";
 
 export async function installPyReqs(
   espIdfPath: string,
@@ -28,8 +27,8 @@ export async function installPyReqs(
   gitPath: string,
   context: ExtensionContext,
   progress: Progress<{ message: string; increment?: number }>,
-  mirror: ESP.IdfMirror,
-  cancelToken?: CancellationToken
+  cancelToken?: CancellationToken,
+  pypiIndexUrl?: string
 ) {
   progress.report({
     message: `Checking Python and pip exists...`,
@@ -70,8 +69,8 @@ export async function installPyReqs(
     sysPyBinPath,
     gitPath,
     context,
-    mirror,
-    cancelToken
+    cancelToken,
+    pypiIndexUrl
   );
   if (virtualEnvPyBin) {
     if (logTracker.Log.indexOf("Exception") < 0) {

--- a/src/setup/pyReqsInstallStep.ts
+++ b/src/setup/pyReqsInstallStep.ts
@@ -19,7 +19,6 @@ import { SetupPanel } from "./SetupPanel";
 import { saveSettings } from "./setupInit";
 import { getOpenOcdRules } from "./addOpenOcdRules";
 import { addIdfPath } from "./espIdfJson";
-import { ESP } from "../config";
 
 export async function createPyReqs(
   idfPath: string,
@@ -32,7 +31,7 @@ export async function createPyReqs(
   cancelToken: vscode.CancellationToken,
   workspaceFolderUri: vscode.Uri,
   espIdfStatusBar: vscode.StatusBarItem,
-  mirror: ESP.IdfMirror
+  pypiIndexUrl?: string
 ) {
   SetupPanel.postMessage({
     command: "updatePyVEnvStatus",
@@ -45,8 +44,8 @@ export async function createPyReqs(
     gitPath,
     context,
     progress,
-    mirror,
-    cancelToken
+    cancelToken,
+    pypiIndexUrl
   );
   await saveSettings(
     idfPath,

--- a/src/setup/toolsDownloadStep.ts
+++ b/src/setup/toolsDownloadStep.ts
@@ -34,6 +34,7 @@ export async function downloadIdfTools(
   progress?: vscode.Progress<{ message: string; increment?: number }>,
   cancelToken?: vscode.CancellationToken,
   onReqPkgs?: string[],
+  pypiIndexUrl?: string
 ) {
   const idfToolsManager = await IdfToolsManager.createIdfToolsManager(idfPath);
   const requiredTools = await idfToolsManager.getRequiredToolsInfo(
@@ -69,6 +70,6 @@ export async function downloadIdfTools(
     cancelToken,
     workspaceFolderUri,
     espIdfStatusBar,
-    mirror
+    pypiIndexUrl
   );
 }

--- a/src/views/setup/Install.vue
+++ b/src/views/setup/Install.vue
@@ -33,6 +33,7 @@ const {
   espIdf,
   espIdfContainer,
   isInstallButtonDisabled,
+  pypiIndex,
 } = storeToRefs(store);
 
 const isNotWinPlatform = computed(() => {
@@ -112,6 +113,10 @@ function setPyExecErrorStatus() {
 function setToolsFolder(newToolsPath: string) {
   store.toolsFolder = newToolsPath;
 }
+
+function setPypiIndex(newPypiIndex: string) {
+  store.pypiIndex = newPypiIndex;
+}
 </script>
 
 <template>
@@ -152,6 +157,23 @@ function setToolsFolder(newToolsPath: string) {
 
       <div v-if="!toolsFolder" class="notification is-danger">
         ESP-IDF Tools path should not be empty.
+      </div>
+
+      <div class="field">
+        <label class="label">PyPI Index URL (optional):</label>
+        <div class="control">
+          <input
+            class="input"
+            type="text"
+            placeholder="https://pypi.org/simple/"
+            :value="pypiIndex"
+            @input="setPypiIndex(($event.target as HTMLInputElement).value)"
+            data-config-id="pypi-index-input"
+          />
+        </div>
+        <p class="help">
+          Specify a custom PyPI index URL for Python package installation. Leave empty to use the default PyPI index.
+        </p>
       </div>
 
       <selectPyVersion v-if="isNotWinPlatform" />

--- a/src/views/setup/store.ts
+++ b/src/views/setup/store.ts
@@ -100,6 +100,7 @@ export const useSetupStore = defineStore("setup", () => {
   let extensionVersion: Ref<string> = ref("");
   let idfPathError: Ref<string> = ref("");
   let isInstallButtonDisabled: Ref<boolean> = ref(false);
+  let pypiIndex: Ref<string> = ref("");
 
   function clearIdfPathError() {
     idfPathError.value = "";
@@ -210,6 +211,7 @@ export const useSetupStore = defineStore("setup", () => {
       setupMode: setupMode.value,
       toolsPath: toolsFolder.value,
       saveScope: saveScope.value,
+      pypiIndex: pypiIndex.value,
     });
   }
 
@@ -226,6 +228,7 @@ export const useSetupStore = defineStore("setup", () => {
       pyPath,
       toolsPath: toolsFolder.value,
       saveScope: saveScope.value,
+      pypiIndex: pypiIndex.value,
     });
   }
 
@@ -255,6 +258,7 @@ export const useSetupStore = defineStore("setup", () => {
       toolsPath: toolsFolder.value,
       saveScope: saveScope.value,
       mirror: selectedIdfMirror.value,
+      pypiIndex: pypiIndex.value,
     });
   }
 
@@ -505,5 +509,6 @@ export const useSetupStore = defineStore("setup", () => {
     validateEspIdfPath,
     clearIdfPathError,
     espIdfVersion,
+    pypiIndex,
   };
 });


### PR DESCRIPTION
## Description

This pull request introduces support for selecting an ESP-IDF Python package mirror during setup, enabling users to specify which mirror to use for Python requirements installation. The changes propagate the new `mirror` parameter through the setup flow, ensuring it is passed to all relevant functions and used to set the appropriate environment variable for pip. Additionally, there are minor code cleanups and bug fixes in the setup logic.

**Support for ESP-IDF Python package mirror selection:**

* Added a `mirror` parameter to the setup flow, including functions such as `installPythonEnvFromIdfTools`, `installPyReqs`, `createPyReqs`, and `downloadIdfTools`, allowing users to specify which Python package mirror to use. [[1]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eR118) [[2]](diffhunk://#diff-104c92eb5de34178f6fe3a7952f54ee57d0b714fe1e7a2d56a7c40ee6ff61440R31) [[3]](diffhunk://#diff-6d068c9579dfc844abf42d4c51685ff932eae04f9ed11c56d0adfc46fb8456a7L33-R35) [[4]](diffhunk://#diff-5987a06e444e3943eb2d8d0bff7062dab06d4b7f37bef2241a292a95c032d654L71-R72)
* Set the `PIP_EXTRA_INDEX_URL` environment variable to the Espressif mirror (`https://dl.espressif.cn/pypi`) when the selected mirror is `ESP.IdfMirror.Espressif`, ensuring pip uses the correct source for package installation.

**Integration of mirror selection in setup UI and store:**

* Updated the setup store and UI logic to include the selected mirror (`selectedIdfMirror.value`) when checking ESP-IDF tools and posting setup messages, ensuring the mirror choice is respected throughout the process.

**Propagation of mirror parameter through setup classes and functions:**

* Passed the `mirror` parameter through the `SetupPanel` class methods and related function calls, maintaining consistency and enabling correct environment configuration. [[1]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL261-R263) [[2]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL627-R633) [[3]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL663-R670) [[4]](diffhunk://#diff-6d068c9579dfc844abf42d4c51685ff932eae04f9ed11c56d0adfc46fb8456a7R48)

**Minor code cleanups and bug fixes:**

* Fixed a bug in the setup store where `.value` was missing in the Python version selection logic, ensuring the correct path is used.
* Minor formatting and whitespace cleanups for improved readability and maintainability. [[1]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL332-R338) [[2]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL352-R358) [[3]](diffhunk://#diff-b82412394254fe4af2444f06fbbf8b97637fecad92e0ab67ad98cc4a24654fbdL284-R287)

Fixes #1688

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Configure ESP-IDF Extension" command and run the setup either Express or Advanced. Choose **Espressif** mirror when installing.
2. Execute action.
3. Observe results. During Python packages step, see that  `https://dl.espressif.cn/pypi` is used to download python packages.

- Expected behaviour:

When using the Espressif Mirror, the `https://dl.espressif.cn/pypi` is set in PIP_INDEX_URL when installing the ESP-IDF python packages.

- Expected output:

When using the Espressif Mirror, the `https://dl.espressif.cn/pypi` is set in PIP_INDEX_URL when installing the ESP-IDF python packages.

## How has this been tested?

Manual testing using steps above.

**Test Configuration**:
* ESP-IDF Version: master
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
