### PR TITLE
[VSC-1830] Prevent set target's QuickPick from closing on focus loss (WSL)

### DIFF
--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -164,6 +164,7 @@ export async function setIdfTarget(
             : defaultBoards;
         const selectedTarget = await window.showQuickPick(quickPickItems, {
           placeHolder: placeHolderMsg,
+          ignoreFocusOut: true
         });
         if (!selectedTarget) {
           return;


### PR DESCRIPTION
## Description

Fixes an issue in Remote-WSL where the ESP-IDF: Set Target dropdown (QuickPick) closes immediately, causing the command to exit without selecting a target. The QuickPick now ignores focus changes so it stays open long enough to make a selection.

Fixes #1743 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Open a project in **Remote - WSL** with the ESP-IDF extension installed.
2. Run **Command Palette** → `ESP-IDF: Set Target`.
3. Observe the target selection dropdown remains open and allows selecting a target.

- Expected behaviour:
  - The target selection dropdown stays open (does not disappear immediately) and selection proceeds normally.

- Expected output:
  - A target is selected and applied successfully
  
## How has this been tested?

As described above 

**Test Configuration**:
* ESP-IDF Version: 5.5.1
* OS (Windows,Linux and macOS): WSL Ubuntu

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
