### PR TITLE
[VSC-1833] Menuconfig: add visual separators between root sections

### DIFF
--- a/src/views/menuconfig/Menuconfig.vue
+++ b/src/views/menuconfig/Menuconfig.vue
@@ -69,37 +69,13 @@ const items = computed(() => {
   return store.items;
 });
 
-function isRootLevelUncategorized(item: Menu) {
-  // Root-level entries that are not menus have no "category" in our UI.
-  // Without a visual separator, they can look like they belong to the menu above.
-  return item?.type !== "menu";
-}
-
-function findPrevVisibleRootItem(rootItems: Menu[], index: number) {
-  for (let i = index - 1; i >= 0; i--) {
-    const prev = rootItems[i];
-    if (prev?.isVisible) return prev;
+const lastVisibleRootIndex = computed(() => {
+  const arr = items.value || [];
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i]?.isVisible) return i;
   }
-  return undefined;
-}
-
-function shouldShowSectionDivider(rootItems: Menu[], index: number) {
-  const item = rootItems?.[index];
-  if (!item?.isVisible) return false;
-
-  // Never show a divider before the first visible item (e.g. "Build type").
-  const prevVisible = findPrevVisibleRootItem(rootItems, index);
-  if (!prevVisible) return false;
-
-  // 1) Always separate visible root-level menus from whatever comes above.
-  if (item.type === "menu") return true;
-
-  // 2) For uncategorized root-level configs: add a divider only when they start
-  // after a menu, so they don't look like the last menu's children.
-  if (isRootLevelUncategorized(item) && prevVisible.type === "menu") return true;
-
-  return false;
-}
+  return -1;
+});
 
 function onScroll() {
   const configList = document.querySelector(".config-list") as HTMLElement;
@@ -213,13 +189,11 @@ onUnmounted(() => {
       ></div>
       <div id="scrollable" class="config-list" @scroll="handleScroll">
         <div v-for="(config, index) in items" :key="config.id">
-          <div
-            v-if="shouldShowSectionDivider(items, index)"
-            class="section-divider-wrapper"
-          >
-            <div class="section-divider" />
-          </div>
           <ConfigElement :config="config" />
+          <div
+            class="section-divider"
+            v-if="config.isVisible && index !== lastVisibleRootIndex"
+          />
         </div>
       </div>
     </div>
@@ -289,11 +263,6 @@ p {
   min-width: 300px;
   max-width: 800px;
   padding: 0 0.5rem;
-}
-
-.section-divider-wrapper {
-  margin-top: 10px;
-  margin-bottom: 6px;
 }
 
 .section-divider {


### PR DESCRIPTION
### Description

Fixes #1749

**Fix MenuConfig UI: visually separate root sections and uncategorized options**

This PR improves readability in the SDK Configuration Editor (MenuConfig webview) by adding **subtle visual separators** between top-level sections. This prevents root-level options that don’t belong to any `menu` (e.g. `IDF_EXPERIMENTAL_FEATURES`) from **appearing as if they belong to the previous menu**.

- **What changed**
  - Add a thin divider **before each visible root-level menu section** (except the first visible item, so nothing appears above “Build type”).
  - Add the same divider **when a visible root-level non-menu item starts after a menu**, so uncategorized options don’t look like they’re part of the previous section.

- **Why**
  - Our left tree navigation is menu-based, and the right panel renders items sequentially; when an option is not enclosed in a `menu`, the UI can make it look “attached” to the menu above. This addresses [GitHub issue #1749](https://github.com/espressif/vscode-esp-idf-extension/issues/1749).

- **Scope**
  - Webview-only change; **no changes** to confserver, `kconfig_menus.json`, or Kconfig parsing.

## How has this been tested?

1) Create esp-project (i used sample_project example)
2) Create a "components" folder in root of the project
3) Cd into it, open esp-idf terminal and add a new component (idf.py create-component myComponent)
4) Add a Konfig file to "myComponent with
```
menu "My Component Settings"
    config MYCOMPONENT_AWESOME_FEATURE
        bool "Enable somehting awesome"
        default n
        help
            whether to enable something awesome in my component.
endmenu
```
5) For more details and screenshot check GH issue

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
