### PR TITLE
Define missing env variable:  _PW_ACTUAL_ENVIRONMENT_ROOT required for esp-matter

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1123,6 +1123,12 @@ export async function appendIdfAndToolsToPath(curWorkspace: vscode.Uri) {
       "packages",
       "zap"
     );
+    modifiedEnv._PW_ACTUAL_ENVIRONMENT_ROOT = path.join(
+      modifiedEnv.ESP_MATTER_PATH,
+      "connectedhomeip",
+      "connectedhomeip",
+      ".environment"
+    );
   }
   const sysPythonPath = await getPythonPath(curWorkspace);
   let pythonBinPath = "";


### PR DESCRIPTION
Fix esp-matter examples build using esp idf vscode extension
The environment variable was added in this [PR](https://github.com/espressif/esp-matter/commit/211658c88ecd2984c768de4dc7837a531bea9d7a#diff-a70ab199085ab146f5b9ca4fde5b679154668c0143b58478c13910d2154fd889R60)

Updated environment [variable](https://github.com/espressif/esp-matter/blob/1cbceb0d43b7576f939424946b780287478abc42/export.sh#L60)

Fixes https://github.com/espressif/esp-matter/issues/1594

## Testing
Adding the _PW_ACTUAL_ENVIRONMENT_ROOT environment variable in settings.json file build works.