### PR TITLE
listen to disconnect request restart argument

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1454,16 +1454,12 @@ export async function activate(context: vscode.ExtensionContext) {
             }
             peripheralTreeProvider.refresh();
           }
-
-          if (
-            m &&
-            m.type === "event" &&
-            m.event === "output" &&
-            m.body.output.indexOf(
-              `From client: disconnect({"restart":true})`
-            ) !== -1
-          ) {
-            isDebugRestarted = true;
+        },
+        onWillReceiveMessage(message) {
+          if (message && message.command === "disconnect") {
+            if (message.arguments.restart) {
+              isDebugRestarted = true;
+            }
           }
         },
       };


### PR DESCRIPTION

## Description


The only way to know if the restart event happens is from the disconnect request from VS Code editor.

Fixes #1701

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Start a debug session with any ESP-IDF Project 
2. Execute restart action.
3. Observe results. The debug session should restart but OpenOCD remains connected.

- Expected behaviour:
The debug session should restart but OpenOCD remains connected.

- Expected output:
The debug session should restart but OpenOCD remains connected.

## How has this been tested?

Manual testing as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
