### PR TITLE
Minor Typo after Flashing - fix from "Monitor command" to "Monitor Device"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4149,7 +4149,7 @@ const flash = (
           )
         ) {
           OutputChannel.appendLine(
-            "Flash has finished. You can monitor your device with 'ESP-IDF: Monitor command'"
+            "Flash has finished. You can monitor your device with 'ESP-IDF: Monitor Device'"
           );
         }
       }


### PR DESCRIPTION
## Description
The current extension shows the following Output after flashing:
```
[Flash]
Flash Done ⚡️
Flash has finished. You can monitor your device with 'ESP-IDF: Monitor command'
```

However, the correct is `ESP-IDF: Monitor Device`, this is a minor typo fix.

## Type of change

Bug fix

## Steps to test this pull request

1. Click on "Flash Device"
2. Observe output results.

- Expected behaviour:
N/A

- Expected output:
Output message after flashing to mention `ESP-IDF: Monitor Device`

```
[Flash]
Flash Done ⚡️
Flash has finished. You can monitor your device with 'ESP-IDF: Monitor Device'
```


**Test Configuration**:
* ESP-IDF Version: 5.5.3
* OS (Windows,Linux and macOS): Windows 11

## Dependent components impacted by this PR:

N/A

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
