### PR TITLE
update openOCD fallback boards

### DIFF
--- a/src/espIdf/openOcd/defaultBoards.ts
+++ b/src/espIdf/openOcd/defaultBoards.ts
@@ -20,87 +20,303 @@ import { IdfBoard } from "./boardConfiguration";
 
 export const defaultBoards = [
   {
-    name: "ESP32 module",
-    description: "ESP32 used with ESP-PROG board",
+    name: "ESP-WROVER-KIT 3.3V",
+    description: "ESP-WROVER-KIT with 3.3V ESP32-WROVER-B module",
     target: "esp32",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32.cfg"],
+    configFiles: ["board/esp32-wrover-kit-3.3v.cfg"],
   } as IdfBoard,
   {
-    name: "ESP32-C3 chip (via ESP-PROG)",
-    description: "ESP32-C3 used with ESP-PROG board",
-    target: "esp32c3",
-    configFiles: ["board/esp32c3-ftdi.cfg"],
+    name: "ESP-WROVER-KIT 1.8V",
+    description: "ESP-WROVER-KIT with 1.8V ESP32-WROVER-B module",
+    target: "esp32",
+    configFiles: ["board/esp32-wrover-kit-1.8v.cfg"],
   } as IdfBoard,
   {
-    name: "ESP32-C3 chip (via ESP-PROG-2)",
-    description: "ESP32-C3 debugging via ESP-PROG-2 board",
-    target: "esp32c3",
-    configFiles: ["board/esp32c3-bridge.cfg"],
+    name: "ESP32-ETHERNET-KIT",
+    description: "ESP32-ETHERNET-KIT with ESP32-WROVER-E module",
+    target: "esp32",
+    configFiles: ["board/esp32-ethernet-kit-3.3v.cfg"],
   } as IdfBoard,
   {
-    name: "ESP32-C3 chip (via builtin USB-JTAG)",
-    description: "ESP32-C3 debugging via builtin USB-JTAG",
-    target: "esp32c3",
-    configFiles: ["board/esp32c3-builtin.cfg"],
+    name: "ESP32 chip (via ESP-PROG)",
+    description: "ESP32 debugging via ESP-PROG board",
+    target: "esp32",
+    configFiles: [
+      "interface/ftdi/esp_ftdi.cfg",
+      "target/esp32.cfg"
+    ],
   } as IdfBoard,
   {
-    name: "ESP32-C6 chip (via ESP-PROG)",
-    description: "ESP32-C6 used with ESP-PROG board",
-    target: "esp32c6",
-    configFiles: ["board/esp32c6-ftdi.cfg"],
+    name: "ESP32 chip (via ESP-PROG-2)",
+    description: "ESP32 debugging via ESP-PROG-2 board",
+    target: "esp32",
+    configFiles: [
+      "board/esp32-bridge.cfg"
+    ],
   } as IdfBoard,
   {
-    name: "ESP32-C6 chip (via ESP-PROG-2)",
-    description: "ESP32-C6 debugging via ESP-PROG-2 board",
-    target: "esp32c6",
-    configFiles: ["board/esp32c6-bridge.cfg"],
+    name: "ESP32-SOLO-1 module (via ESP-PROG)",
+    description: "ESP32-SOLO-1 debugging via ESP-PROG board",
+    target: "esp32",
+    configFiles: [
+      "interface/ftdi/esp_ftdi.cfg",
+      "target/esp32-solo-1.cfg"
+    ],
   } as IdfBoard,
   {
-    name: "ESP32-C6 chip (via builtin USB-JTAG)",
-    description: "ESP32-C6 debugging via builtin USB-JTAG",
-    target: "esp32c6",
-    configFiles: ["board/esp32c6-builtin.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-H2 chip (via builtin USB-JTAG)",
-    description: "ESP32-H2 debugging via builtin USB-JTAG",
-    target: "esp32h2",
-    configFiles: ["board/esp32h2-builtin.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-H2 chip (via ESP-PROG)",
-    description: "ESP32-H2 debugging via ESP-PROG board",
-    target: "esp32h2",
-    configFiles: [ "board/esp32h2-ftdi.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-H2 chip (via ESP-PROG-2)",
-    description: "ESP32-H2 debugging via ESP-PROG-2 board",
-    target: "esp32h2",
-    configFiles: ["board/esp32h2-bridge.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-S2 module",
-    description: "ESP32-S2 used with ESP-PROG board",
+    name: "ESP32-S2-KALUGA-1",
+    description: "ESP32-S2-KALUGA-1 kit",
     target: "esp32s2",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s2.cfg"],
+    configFiles: ["board/esp32s2-kaluga-1.cfg"],
+  } as IdfBoard,
+  {
+    name: "ESP32-S2 chip (via ESP-PROG)",
+    description: "ESP32-S2 debugging via ESP-PROG board",
+    target: "esp32s2",
+    configFiles: [
+      "interface/ftdi/esp_ftdi.cfg",
+      "target/esp32s2.cfg"
+    ],
   } as IdfBoard,
   {
     name: "ESP32-S2 chip (via ESP-PROG-2)",
     description: "ESP32-S2 debugging via ESP-PROG-2 board",
     target: "esp32s2",
-    configFiles: ["board/esp32s2-bridge.cfg"],
-  } as IdfBoard,
-  {
-    name: "ESP32-S3 chip (via ESP-PROG)",
-    description: "ESP32-S3 used with ESP-PROG board",
-    target: "esp32s3",
-    configFiles: ["interface/ftdi/esp32_devkitj_v1.cfg", "target/esp32s3.cfg"],
+    configFiles: [
+      "board/esp32s2-bridge.cfg"
+    ],
   } as IdfBoard,
   {
     name: "ESP32-S3 chip (via builtin USB-JTAG)",
     description: "ESP32-S3 debugging via builtin USB-JTAG",
     target: "esp32s3",
-    configFiles: ["board/esp32s3-builtin.cfg"],
+    configFiles: [
+      "board/esp32s3-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-S3 chip (via ESP-PROG)",
+    description: "ESP32-S3 debugging via ESP-PROG board",
+    target: "esp32s3",
+    configFiles: [
+      "interface/ftdi/esp_ftdi.cfg",
+      "target/esp32s3.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-S3 chip (via ESP-PROG-2)",
+    description: "ESP32-S3 debugging via ESP-PROG-2 board",
+    target: "esp32s3",
+    configFiles: [
+      "board/esp32s3-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C2 chip (via ESP-PROG)",
+    description: "ESP32-C2 debugging via ESP-PROG board",
+    target: "esp32c2",
+    configFiles: [
+      "board/esp32c2-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C2 chip (via ESP-PROG-2)",
+    description: "ESP32-C2 debugging via ESP-PROG-2 board",
+    target: "esp32c2",
+    configFiles: [
+      "board/esp32c2-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via builtin USB-JTAG)",
+    description: "ESP32-C3 debugging via builtin USB-JTAG",
+    target: "esp32c3",
+    configFiles: [
+      "board/esp32c3-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via ESP-PROG)",
+    description: "ESP32-C3 debugging via ESP-PROG board",
+    target: "esp32c3",
+    configFiles: [
+      "board/esp32c3-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C3 chip (via ESP-PROG-2)",
+    description: "ESP32-C3 debugging via ESP-PROG-2 board",
+    target: "esp32c3",
+    configFiles: [
+      "board/esp32c3-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C5 chip (via builtin USB-JTAG)",
+    description: "ESP32-C5 debugging via builtin USB-JTAG",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C5 chip (via ESP-PROG)",
+    description: "ESP32-C5 debugging via ESP-PROG board",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C5 chip (via ESP-PROG-2)",
+    description: "ESP32-C5 debugging via ESP-PROG-2 board",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via builtin USB-JTAG)",
+    description: "ESP32-C6 debugging via builtin USB-JTAG",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via ESP-PROG)",
+    description: "ESP32-C6 debugging via ESP-PROG board",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip (via ESP-PROG-2)",
+    description: "ESP32-C6 debugging via ESP-PROG-2 board",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip with LP core (via builtin USB-JTAG)",
+    description: "ESP32-C6 with LP core debugging via builtin USB-JTAG",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-lpcore-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip with LP core (via ESP-PROG)",
+    description: "ESP32-C6 with LP core debugging via ESP-PROG board",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-lpcore-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C6 chip with LP core (via ESP-PROG-2)",
+    description: "ESP32-C6 with LP core debugging via ESP-PROG-2 board",
+    target: "esp32c6",
+    configFiles: [
+      "board/esp32c6-lpcore-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C61 chip (via builtin USB-JTAG)",
+    description: "ESP32-C61 debugging via builtin USB-JTAG",
+    target: "esp32c61",
+    configFiles: [
+      "board/esp32c61-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C61 chip (via ESP-PROG)",
+    description: "ESP32-C61 debugging via ESP-PROG board",
+    target: "esp32c61",
+    configFiles: [
+      "board/esp32c61-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C61 chip (via ESP-PROG-2)",
+    description: "ESP32-C61 debugging via ESP-PROG-2 board",
+    target: "esp32c61",
+    configFiles: [
+      "board/esp32c61-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via builtin USB-JTAG)",
+    description: "ESP32-H2 debugging via builtin USB-JTAG",
+    target: "esp32h2",
+    configFiles: [
+      "board/esp32h2-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via ESP-PROG)",
+    description: "ESP32-H2 debugging via ESP-PROG board",
+    target: "esp32h2",
+    configFiles: [
+      "board/esp32h2-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H2 chip (via ESP-PROG-2)",
+    description: "ESP32-H2 debugging via ESP-PROG-2 board",
+    target: "esp32h2",
+    configFiles: [
+      "board/esp32h2-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H4 chip (via builtin USB-JTAG)",
+    description: "ESP32-H4 debugging via builtin USB-JTAG",
+    target: "esp32h4",
+    configFiles: [
+      "board/esp32h4-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H4 chip (via ESP-PROG)",
+    description: "ESP32-H4 debugging via ESP-PROG board",
+    target: "esp32h4",
+    configFiles: [
+      "board/esp32h4-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-H4 chip (via ESP-PROG-2)",
+    description: "ESP32-H4 debugging via ESP-PROG-2 board",
+    target: "esp32h4",
+    configFiles: [
+      "board/esp32h4-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-P4 chip (via builtin USB-JTAG)",
+    description: "ESP32-P4 debugging via builtin USB-JTAG",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-P4 chip (via ESP-PROG)",
+    description: "ESP32-P4 debugging via ESP-PROG board",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-P4 chip (via ESP-PROG-2)",
+    description: "ESP32-P4 debugging via ESP-PROG-2 board",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-bridge.cfg"
+    ],
   } as IdfBoard,
 ]; 


### PR DESCRIPTION
## Description

This pull request significantly expands and updates the list of default supported boards for OpenOCD in the `defaultBoards` array. It introduces support for newer ESP32 chip variants, adds more board configurations for existing chips, and improves the descriptions and config file references for better clarity and maintainability.

**Board support expansion:**

* Added support for new ESP32 chip variants: ESP32-C5, ESP32-C6 (including LP core), ESP32-C61, ESP32-H4, and ESP32-P4, each with multiple debugging interface options (builtin USB-JTAG, ESP-PROG, ESP-PROG-2).
* Added new board entries for existing chips such as ESP32-WROVER-KIT (1.8V and 3.3V), ESP32-ETHERNET-KIT, ESP32-S2-KALUGA-1, and ESP32-SOLO-1, increasing the range of supported hardware.

**Configuration and description improvements:**

* Updated and standardized the `description` fields for all boards to clearly indicate the chip variant and debugging method.
* Changed `configFiles` references to use specific board or interface configuration files, improving accuracy and maintainability.

**Refactoring and cleanup:**

* Removed outdated board entries

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Check on OpenOCD CI tests for `OpenOCD Board tests` and `Check default boards`.

You can also temporary delete (or rename) `$OPENOCD_SCRIPTS/esp-config.json` and run the `ESP-IDF: Select OpenOCD Board Configuration` which should return the defaults boards since esp-config.json is not found.

## How has this been tested?

Manual testing as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
