### PR TITLE
Use output capture execution only for lang tool commands

### DIFF
--- a/src/customTasks/customTaskProvider.ts
+++ b/src/customTasks/customTaskProvider.ts
@@ -50,12 +50,17 @@ export class CustomTask {
 
   public getProcessExecution(
     cmdString: string,
-    options: ShellExecutionOptions
-  ) {
-    return new ShellOutputCapturingExecution(cmdString, options);
+    options: ShellExecutionOptions,
+    captureOutput?: boolean
+  ): ShellOutputCapturingExecution | ShellExecution {
+    if (captureOutput) {
+      return new ShellOutputCapturingExecution(cmdString, options);
+    } else {
+      return new ShellExecution(cmdString, options);
+    }
   }
 
-  public async addCustomTask(taskType: CustomTaskType) {
+  public async addCustomTask(taskType: CustomTaskType, captureOutput?: boolean) {
     let command: string;
     let taskName: string;
     switch (taskType) {
@@ -112,7 +117,7 @@ export class CustomTask {
       notificationMode === NotificationMode.Output
         ? TaskRevealKind.Always
         : TaskRevealKind.Silent;
-    const customExecution = this.getProcessExecution(command, options);
+    const customExecution = this.getProcessExecution(command, options, captureOutput);
     const customTaskPresentationOptions = {
       reveal: showTaskOutput,
       showReuseMessage: false,

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -19,6 +19,7 @@
 import { ensureDir } from "fs-extra";
 import { join } from "path";
 import {
+  ProcessExecution,
   TaskPanelKind,
   TaskPresentationOptions,
   TaskRevealKind,
@@ -49,7 +50,7 @@ export class IdfSizeTask {
     return join(this.buildDirPath, `${projectName}.map`);
   }
 
-  public async getSizeInfo() {
+  public async getSizeInfo(captureOutput?: boolean) {
     await ensureDir(this.buildDirPath);
     const pythonCommand = await getVirtualEnvPythonPath(this.currentWorkspace);
     const mapFilePath = this.mapFilePath();
@@ -61,11 +62,9 @@ export class IdfSizeTask {
       env: modifiedEnv,
     };
 
-    const sizeExecution = OutputCapturingExecution.create(
-      pythonCommand,
-      args,
-      processOptions
-    );
+    const sizeExecution = captureOutput
+      ? OutputCapturingExecution.create(pythonCommand, args, processOptions)
+      : new ProcessExecution(pythonCommand, args, processOptions);
     const notificationMode = readParameter(
       "idf.notificationMode",
       this.currentWorkspace

--- a/src/taskManager/customExecution.ts
+++ b/src/taskManager/customExecution.ts
@@ -22,7 +22,12 @@ import * as path from "path";
 
 export interface CustomExecutionTaskResult {
   continueFlag: boolean;
-  executions: (OutputCapturingExecution | ShellOutputCapturingExecution)[];
+  executions: (
+    | OutputCapturingExecution
+    | ShellOutputCapturingExecution
+    | vscode.ProcessExecution
+    | vscode.ShellExecution
+  )[];
 }
 
 export interface CapturedTaskOutput {


### PR DESCRIPTION
## Description

Fix #1728 

After introducing #1621 the OutputCapturingCustomExecution does not preserve ANSI escape codes due to not being detected as a terminal by the executed scripts. We need to use only this custom execution for Chat Language tool commands to preserve the ANSI colors on the regular flow.

This pull request introduces a new `captureOutput` option across the build, flash, erase, and size tasks in the codebase. This option allows commands to either capture their output for further processing or run as standard VSCode tasks without output capturing. The changes propagate this option through the main command functions and their supporting classes, updating method signatures and logic to support both execution modes.

Key changes include:

**Support for Output Capturing in Task Execution:**

- Added an optional `captureOutput` parameter to the main build, flash, erase, and size task functions (e.g., `buildCommandMain`, `flash`, `eraseFlash`, `getSizeInfo`, etc.), allowing tasks to run with or without output capture. This parameter is passed through all relevant internal method calls. [[1]](diffhunk://#diff-da252b9e541cdadedfc214556fcdd522d6c8374c068f2007bff8974ee8d666fcL58-R59) [[2]](diffhunk://#diff-da252b9e541cdadedfc214556fcdd522d6c8374c068f2007bff8974ee8d666fcL80-R104) [[3]](diffhunk://#diff-da252b9e541cdadedfc214556fcdd522d6c8374c068f2007bff8974ee8d666fcL122-R127) [[4]](diffhunk://#diff-4225b82a659a3d243e9915480f39a57dcc72eff39486b4a94fe4a0667a761947L39-R44) [[5]](diffhunk://#diff-c363215690b86ceca02610e877036fd184b1acb49a274c22e9e968e7a44a0fd4L52-R53) [[6]](diffhunk://#diff-ba176160e86a4a31ac09fce59727c25327ed658f6f5f78689de42c8680e0959aL73-R67) [[7]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4L88-R88)

- Updated task execution logic to instantiate either output-capturing execution classes (e.g., `OutputCapturingExecution`, `ShellOutputCapturingExecution`) or standard VSCode execution classes (`ProcessExecution`, `ShellExecution`) based on the `captureOutput` flag. This pattern is applied in build, flash, erase, and size task implementations. [[1]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8R178-R190) [[2]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8R220-R232) [[3]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8L280-R300) [[4]](diffhunk://#diff-fbe37d5457e101761d3ec4b65e769324238b47f348b75348693b05c5ab322ee3L53-R63) [[5]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4L162-R183) [[6]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4R207-R236) [[7]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4L115-R143) [[8]](diffhunk://#diff-ba176160e86a4a31ac09fce59727c25327ed658f6f5f78689de42c8680e0959aL129-R146) [[9]](diffhunk://#diff-c363215690b86ceca02610e877036fd184b1acb49a274c22e9e968e7a44a0fd4L64-R67)

**API and Signature Updates:**

- Modified method signatures throughout the codebase to accept the new `captureOutput` parameter, including in classes such as `BuildTask`, `FlashTask`, `EraseFlashTask`, `IdfSizeTask`, and `CustomTask`. [[1]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8L66-R65) [[2]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4L88-R88) [[3]](diffhunk://#diff-ba176160e86a4a31ac09fce59727c25327ed658f6f5f78689de42c8680e0959aL73-R67) [[4]](diffhunk://#diff-c363215690b86ceca02610e877036fd184b1acb49a274c22e9e968e7a44a0fd4L52-R53) [[5]](diffhunk://#diff-fbe37d5457e101761d3ec4b65e769324238b47f348b75348693b05c5ab322ee3L53-R63)

**Internal Handling and Type Adjustments:**

- Adjusted type annotations and result handling to accommodate both output-capturing and standard execution objects in arrays and return types. (F0e64392L113R113, [[1]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8L232-R260) [[2]](diffhunk://#diff-c488f7f32ce129f5e1d4ad11de7016cd68a9e8fbfcf5f82b00a1d3a0bb8c02a4L106-R106)

**Minor Refactoring and Cleanup:**

- Cleaned up imports and removed unused variables in affected files. [[1]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8L40) [[2]](diffhunk://#diff-ba176160e86a4a31ac09fce59727c25327ed658f6f5f78689de42c8680e0959aL19-L21) [[3]](diffhunk://#diff-ba176160e86a4a31ac09fce59727c25327ed658f6f5f78689de42c8680e0959aL31-R29) [[4]](diffhunk://#diff-c363215690b86ceca02610e877036fd184b1acb49a274c22e9e968e7a44a0fd4R22) [[5]](diffhunk://#diff-4225b82a659a3d243e9915480f39a57dcc72eff39486b4a94fe4a0667a761947L29-R33)

These changes provide greater flexibility in how tasks are executed and how their outputs are handled, enabling more robust integration with the IDE and potential downstream processing.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Build your project". 
2. Execute action. 
3. Observe results. The IDF Size task should preserve the ANSI colors in terminal.

- Expected behaviour:
ANSI Colors remain in tasks terminal output.

- Expected output:
ANSI Colors remain in tasks terminal output.

## How has this been tested?

Manual testing with steps above.

**Test Configuration**:
* ESP-IDF Version: 6.1.0
* OS (Windows,Linux and macOS): Windows and MacOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
