### PR TITLE
[VSC-1857, 1858]fix: activation crash when IDF_PATH is unset

### DIFF
--- a/src/eim/loadIdfSetup.ts
+++ b/src/eim/loadIdfSetup.ts
@@ -38,7 +38,8 @@ export async function loadIdfSetup(workspaceFolder: Uri) {
     if (idfEnvSetup) {
       return idfEnvSetup;
     }
-    await promptOpenEspIdfInstallationManager();
+    // Do not await here: activation must continue to register the command first.
+    void promptOpenEspIdfInstallationManager();
     return;
   }
   const currentIdfConfigurationName = readParameter(
@@ -76,7 +77,8 @@ export async function loadIdfSetup(workspaceFolder: Uri) {
 
   if (!idfSetupToUse) {
     Logger.infoNotify("Current ESP-IDF setup is not found.");
-    await promptOpenEspIdfInstallationManager();
+    // Do not await here: activation must continue to register the command first.
+    void promptOpenEspIdfInstallationManager();
     return;
   }
 


### PR DESCRIPTION
## Description

Fixes #1773
Fixes #1774 

Improves first-run setup detection so we don’t show misleading notifications and we avoid calling version detection with an unset `IDF_PATH`.

Changes:

- **No setups case**: when `getIdfSetups()` returns an empty array and `loadEnvVarsAsIdfSetup()` cannot infer a setup, `loadIdfSetup()` now **immediately prompts** the user to **Open ESP-IDF Installation Manager** and then **returns** (so it won’t later fall through into “Current ESP-IDF setup is not found.”).
- **Deduplicated prompt**: the “extension configuration is not valid → Open ESP-IDF Installation Manager” message/action is centralized into `promptOpenEspIdfInstallationManager()` and reused from both failure paths.
- **Early validation**: `loadEnvVarsAsIdfSetup()` now checks `idfPath` (`IDF_PATH` / `idf.customExtraVars.IDF_PATH`) and returns early when missing/blank, preventing `getEspIdfFromCMake(idfPath)` from being called with `undefined`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

### Test 1: Fresh install / no setups / no IDF_PATH
- Remove `.espressif` and any workspace settings for ESP-IDF
- Ensure `IDF_PATH` is not set in the environment
- Install/reload the extension with any non-ESP-IDF folder open  
**Expected behaviour**: No “Current ESP-IDF setup is not found.” notification  
**Expected output**: Prompt appears offering **Open ESP-IDF Installation Manager**

### Test 2: No setups but invalid env inference
- Keep `.espressif` removed
- Set `idf.customExtraVars.IDF_PATH` to empty/whitespace (or leave unset)  
**Expected behaviour**: No crash, no misleading “current setup not found”  
**Expected output**: Prompt to open EIM is shown

### Test 3: Setups exist but current setup is missing/invalid
- Have at least one setup discoverable (e.g. via `esp_idf.json`)
- Ensure `idf.currentSetup` points to a non-existent/removed setup  
**Expected behaviour**: “Current ESP-IDF setup is not found.” can appear (valid in this scenario)  
**Expected output**: Prompt appears offering **Open ESP-IDF Installation Manager**

## How has this been tested?

As described above

**Test Configuration**:
* ESP-IDF Version: Doesn't matter
* OS (Windows,Linux and macOS): Doesn't matter

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added option to open ESP-IDF Installation Manager directly when setup is not found

## Bug Fixes
* Improved error messages for ESP-IDF setup issues in Spanish, Portuguese, Russian, and Chinese
* Enhanced error handling when no valid ESP-IDF setup is detected, replacing generic extension configuration errors with more specific setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->