### PR TITLE
Fix EIM executable call

### DIFF
--- a/src/eim/downloadInstall.ts
+++ b/src/eim/downloadInstall.ts
@@ -68,7 +68,7 @@ export async function runExistingEIM(
           process.env.USERPROFILE || "",
           ".espressif",
           "eim_gui",
-          "eim.exe"
+          "eim-gui-windows-x64.exe"
         );
       } else if (process.platform === "darwin") {
         eimPath = "/Applications/eim.app";
@@ -259,7 +259,7 @@ export async function downloadExtractAndRunEIM(
     if (process.platform === "win32") {
       binaryPath = `Start-Process -FilePath "${join(
         eimInstallPath,
-        "eim.exe"
+        "eim-gui-windows-x64.exe"
       )}"`;
     } else if (process.platform === "linux") {
       binaryPath = `./eim`;


### PR DESCRIPTION
## Description

This pull request updates the Windows executable name used for running the EIM GUI to match the new binary naming convention. The changes ensure that both the path construction and the launch command reference the correct executable.

**Windows binary name update:**

* Changed the Windows executable filename from `eim.exe` to `eim-gui-windows-x64.exe` in the path construction within `runExistingEIM` in `src/eim/downloadInstall.ts`.
* Updated the launch command for Windows to use `eim-gui-windows-x64.exe` instead of `eim.exe` in `downloadExtractAndRunEIM` in `src/eim/downloadInstall.ts`.

Fixes #1696

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Open ESP-IDF Install Manager"
2. Execute action. 
3. Observe results. The EIM should be launched.

- Expected behaviour:

EIM can be launched from this extension.

- Expected output:

## How has this been tested?

Manual testing as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): Windows


## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [x] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
