### PR TITLE
rm clang check await on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -274,7 +274,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Check if running in a VS Code fork and prompt for clangd extension installation
   if (PreCheck.isRunningInVSCodeFork()) {
-    await checkAndPromptForClangdExtension();
+    checkAndPromptForClangdExtension();
   }
 
   // Check for root CMakeLists.txt and its content before full activation


### PR DESCRIPTION
## Description

This pull request makes a minor change to the activation flow in `src/extension.ts`. The asynchronous call to `checkAndPromptForClangdExtension` is no longer awaited, allowing the activation process to proceed without waiting for this check to complete.

Fix clang extension install prompt should not await in extension activation.

Fixes #1729

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Start extension on VS Code Insiders or Cursor.
2. Execute action. If user doesn't select install clang or not now, the extension should load as usual.
3. Observe results.

- Expected behaviour:

Extension continues activation lifecycle even if install clang is not selected.

- Expected output:

## How has this been tested?

Manual steps as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): macOS

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
