### PR TITLE
feat: Add espIdfPortInfo context tool for AI agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -2491,6 +2491,28 @@
             "command"
           ]
         }
+      },
+      {
+        "name": "espIdfPortInfo",
+        "displayName": "ESP-IDF Port Information",
+        "modelDescription": "Query serial port configuration and available ESP devices. Use this tool BEFORE attempting to flash to verify that a valid ESP device is connected. Returns the currently configured port, list of available serial ports, which ports are ESP devices, and whether the configuration is valid. This helps prevent flash failures due to incorrect port configuration.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "espIdfPortInfo",
+        "tags": [
+          "esp-idf",
+          "serial port",
+          "port",
+          "device detection",
+          "usb",
+          "flash preparation",
+          "check port",
+          "list ports"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {},
+          "required": []
+        }
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,7 @@ import { configureClangSettings } from "./clang";
 import { OpenOCDErrorMonitor } from "./espIdf/hints/openocdhint";
 import { updateHintsStatusBarItem } from "./statusBar";
 import { activateLanguageTool, deactivateLanguageTool } from "./langTools";
+import { activateContextTools, deactivateContextTools } from "./langTools/contextTools";
 import { readSerialPort } from "./idfConfiguration";
 import { openFolderCheck, webIdeCheck } from "./common/PreCheck";
 import { buildFlashAndMonitor } from "./buildFlashMonitor";
@@ -339,6 +340,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Initialize ESP-IDF Language Tool for chat commands
   activateLanguageTool(context);
+  activateContextTools(context);
 
   openOCDManager = OpenOCDManager.init();
   qemuManager = QemuManager.init();
@@ -4408,4 +4410,5 @@ export function deactivate() {
   }
   KconfigLangClient.stopKconfigLangServer();
   deactivateLanguageTool();
+  deactivateContextTools();
 }

--- a/src/langTools/contextTools.ts
+++ b/src/langTools/contextTools.ts
@@ -1,0 +1,183 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Context Query Tools for AI Agents
+ * Copyright 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from "vscode";
+import * as SerialPortLib from "serialport";
+import { ESP } from "../config";
+import { readParameter } from "../idfConfiguration";
+import { getIdfTargetFromSdkconfig } from "../workspaceConfig";
+import { Logger } from "../logger/logger";
+
+/**
+ * ESP-IDF Context Tools for AI Agents
+ *
+ * These tools allow AI agents to QUERY project state before executing commands.
+ * This enables agents to make informed decisions and avoid blind execution failures.
+ *
+ */
+
+/**
+ * Extract ESP vendor IDs from idf.usbSerialPortFilters configuration.
+ * This ensures we use the same source of truth as the rest of the extension.
+ */
+function getEspVendorIds(workspaceURI: vscode.Uri): Set<string> {
+  const vendorIds = new Set<string>();
+  
+  // Extract vendor IDs from user configuration
+  const usbSerialPortFilters = readParameter(
+    "idf.usbSerialPortFilters",
+    workspaceURI
+  ) as { [key: string]: { vendorId: string; productId: string } } | undefined;
+  
+  if (usbSerialPortFilters) {
+    Object.values(usbSerialPortFilters).forEach((filter) => {
+      if (filter.vendorId) {
+        // Remove "0x" prefix and convert to lowercase
+        const vendorId = filter.vendorId.toLowerCase().replace(/^0x/, "");
+        if (vendorId) {
+          vendorIds.add(vendorId);
+        }
+      }
+    });
+  }
+  
+  return vendorIds;
+}
+
+let portInfoDisposable: vscode.Disposable | undefined;
+
+export function activateContextTools(context: vscode.ExtensionContext) {
+  portInfoDisposable = vscode.lm.registerTool("espIdfPortInfo", {
+    async invoke(
+      options: { input: {} },
+      token: vscode.CancellationToken
+    ) {
+      try {
+        const defaultWorkspace = vscode.workspace.workspaceFolders?.[0];
+        const workspaceURI = ESP.GlobalConfiguration.store.get<vscode.Uri>(
+          ESP.GlobalConfiguration.SELECTED_WORKSPACE_FOLDER,
+          defaultWorkspace?.uri
+        );
+
+        if (!workspaceURI) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(
+              JSON.stringify({
+                error: "No ESP-IDF workspace found. Please open an ESP-IDF project folder first."
+              })
+            ),
+          ]);
+        }
+
+        const configuredPort = readParameter("idf.port", workspaceURI) as string;
+        const currentTarget = await getIdfTargetFromSdkconfig(workspaceURI);
+        const espVendorIds = getEspVendorIds(workspaceURI);
+
+        let availablePorts: Array<{
+          path: string;
+          manufacturer?: string;
+          vendorId?: string;
+          productId?: string;
+          isEspDevice: boolean;
+        }> = [];
+
+        try {
+          const ports = await SerialPortLib.SerialPort.list();
+          availablePorts = ports.map((port) => {
+            const vendorIdLower = port.vendorId?.toLowerCase();
+            const isEspDevice = vendorIdLower ? espVendorIds.has(vendorIdLower) : false;
+            return {
+              path: port.path,
+              manufacturer: port.manufacturer,
+              vendorId: port.vendorId,
+              productId: port.productId,
+              isEspDevice,
+            };
+          });
+        } catch (listError) {
+          // If listing fails, continue with empty list
+          Logger.warn(`Failed to list serial ports: ${listError.message}`);
+        }
+
+        const configuredPortInfo = availablePorts.find(
+          (p) => p.path === configuredPort ||
+                 p.path.includes(configuredPort) ||
+                 configuredPort.includes(p.path)
+        );
+
+        const configuredPortExists = !!configuredPortInfo;
+        const configuredPortIsEspDevice = configuredPortInfo?.isEspDevice ?? false;
+        const espDevices = availablePorts.filter((p) => p.isEspDevice);
+
+        let recommendation: string;
+        if (configuredPort === "detect") {
+          if (espDevices.length > 0) {
+            recommendation = `Port set to auto-detect. Found ${espDevices.length} ESP device(s): ${espDevices.map(d => d.path).join(", ")}`;
+          } else {
+            recommendation = "Port set to auto-detect but no ESP devices found. Please connect an ESP device.";
+          }
+        } else if (!configuredPortExists) {
+          if (espDevices.length > 0) {
+            recommendation = `Configured port "${configuredPort}" not found. Consider using one of the detected ESP devices: ${espDevices.map(d => d.path).join(", ")}`;
+          } else {
+            recommendation = `Configured port "${configuredPort}" not found and no ESP devices detected. Please connect an ESP device.`;
+          }
+        } else if (!configuredPortIsEspDevice) {
+          if (espDevices.length > 0) {
+            recommendation = `Warning: Configured port "${configuredPort}" does not appear to be an ESP device. Consider using: ${espDevices.map(d => d.path).join(", ")}`;
+          } else {
+            recommendation = `Warning: Configured port "${configuredPort}" does not appear to be an ESP device. No other ESP devices detected.`;
+          }
+        } else {
+          recommendation = `Ready to flash. Port "${configuredPort}" is configured and appears to be a valid ESP device.`;
+        }
+
+        const result = {
+          configuredPort,
+          portSetting: "idf.port",
+          currentTarget: currentTarget || "unknown",
+          availablePorts,
+          espDevicesFound: espDevices.length,
+          configuredPortExists,
+          configuredPortIsEspDevice,
+          recommendation,
+        };
+
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(JSON.stringify(result, null, 2)),
+        ]);
+      } catch (error) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(
+            JSON.stringify({
+              error: `Failed to get port information: ${error.message}`,
+            })
+          ),
+        ]);
+      }
+    },
+  });
+  context.subscriptions.push(portInfoDisposable);
+}
+
+export function deactivateContextTools() {
+  if (portInfoDisposable) {
+    portInfoDisposable.dispose();
+    portInfoDisposable = undefined;
+  }
+}


### PR DESCRIPTION
## Description

Add support for context-querying that allow AI agents to inspect project state before executing commands.

Changes:
- Add espIdfPortInfo tool to query serial port configuration
- Extract ESP vendor IDs from idf.usbSerialPortFilters config

This enables agents to make informed decisions and avoid failures like attempting to flash when no ESP device is connected.

Fixes #XXX

## Type of change

- New feature (non-breaking change which adds functionality)


## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
