### PR TITLE
use sdkconfig file path from project description json

### DIFF
--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -40,6 +40,10 @@ export class BuildTask {
 
   constructor(workspaceUri: vscode.Uri) {
     this.currentWorkspace = workspaceUri;
+    this.buildDirPath = idfConf.readParameter(
+      "idf.buildPath",
+      workspaceUri
+    ) as string;
   }
 
   public building(flag: boolean) {
@@ -62,7 +66,7 @@ export class BuildTask {
     } catch (error) {
       const errorMessage =
         "Failed to save unsaved files, ignoring and continuing with the build";
-      Logger.error(errorMessage, error, "build saveBeforeBuild");
+      Logger.error(errorMessage, error as Error, "build saveBeforeBuild");
       Logger.warnNotify(errorMessage);
     }
     if (BuildTask.isBuilding) {
@@ -90,9 +94,11 @@ export class BuildTask {
       throw new Error("CMake or Ninja executables not found");
     }
 
-    const currentWorkspaceFolder = vscode.workspace.workspaceFolders.find(
-      (w) => w.uri === this.currentWorkspace
-    );
+    const currentWorkspaceFolder = vscode.workspace.workspaceFolders?.length
+      ? vscode.workspace.workspaceFolders.find(
+          (w) => w.uri === this.currentWorkspace
+        )
+      : undefined;
 
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode",
@@ -104,27 +110,27 @@ export class BuildTask {
         ? vscode.TaskRevealKind.Always
         : vscode.TaskRevealKind.Silent;
 
-    let compileExecution: OutputCapturingExecution | vscode.ProcessExecution;
-    let buildExecution: OutputCapturingExecution | vscode.ProcessExecution;
+    let compileExecution:
+      | OutputCapturingExecution
+      | vscode.ProcessExecution
+      | undefined = undefined;
+    let buildExecution:
+      | OutputCapturingExecution
+      | vscode.ProcessExecution
+      | undefined = undefined;
 
     if (!cmakeCacheExists) {
-      const espIdfVersion = await getEspIdfFromCMake(idfPathDir);
-      let defaultCompilerArgs;
-      if (espIdfVersion === "x.x") {
-        Logger.warn(
-          "Could not determine ESP-IDF version. Using default compiler arguments for the latest known version."
-        );
-        defaultCompilerArgs = [
-          "-G",
-          "Ninja",
-          "-DPYTHON_DEPS_CHECKED=1",
-          "-DESP_PLATFORM=1",
-        ];
-      }
-      let compilerArgs = idfConf.readParameter(
-        "idf.cmakeCompilerArgs",
-        this.currentWorkspace
-      ) as Array<string>;
+      let defaultCompilerArgs = [
+        "-G",
+        "Ninja",
+        "-DPYTHON_DEPS_CHECKED=1",
+        "-DESP_PLATFORM=1",
+      ];
+      let compilerArgs =
+        (idfConf.readParameter(
+          "idf.cmakeCompilerArgs",
+          this.currentWorkspace
+        ) as Array<string>) || [];
 
       if (!compilerArgs || compilerArgs.length === 0) {
         compilerArgs = defaultCompilerArgs;
@@ -139,7 +145,12 @@ export class BuildTask {
       }
 
       const sdkconfigFile = await getSDKConfigFilePath(this.currentWorkspace);
-      if (sdkconfigFile && compilerArgs.indexOf("SDKCONFIG") === -1) {
+      const hasSdkconfigArg = compilerArgs.some(
+        (arg, index) =>
+          arg.startsWith("-DSDKCONFIG=") ||
+          (arg === "-D" && compilerArgs[index + 1]?.startsWith("SDKCONFIG="))
+      );
+      if (sdkconfigFile && !hasSdkconfigArg) {
         compilerArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
       }
 
@@ -252,9 +263,11 @@ export class BuildTask {
     this.building(true);
     await ensureDir(this.buildDirPath);
 
-    const currentWorkspaceFolder = vscode.workspace.workspaceFolders.find(
-      (w) => w.uri === this.currentWorkspace
-    );
+    const currentWorkspaceFolder = vscode.workspace.workspaceFolders?.length
+      ? vscode.workspace.workspaceFolders.find(
+          (w) => w.uri === this.currentWorkspace
+        )
+      : undefined;
 
     const notificationMode = idfConf.readParameter(
       "idf.notificationMode",
@@ -282,6 +295,9 @@ export class BuildTask {
       selectedDFUAdapterId(adapterTargetName).toString(),
     ];
     const pythonBinPath = await getVirtualEnvPythonPath();
+    if (!pythonBinPath) {
+      throw new Error("Python virtual environment not found");
+    }
     const processOptions = {
       cwd: this.buildDirPath,
       env: modifiedEnv,

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -23,13 +23,12 @@ import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
 import {
   getEspIdfFromCMake,
-  getSDKConfigFilePath,
   isBinInPath,
 } from "../utils";
 import { TaskManager } from "../taskManager";
 import { selectedDFUAdapterId } from "../flash/dfu";
 import { getVirtualEnvPythonPath } from "../pythonManager";
-import { getIdfTargetFromSdkconfig } from "../workspaceConfig";
+import { getIdfTargetFromSdkconfig, getSDKConfigFilePath } from "../workspaceConfig";
 import { configureEnvVariables } from "../common/prepareEnv";
 import { ESP } from "../config";
 import { OutputCapturingExecution } from "../taskManager/customExecution";

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -21,14 +21,11 @@ import { join } from "path";
 import { Logger } from "../logger/logger";
 import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
-import { getEspIdfFromCMake, isBinInPath } from "../utils";
+import { isBinInPath } from "../utils";
 import { TaskManager } from "../taskManager";
 import { selectedDFUAdapterId } from "../flash/dfu";
 import { getVirtualEnvPythonPath } from "../pythonManager";
-import {
-  getIdfTargetFromSdkconfig,
-  getSDKConfigFilePath,
-} from "../workspaceConfig";
+import { getIdfTargetFromSdkconfig } from "../workspaceConfig";
 import { configureEnvVariables } from "../common/prepareEnv";
 import { ESP } from "../config";
 import { OutputCapturingExecution } from "../taskManager/customExecution";
@@ -114,10 +111,7 @@ export class BuildTask {
       | OutputCapturingExecution
       | vscode.ProcessExecution
       | undefined = undefined;
-    let buildExecution:
-      | OutputCapturingExecution
-      | vscode.ProcessExecution
-      | undefined = undefined;
+    let buildExecution: OutputCapturingExecution | vscode.ProcessExecution;
 
     if (!cmakeCacheExists) {
       let defaultCompilerArgs = [
@@ -144,7 +138,10 @@ export class BuildTask {
         compilerArgs.push("-S", this.currentWorkspace.fsPath);
       }
 
-      const sdkconfigFile = await getSDKConfigFilePath(this.currentWorkspace);
+      const sdkconfigFile = idfConf.readParameter(
+        "idf.sdkconfigFilePath",
+        this.currentWorkspace
+      ) as string;
       const hasSdkconfigArg = compilerArgs.some(
         (arg, index) =>
           arg.startsWith("-DSDKCONFIG=") ||
@@ -155,7 +152,10 @@ export class BuildTask {
       }
 
       const sdkconfigDefaults =
-        (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+        (idfConf.readParameter(
+          "idf.sdkconfigDefaults",
+          this.currentWorkspace
+        ) as string[]) || [];
 
       if (
         compilerArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&

--- a/src/build/buildTask.ts
+++ b/src/build/buildTask.ts
@@ -21,14 +21,14 @@ import { join } from "path";
 import { Logger } from "../logger/logger";
 import * as vscode from "vscode";
 import * as idfConf from "../idfConfiguration";
-import {
-  getEspIdfFromCMake,
-  isBinInPath,
-} from "../utils";
+import { getEspIdfFromCMake, isBinInPath } from "../utils";
 import { TaskManager } from "../taskManager";
 import { selectedDFUAdapterId } from "../flash/dfu";
 import { getVirtualEnvPythonPath } from "../pythonManager";
-import { getIdfTargetFromSdkconfig, getSDKConfigFilePath } from "../workspaceConfig";
+import {
+  getIdfTargetFromSdkconfig,
+  getSDKConfigFilePath,
+} from "../workspaceConfig";
 import { configureEnvVariables } from "../common/prepareEnv";
 import { ESP } from "../config";
 import { OutputCapturingExecution } from "../taskManager/customExecution";
@@ -139,7 +139,7 @@ export class BuildTask {
       }
 
       const sdkconfigFile = await getSDKConfigFilePath(this.currentWorkspace);
-      if (compilerArgs.indexOf("SDKCONFIG") === -1) {
+      if (sdkconfigFile && compilerArgs.indexOf("SDKCONFIG") === -1) {
         compilerArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
       }
 

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -26,7 +26,7 @@ import {
   workspace,
 } from "vscode";
 import { readParameter } from "../idfConfiguration";
-import { getIdfTargetFromSdkconfig, getProjectName } from "../workspaceConfig";
+import { getIdfTargetFromSdkconfig, getProjectElfFilePath } from "../workspaceConfig";
 import { join } from "path";
 import { pathExists } from "fs-extra";
 import { verifyAppBinary } from "../espIdf/debugAdapter/verifyApp";
@@ -104,9 +104,7 @@ export class CDTDebugConfigurationProvider
         }
       }
       if (!config.program) {
-        const buildDirPath = readParameter("idf.buildPath", folder) as string;
-        const projectName = await getProjectName(buildDirPath);
-        const elfFilePath = join(buildDirPath, `${projectName}.elf`);
+        const elfFilePath = await getProjectElfFilePath(folder.uri);
         const elfFileExists = await pathExists(elfFilePath);
         if (!elfFileExists) {
           throw new Error(
@@ -134,6 +132,9 @@ export class CDTDebugConfigurationProvider
         );
         if (isAppReproducibleBuildEnabled === "y") {
           const buildDirPath = readParameter("idf.buildPath", folder) as string;
+          if (!buildDirPath) {
+            throw new Error("Failed to get build directory path.");
+          }
           const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
           const gdbinitPrefixMapExists = await pathExists(gdbinitPrefixMap);
           if (gdbinitPrefixMapExists) {

--- a/src/coverage/configureProject.ts
+++ b/src/coverage/configureProject.ts
@@ -124,7 +124,7 @@ export async function configureProjectWithGcov(workspacePath: Uri) {
   }
   const gcovEnableRequest = `{"version": 2, "set": { "APPTRACE_DEST_TRAX": true, "APPTRACE_GCOV_ENABLE": true }}\n`;
   ConfserverProcess.sendUpdatedValue(gcovEnableRequest);
-  await ConfserverProcess.saveGuiConfigValues();
+  ConfserverProcess.saveGuiConfigValues();
   await openCoverageUrl(workspacePath);
 }
 

--- a/src/coverage/configureProject.ts
+++ b/src/coverage/configureProject.ts
@@ -124,12 +124,15 @@ export async function configureProjectWithGcov(workspacePath: Uri) {
   }
   const gcovEnableRequest = `{"version": 2, "set": { "APPTRACE_DEST_TRAX": true, "APPTRACE_GCOV_ENABLE": true }}\n`;
   ConfserverProcess.sendUpdatedValue(gcovEnableRequest);
-  ConfserverProcess.saveGuiConfigValues();
+  await ConfserverProcess.saveGuiConfigValues();
   await openCoverageUrl(workspacePath);
 }
 
 export async function openCoverageUrl(workspacePath: Uri) {
   const docsVersions = await getDocsVersion();
+  if (!docsVersions) {
+    return;
+  }
   const currentEnvVars = ESP.ProjectConfiguration.store.get<{
     [key: string]: string;
   }>(ESP.ProjectConfiguration.CURRENT_IDF_CONFIGURATION, {});
@@ -142,18 +145,19 @@ export async function openCoverageUrl(workspacePath: Uri) {
     docVersion = docsVersions.find((docVer) => docVer.name === "latest");
   }
   if (
+    docVersion &&
     docVersion.supportedTargets &&
     docVersion.supportedTargets.indexOf(idfTarget) !== -1
   ) {
     targetToUse = idfTarget;
-  }
-  const localeLang = getDocsLocaleLang();
-  const coverageDocUrl = `https://docs.espressif.com/projects/esp-idf/${localeLang}/${docVersion.name}/${targetToUse}/api-guides/app_trace.html#compiler-option`;
-  const option = await window.showInformationMessage(
-    "Your project sdkconfig has been configured. Make sure to compile the source file with the --coverage option.",
-    "See the docs"
-  );
-  if (option === "See the docs") {
-    env.openExternal(Uri.parse(coverageDocUrl));
+    const localeLang = getDocsLocaleLang();
+    const coverageDocUrl = `https://docs.espressif.com/projects/esp-idf/${localeLang}/${docVersion.name}/${targetToUse}/api-guides/app_trace.html#compiler-option`;
+    const option = await window.showInformationMessage(
+      "Your project sdkconfig has been configured. Make sure to compile the source file with the --coverage option.",
+      "See the docs"
+    );
+    if (option && option === "See the docs") {
+      env.openExternal(Uri.parse(coverageDocUrl));
+    }
   }
 }

--- a/src/espIdf/menuconfig/MenuconfigPanel.ts
+++ b/src/espIdf/menuconfig/MenuconfigPanel.ts
@@ -112,15 +112,17 @@ export class MenuConfigPanel {
               { title: returnToGuiconfigMsg, isCloseAffordance: false },
               { title: discardMsg, isCloseAffordance: true }
             )
-            .then((selected) => {
+            .then(async (selected) => {
+              if (!selected || selected.title === discardMsg) {
+                await ConfserverProcess.loadGuiConfigValues(true);
+                return;
+              }
               if (selected.title === saveMsg) {
-                ConfserverProcess.saveGuiConfigValues();
+                await ConfserverProcess.saveGuiConfigValues();
               } else if (selected.title === returnToGuiconfigMsg) {
                 this.dispose();
                 vscode.commands.executeCommand("espIdf.menuconfig.start");
                 return;
-              } else {
-                ConfserverProcess.loadGuiConfigValues(true);
               }
             });
         }
@@ -159,7 +161,7 @@ export class MenuConfigPanel {
               { title: yesMsg, isCloseAffordance: false },
               { title: noMsg, isCloseAffordance: true }
             );
-            if (selected.title === yesMsg) {
+            if ( selected && selected.title === yesMsg) {
               const notificationMode = readParameter(
                 "idf.notificationMode",
                 this.curWorkspaceFolder
@@ -187,9 +189,13 @@ export class MenuConfigPanel {
                       progress
                     );
                   } catch (error) {
+                    const errMsg =
+                      error && typeof error === "object" && "message" in error
+                        ? (error as Error).message
+                        : String(error);
                     Logger.errorNotify(
-                      error.message,
-                      error,
+                      errMsg,
+                      error as Error,
                       "MenuConfigPanel setDefaultValues"
                     );
                   }
@@ -199,21 +205,21 @@ export class MenuConfigPanel {
           }
           break;
         case "saveChanges":
-          ConfserverProcess.saveGuiConfigValues();
+          await ConfserverProcess.saveGuiConfigValues();
           const saveMessage = vscode.l10n.t(
             "Saved changes in SDK Configuration editor"
           );
           Logger.infoNotify(saveMessage);
           break;
         case "discardChanges":
-          ConfserverProcess.loadGuiConfigValues();
+          await ConfserverProcess.loadGuiConfigValues();
           const discardMessage = vscode.l10n.t(
             "Discarded changes in SDK Configuration editor"
           );
           Logger.infoNotify(discardMessage);
           break;
         case "requestInitValues":
-          MenuConfigPanel.currentPanel.panel.webview.postMessage({
+          MenuConfigPanel.currentPanel?.panel.webview.postMessage({
             command: "load_initial_values",
             menus: initialValues,
             version: ConfserverProcess.confserverVersion,
@@ -252,7 +258,7 @@ export class MenuConfigPanel {
       return;
     }
     const updatedMenus = ConfserverProcess.updateValues(values);
-    MenuConfigPanel.currentPanel.panel.webview.postMessage({
+    MenuConfigPanel.currentPanel?.panel.webview.postMessage({
       command: "update_values",
       updated_values: updatedMenus,
     });

--- a/src/espIdf/menuconfig/MenuconfigPanel.ts
+++ b/src/espIdf/menuconfig/MenuconfigPanel.ts
@@ -114,11 +114,11 @@ export class MenuConfigPanel {
             )
             .then(async (selected) => {
               if (!selected || selected.title === discardMsg) {
-                await ConfserverProcess.loadGuiConfigValues(true);
+                ConfserverProcess.loadGuiConfigValues(true);
                 return;
               }
               if (selected.title === saveMsg) {
-                await ConfserverProcess.saveGuiConfigValues();
+                ConfserverProcess.saveGuiConfigValues();
               } else if (selected.title === returnToGuiconfigMsg) {
                 this.dispose();
                 vscode.commands.executeCommand("espIdf.menuconfig.start");
@@ -161,7 +161,7 @@ export class MenuConfigPanel {
               { title: yesMsg, isCloseAffordance: false },
               { title: noMsg, isCloseAffordance: true }
             );
-            if ( selected && selected.title === yesMsg) {
+            if (selected && selected.title === yesMsg) {
               const notificationMode = readParameter(
                 "idf.notificationMode",
                 this.curWorkspaceFolder
@@ -204,20 +204,22 @@ export class MenuConfigPanel {
             }
           }
           break;
-        case "saveChanges":
-          await ConfserverProcess.saveGuiConfigValues();
+        case "saveChanges": {
+          ConfserverProcess.saveGuiConfigValues();
           const saveMessage = vscode.l10n.t(
             "Saved changes in SDK Configuration editor"
           );
           Logger.infoNotify(saveMessage);
           break;
-        case "discardChanges":
-          await ConfserverProcess.loadGuiConfigValues();
+        }
+        case "discardChanges": {
+          ConfserverProcess.loadGuiConfigValues();
           const discardMessage = vscode.l10n.t(
             "Discarded changes in SDK Configuration editor"
           );
           Logger.infoNotify(discardMessage);
           break;
+        }
         case "requestInitValues":
           MenuConfigPanel.currentPanel?.panel.webview.postMessage({
             command: "load_initial_values",

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -23,10 +23,7 @@ import * as vscode from "vscode";
 import * as idfConf from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
-import {
-  delConfigFile,
-  isStringNotEmpty,
-} from "../../utils";
+import { delConfigFile, isStringNotEmpty } from "../../utils";
 import { KconfigMenuLoader } from "./kconfigMenuLoader";
 import { Menu, menuType } from "./Menu";
 import { MenuConfigPanel } from "./MenuconfigPanel";
@@ -72,15 +69,11 @@ export class ConfserverProcess {
 
   public static async init(workspaceFolder: vscode.Uri, extensionPath: string) {
     return new Promise(async (resolve) => {
-      const pythonBinPath = await getVirtualEnvPythonPath();
       const modifiedEnv = await configureEnvVariables(workspaceFolder);
       if (!ConfserverProcess.instance) {
-        const configFile = await getSDKConfigFilePath(workspaceFolder);
         ConfserverProcess.instance = new ConfserverProcess(
           workspaceFolder,
           extensionPath,
-          pythonBinPath,
-          configFile,
           modifiedEnv
         );
       }
@@ -97,7 +90,7 @@ export class ConfserverProcess {
   }
 
   public static isSavedByUI() {
-    return ConfserverProcess.instance.isSavingSdkconfig;
+    return ConfserverProcess.instance?.isSavingSdkconfig;
   }
 
   public static resetSavedByUI() {
@@ -108,15 +101,20 @@ export class ConfserverProcess {
 
   public static loadExistingInstance() {
     ConfserverProcess.checkInitialized();
-    MenuConfigPanel.createOrShow(
-      ConfserverProcess.instance.extensionPath,
-      ConfserverProcess.instance.workspaceFolder,
-      ConfserverProcess.instance.kconfigsMenus
-    );
+    if (ConfserverProcess.instance) {
+      MenuConfigPanel.createOrShow(
+        ConfserverProcess.instance.extensionPath,
+        ConfserverProcess.instance.workspaceFolder,
+        ConfserverProcess.instance.kconfigsMenus
+      );
+    }
   }
 
   public static registerListener(listener: (values: string) => void) {
     ConfserverProcess.checkInitialized();
+    if (!ConfserverProcess.instance) {
+      return;
+    }
     ConfserverProcess.instance.jsonListener = listener;
   }
 
@@ -128,6 +126,9 @@ export class ConfserverProcess {
 
   public static updateValues(values: string): Menu[] {
     ConfserverProcess.checkInitialized();
+    if (!ConfserverProcess.instance) {
+      return [];
+    }
     const jsonValues = JSON.parse(values);
     const newKconfigMenus: Menu[] = [];
     for (const config of ConfserverProcess.instance.kconfigsMenus) {
@@ -145,7 +146,9 @@ export class ConfserverProcess {
   }
 
   public static resetElementChildren(children: string[]) {
-    let resetValueRequest = `{"version": 3, "reset": [ "${children.join("\", \"")}" ]}\n`;
+    let resetValueRequest = `{"version": 3, "reset": [ "${children.join(
+      '", "'
+    )}" ]}\n`;
     ConfserverProcess.sendUpdatedValue(resetValueRequest);
   }
 
@@ -181,32 +184,51 @@ export class ConfserverProcess {
 
   public static sendUpdatedValue(newValueRequest: string) {
     OutputChannel.appendLine(newValueRequest, "SDK Configuration Editor");
-    ConfserverProcess.instance.confServerProcess.stdin.write(newValueRequest);
-    ConfserverProcess.instance.areValuesSaved = false;
+    if (ConfserverProcess.instance) {
+      ConfserverProcess.instance?.confServerProcess?.stdin?.write(
+        newValueRequest
+      );
+      ConfserverProcess.instance.areValuesSaved = false;
+    } else {
+      OutputChannel.appendLine(
+        "No instance available",
+        "SDK Configuration Editor"
+      );
+    }
   }
 
-  public static saveGuiConfigValues() {
-    ConfserverProcess.instance.isSavingSdkconfig = true;
-    const saveRequest = JSON.stringify({
-      version: 2,
-      save: ConfserverProcess.instance.configFile,
-    });
-    OutputChannel.appendLine(saveRequest, "SDK Configuration Editor");
-    ConfserverProcess.instance.confServerProcess.stdin.write(saveRequest);
-    ConfserverProcess.instance.confServerProcess.stdin.write("\n");
-    ConfserverProcess.instance.areValuesSaved = true;
-  }
-
-  public static loadGuiConfigValues(isClosingWithoutSaving?: boolean) {
-    const loadRequest = JSON.stringify({
-      version: 2,
-      load: ConfserverProcess.instance.configFile,
-    });
-    OutputChannel.appendLine(loadRequest, "SDK Configuration Editor");
-    ConfserverProcess.instance.confServerProcess.stdin.write(loadRequest);
-    ConfserverProcess.instance.confServerProcess.stdin.write("\n");
-    if (isClosingWithoutSaving) {
+  public static async saveGuiConfigValues() {
+    if (ConfserverProcess.instance) {
+      ConfserverProcess.instance.isSavingSdkconfig = true;
+      const configFile = await getSDKConfigFilePath(
+        ConfserverProcess.instance.workspaceFolder
+      );
+      const saveRequest = JSON.stringify({
+        version: 2,
+        save: configFile,
+      });
+      OutputChannel.appendLine(saveRequest, "SDK Configuration Editor");
+      ConfserverProcess.instance.confServerProcess?.stdin?.write(saveRequest);
+      ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
       ConfserverProcess.instance.areValuesSaved = true;
+    }
+  }
+
+  public static async loadGuiConfigValues(isClosingWithoutSaving?: boolean) {
+    if (ConfserverProcess.instance) {
+      const configFile = await getSDKConfigFilePath(
+        ConfserverProcess.instance.workspaceFolder
+      );
+      const loadRequest = JSON.stringify({
+        version: 2,
+        load: configFile,
+      });
+      OutputChannel.appendLine(loadRequest, "SDK Configuration Editor");
+      ConfserverProcess.instance.confServerProcess?.stdin?.write(loadRequest);
+      ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
+      if (isClosingWithoutSaving) {
+        ConfserverProcess.instance.areValuesSaved = true;
+      }
     }
   }
 
@@ -214,6 +236,9 @@ export class ConfserverProcess {
     extensionPath: string,
     progress: vscode.Progress<{ message: string; increment: number }>
   ) {
+    if (!ConfserverProcess.instance) {
+      return;
+    }
     progress.report({ increment: 10, message: "Deleting current values..." });
     ConfserverProcess.instance.areValuesSaved = true;
     const currWorkspace = ConfserverProcess.instance.workspaceFolder;
@@ -225,6 +250,11 @@ export class ConfserverProcess {
     const idfPyPath = path.join(guiconfigEspPath, "tools", "idf.py");
     const modifiedEnv = await configureEnvVariables(currWorkspace);
     const pythonBinPath = await getVirtualEnvPythonPath();
+    if (!pythonBinPath) {
+      throw new Error(
+        "Python binary path not found. Please check your Python configuration."
+      );
+    }
     const enableCCache = idfConf.readParameter(
       "idf.enableCCache",
       currWorkspace
@@ -235,14 +265,22 @@ export class ConfserverProcess {
     }
     reconfigureArgs.push("-C", currWorkspace.fsPath);
     const sdkconfigDefaults =
-    (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
-    
-    if (reconfigureArgs.indexOf("SDKCONFIG") === -1) {
-      reconfigureArgs.push(
-        `-DSDKCONFIG='${ConfserverProcess.instance.configFile}'`
-      );
+      (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+
+    const sdkconfigFile = idfConf.readParameter(
+      "idf.sdkconfigFilePath",
+      currWorkspace
+    ) as string;
+    const hasSdkconfigArg = reconfigureArgs.some(
+      (arg, index) =>
+        arg.startsWith("-DSDKCONFIG=") ||
+        (arg === "-D" && reconfigureArgs[index + 1]?.startsWith("SDKCONFIG="))
+    );
+
+    if (sdkconfigFile && !hasSdkconfigArg) {
+      reconfigureArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
     }
-    
+
     if (
       reconfigureArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&
       sdkconfigDefaults &&
@@ -254,7 +292,7 @@ export class ConfserverProcess {
     }
     reconfigureArgs.push("reconfigure");
     await delConfigFile(currWorkspace);
-    
+
     const getSdkconfigProcess = spawn(pythonBinPath, reconfigureArgs, {
       env: modifiedEnv,
     });
@@ -300,7 +338,14 @@ export class ConfserverProcess {
 
   public static dispose() {
     if (ConfserverProcess.instance) {
-      ConfserverProcess.instance.confServerProcess.stdin.end();
+      const proc = ConfserverProcess.instance.confServerProcess;
+      if (proc) {
+        proc.stdout?.removeAllListeners();
+        proc.stderr?.removeAllListeners();
+        proc.removeAllListeners();
+        proc.stdin?.destroy();
+        proc.kill("SIGTERM");
+      }
       ConfserverProcess.instance.confServerProcess = null;
       ConfserverProcess.instance = null;
     }
@@ -310,7 +355,7 @@ export class ConfserverProcess {
   }
   public static confserverVersion: number = 2;
 
-  private static instance: ConfserverProcess;
+  private static instance: ConfserverProcess | null = null;
   private static progress: vscode.Progress<{
     message: string;
     increment: number;
@@ -323,22 +368,18 @@ export class ConfserverProcess {
   }
 
   private areValuesSaved: boolean = true;
-  private confServerProcess: ChildProcess;
-  private espIdfPath: string;
+  private confServerProcess: ChildProcess | null;
   private emitter: EventEmitter;
   private isSavingSdkconfig: boolean = false;
   private jsonListener: (values: string) => void;
   private receivedDataBuffer: string = "";
-  private configFile: string;
   private workspaceFolder: vscode.Uri;
   private extensionPath: string;
-  private kconfigsMenus: Menu[];
+  private kconfigsMenus: Menu[] = [];
 
   constructor(
     workspaceFolder: vscode.Uri,
     extensionPath: string,
-    pythonBinPath: string,
-    configFile: string,
     modifiedEnv: { [key: string]: string }
   ) {
     this.workspaceFolder = workspaceFolder;
@@ -347,10 +388,10 @@ export class ConfserverProcess {
     const currentEnvVars = ESP.ProjectConfiguration.store.get<{
       [key: string]: string;
     }>(ESP.ProjectConfiguration.CURRENT_IDF_CONFIGURATION, {});
-    this.espIdfPath = currentEnvVars["IDF_PATH"];
+    const espIdfPath = currentEnvVars["IDF_PATH"];
+
     modifiedEnv.PYTHONUNBUFFERED = "0";
-    this.configFile = configFile;
-    const idfPath = path.join(this.espIdfPath, "tools", "idf.py");
+    const idfPath = path.join(espIdfPath, "tools", "idf.py");
     const enableCCache = idfConf.readParameter(
       "idf.enableCCache",
       workspaceFolder
@@ -367,8 +408,18 @@ export class ConfserverProcess {
     const sdkconfigDefaults =
       (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
 
-    if (confServerArgs.indexOf("SDKCONFIG") === -1) {
-      confServerArgs.push(`-DSDKCONFIG='${this.configFile}'`);
+    const sdkconfigFile = idfConf.readParameter(
+      "idf.sdkconfigFilePath",
+      workspaceFolder
+    ) as string;
+    const hasSdkconfigArg = confServerArgs.some(
+      (arg, index) =>
+        arg.startsWith("-DSDKCONFIG=") ||
+        (arg === "-D" && confServerArgs[index + 1]?.startsWith("SDKCONFIG="))
+    );
+
+    if (sdkconfigFile && !hasSdkconfigArg) {
+      confServerArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
     }
 
     if (
@@ -381,6 +432,13 @@ export class ConfserverProcess {
       );
     }
     confServerArgs.push("-C", workspaceFolder.fsPath, "confserver");
+
+    const pythonBinPath = getVirtualEnvPythonPath();
+    if (!pythonBinPath) {
+      throw new Error(
+        "Python binary path not found. Please check your Python configuration."
+      );
+    }
     this.confServerProcess = spawn(pythonBinPath, confServerArgs, {
       env: modifiedEnv,
     });
@@ -401,7 +459,7 @@ export class ConfserverProcess {
     if (newValuesJsonReceived !== null && newValuesJsonReceived.length > 0) {
       const lastIndex = newValuesJsonReceived.length - 1;
       if (this.jsonListener) {
-        ConfserverProcess.instance.emitter.emit("valuesLoaded");
+        ConfserverProcess.instance?.emitter.emit("valuesLoaded");
         this.jsonListener(newValuesJsonReceived[lastIndex]);
       } else {
         this.printError(
@@ -436,7 +494,7 @@ export class ConfserverProcess {
   }
 
   private setupConfigServer() {
-    this.confServerProcess.stdout.on("data", (data) => {
+    this.confServerProcess?.stdout?.on("data", (data) => {
       this.receivedDataBuffer += data;
       if (ConfserverProcess.progress) {
         ConfserverProcess.progress.report({
@@ -448,7 +506,7 @@ export class ConfserverProcess {
       OutputChannel.appendLine(data.toString(), "SDK Configuration Editor");
       this.checkIfJsonIsReceived();
     });
-    this.confServerProcess.stderr.on("data", (data) => {
+    this.confServerProcess?.stderr?.on("data", (data) => {
       const dataStr = data.toString();
       const ignoreList = [
         "Server running, waiting for requests on stdin..",
@@ -468,12 +526,12 @@ export class ConfserverProcess {
         }
       }
     });
-    this.confServerProcess.on("error", (err) => {
-      err.stack === null
-        ? this.printError(err.message)
-        : this.printError(err.stack);
+    this.confServerProcess?.on("error", (err) => {
+      err.stack
+        ? this.printError(err.message + "\n" + err.stack)
+        : this.printError(err.message);
     });
-    this.confServerProcess.on("exit", (code, signal) => {
+    this.confServerProcess?.on("exit", (code, signal) => {
       if (code !== 0) {
         this.printError(
           `SDK Configuration editor confserver process exited with code: ${code}`

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -79,8 +79,9 @@ export class ConfserverProcess {
     await new Promise<void>((resolve) => {
       ConfserverProcess.instance!.emitter.once("valuesLoaded", () => resolve());
     });
-    ConfserverProcess.instance.sdkconfigResolvedPath =
-      await getSDKConfigFilePath(workspaceFolder);
+    ConfserverProcess.instance.sdkconfigResolvedPath = await getSDKConfigFilePath(
+      workspaceFolder
+    );
   }
 
   public static exists() {
@@ -265,7 +266,10 @@ export class ConfserverProcess {
     }
     reconfigureArgs.push("-C", currWorkspace.fsPath);
     const sdkconfigDefaults =
-      (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+      (idfConf.readParameter(
+        "idf.sdkconfigDefaults",
+        currWorkspace
+      ) as string[]) || [];
 
     const sdkconfigFile = idfConf.readParameter(
       "idf.sdkconfigFilePath",
@@ -408,7 +412,10 @@ export class ConfserverProcess {
     ) as string;
     confServerArgs.push("-B", buildDirPath);
     const sdkconfigDefaults =
-      (idfConf.readParameter("idf.sdkconfigDefaults") as string[]) || [];
+      (idfConf.readParameter(
+        "idf.sdkconfigDefaults",
+        workspaceFolder
+      ) as string[]) || [];
 
     const sdkconfigFile = idfConf.readParameter(
       "idf.sdkconfigFilePath",

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -25,7 +25,6 @@ import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
 import {
   delConfigFile,
-  getSDKConfigFilePath,
   isStringNotEmpty,
 } from "../../utils";
 import { KconfigMenuLoader } from "./kconfigMenuLoader";
@@ -34,6 +33,7 @@ import { MenuConfigPanel } from "./MenuconfigPanel";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 import { configureEnvVariables } from "../../common/prepareEnv";
 import { ESP } from "../../config";
+import { getSDKConfigFilePath } from "../../workspaceConfig";
 
 export class ConfserverProcess {
   public static async initWithProgress(

--- a/src/espIdf/menuconfig/confServerProcess.ts
+++ b/src/espIdf/menuconfig/confServerProcess.ts
@@ -68,17 +68,19 @@ export class ConfserverProcess {
   }
 
   public static async init(workspaceFolder: vscode.Uri, extensionPath: string) {
-    return new Promise(async (resolve) => {
-      const modifiedEnv = await configureEnvVariables(workspaceFolder);
-      if (!ConfserverProcess.instance) {
-        ConfserverProcess.instance = new ConfserverProcess(
-          workspaceFolder,
-          extensionPath,
-          modifiedEnv
-        );
-      }
-      ConfserverProcess.instance.emitter.once("valuesLoaded", resolve);
+    const modifiedEnv = await configureEnvVariables(workspaceFolder);
+    if (!ConfserverProcess.instance) {
+      ConfserverProcess.instance = new ConfserverProcess(
+        workspaceFolder,
+        extensionPath,
+        modifiedEnv
+      );
+    }
+    await new Promise<void>((resolve) => {
+      ConfserverProcess.instance!.emitter.once("valuesLoaded", () => resolve());
     });
+    ConfserverProcess.instance.sdkconfigResolvedPath =
+      await getSDKConfigFilePath(workspaceFolder);
   }
 
   public static exists() {
@@ -197,38 +199,36 @@ export class ConfserverProcess {
     }
   }
 
-  public static async saveGuiConfigValues() {
-    if (ConfserverProcess.instance) {
-      ConfserverProcess.instance.isSavingSdkconfig = true;
-      const configFile = await getSDKConfigFilePath(
-        ConfserverProcess.instance.workspaceFolder
-      );
-      const saveRequest = JSON.stringify({
-        version: 2,
-        save: configFile,
-      });
-      OutputChannel.appendLine(saveRequest, "SDK Configuration Editor");
-      ConfserverProcess.instance.confServerProcess?.stdin?.write(saveRequest);
-      ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
-      ConfserverProcess.instance.areValuesSaved = true;
+  public static saveGuiConfigValues() {
+    if (!ConfserverProcess.instance) {
+      return;
     }
+    ConfserverProcess.instance.isSavingSdkconfig = true;
+    const configFile = ConfserverProcess.instance.readSdkconfigFilePath();
+    const saveRequest = JSON.stringify({
+      version: 2,
+      save: configFile,
+    });
+    OutputChannel.appendLine(saveRequest, "SDK Configuration Editor");
+    ConfserverProcess.instance.confServerProcess?.stdin?.write(saveRequest);
+    ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
+    ConfserverProcess.instance.areValuesSaved = true;
   }
 
-  public static async loadGuiConfigValues(isClosingWithoutSaving?: boolean) {
-    if (ConfserverProcess.instance) {
-      const configFile = await getSDKConfigFilePath(
-        ConfserverProcess.instance.workspaceFolder
-      );
-      const loadRequest = JSON.stringify({
-        version: 2,
-        load: configFile,
-      });
-      OutputChannel.appendLine(loadRequest, "SDK Configuration Editor");
-      ConfserverProcess.instance.confServerProcess?.stdin?.write(loadRequest);
-      ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
-      if (isClosingWithoutSaving) {
-        ConfserverProcess.instance.areValuesSaved = true;
-      }
+  public static loadGuiConfigValues(isClosingWithoutSaving?: boolean) {
+    if (!ConfserverProcess.instance) {
+      return;
+    }
+    const configFile = ConfserverProcess.instance.readSdkconfigFilePath();
+    const loadRequest = JSON.stringify({
+      version: 2,
+      load: configFile,
+    });
+    OutputChannel.appendLine(loadRequest, "SDK Configuration Editor");
+    ConfserverProcess.instance.confServerProcess?.stdin?.write(loadRequest);
+    ConfserverProcess.instance.confServerProcess?.stdin?.write("\n");
+    if (isClosingWithoutSaving) {
+      ConfserverProcess.instance.areValuesSaved = true;
     }
   }
 
@@ -368,6 +368,8 @@ export class ConfserverProcess {
   }
 
   private areValuesSaved: boolean = true;
+  /** Set in `init` after first `valuesLoaded` and `getSDKConfigFilePath`. */
+  private sdkconfigResolvedPath: string | undefined;
   private confServerProcess: ChildProcess | null;
   private emitter: EventEmitter;
   private isSavingSdkconfig: boolean = false;
@@ -450,6 +452,17 @@ export class ConfserverProcess {
     }
     this.setupConfigServer();
     this.jsonListener = this.initMenuConfigPanel;
+  }
+
+  private readSdkconfigFilePath(): string {
+    if (this.sdkconfigResolvedPath) {
+      return this.sdkconfigResolvedPath;
+    }
+    const fromSettings = idfConf.readParameter(
+      "idf.sdkconfigFilePath",
+      this.workspaceFolder
+    ) as string;
+    return fromSettings || path.join(this.workspaceFolder.fsPath, "sdkconfig");
   }
 
   private checkIfJsonIsReceived() {

--- a/src/espIdf/monitor/command.ts
+++ b/src/espIdf/monitor/command.ts
@@ -27,7 +27,7 @@ import { IDFMonitor, MonitorConfig } from ".";
 import { ESP } from "../../config";
 import {
   getIdfTargetFromSdkconfig,
-  getProjectName,
+  getProjectElfFilePath,
 } from "../../workspaceConfig";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 
@@ -95,13 +95,8 @@ export async function createNewIdfMonitor(
       "createNewIdfMonitor idf_monitor not found"
     );
   }
-  const buildDirPath = readParameter(
-    "idf.buildPath",
-    workspaceFolder
-  ) as string;
   let idfTarget = await getIdfTargetFromSdkconfig(workspaceFolder);
-  const projectName = await getProjectName(buildDirPath);
-  const elfFilePath = join(buildDirPath, `${projectName}.elf`);
+  const elfFilePath = await getProjectElfFilePath(workspaceFolder);
   const toolchainPrefix = utils.getToolchainToolName(idfTarget, "");
   const shellPath = readParameter(
     "idf.customTerminalExecutable",

--- a/src/espIdf/reconfigure/task.ts
+++ b/src/espIdf/reconfigure/task.ts
@@ -72,7 +72,7 @@ export class IdfReconfigureTask {
     reconfigureArgs.push("-B", this.buildDirPath);
 
     const sdkconfigFile = await getSDKConfigFilePath(this.curWorkspace);
-    if (reconfigureArgs.indexOf("SDKCONFIG") === -1) {
+    if (sdkconfigFile && reconfigureArgs.indexOf("SDKCONFIG") === -1) {
       reconfigureArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
     }
 

--- a/src/espIdf/reconfigure/task.ts
+++ b/src/espIdf/reconfigure/task.ts
@@ -27,11 +27,11 @@ import {
   workspace,
 } from "vscode";
 import { NotificationMode, readParameter } from "../../idfConfiguration";
-import { getSDKConfigFilePath } from "../../utils";
 import { join } from "path";
 import { TaskManager } from "../../taskManager";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 import { configureEnvVariables } from "../../common/prepareEnv";
+import { getSDKConfigFilePath } from "../../workspaceConfig";
 
 export class IdfReconfigureTask {
   private buildDirPath: string;

--- a/src/espIdf/reconfigure/task.ts
+++ b/src/espIdf/reconfigure/task.ts
@@ -31,7 +31,6 @@ import { join } from "path";
 import { TaskManager } from "../../taskManager";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 import { configureEnvVariables } from "../../common/prepareEnv";
-import { getSDKConfigFilePath } from "../../workspaceConfig";
 
 export class IdfReconfigureTask {
   private buildDirPath: string;
@@ -48,13 +47,13 @@ export class IdfReconfigureTask {
       cwd: this.curWorkspace.fsPath,
       env: modifiedEnv,
     };
-    const currentWorkspaceFolder = workspace.workspaceFolders.find(
-      (w) => w.uri === this.curWorkspace
-    );
+    const currentWorkspaceFolder = workspace.workspaceFolders?.length
+      ? workspace.workspaceFolders.find((w) => w.uri === this.curWorkspace)
+      : undefined;
 
     const notificationMode = readParameter(
       "idf.notificationMode",
-      currentWorkspaceFolder
+      this.curWorkspace
     ) as string;
     const showTaskOutput =
       notificationMode === NotificationMode.All ||
@@ -71,13 +70,22 @@ export class IdfReconfigureTask {
     }
     reconfigureArgs.push("-B", this.buildDirPath);
 
-    const sdkconfigFile = await getSDKConfigFilePath(this.curWorkspace);
-    if (sdkconfigFile && reconfigureArgs.indexOf("SDKCONFIG") === -1) {
+    const sdkconfigFile = readParameter(
+      "idf.sdkconfigFilePath",
+      this.curWorkspace
+    ) as string;
+    const hasSdkconfigArg = reconfigureArgs.some(
+      (arg, index) =>
+        arg.startsWith("-DSDKCONFIG=") ||
+        (arg === "-D" && reconfigureArgs[index + 1]?.startsWith("SDKCONFIG="))
+    );
+    if (sdkconfigFile && !hasSdkconfigArg) {
       reconfigureArgs.push(`-DSDKCONFIG='${sdkconfigFile}'`);
     }
 
     const sdkconfigDefaults =
-      (readParameter("idf.sdkconfigDefaults") as string[]) || [];
+      (readParameter("idf.sdkconfigDefaults", this.curWorkspace) as string[]) ||
+      [];
     if (
       reconfigureArgs.indexOf("SDKCONFIG_DEFAULTS") === -1 &&
       sdkconfigDefaults &&
@@ -102,6 +110,12 @@ export class IdfReconfigureTask {
     reconfigureArgs.push("reconfigure");
 
     const pythonBinPath = await getVirtualEnvPythonPath();
+
+    if (!pythonBinPath) {
+      throw new Error(
+        "Python binary path not found. Please check your Python configuration."
+      );
+    }
 
     const reconfigureExecution = new ProcessExecution(
       pythonBinPath,

--- a/src/espIdf/size/idfSize.ts
+++ b/src/espIdf/size/idfSize.ts
@@ -18,10 +18,9 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import * as idfConf from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { fileExists, spawn } from "../../utils";
-import { getProjectName } from "../../workspaceConfig";
+import { getProjectMapFilePath } from "../../workspaceConfig";
 import * as utils from "../../utils";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 import { ESP } from "../../config";
@@ -95,12 +94,7 @@ export class IDFSize {
   }
 
   private async mapFilePath() {
-    const buildDirPath = idfConf.readParameter(
-      "idf.buildPath",
-      this.workspaceFolderUri
-    ) as string;
-    const projectName = await getProjectName(buildDirPath);
-    return path.join(buildDirPath, `${projectName}.map`);
+    return await getProjectMapFilePath(this.workspaceFolderUri);
   }
 
   private idfPath(): string {

--- a/src/espIdf/size/idfSizeTask.ts
+++ b/src/espIdf/size/idfSizeTask.ts
@@ -29,7 +29,7 @@ import {
 } from "vscode";
 import { NotificationMode, readParameter } from "../../idfConfiguration";
 import { TaskManager } from "../../taskManager";
-import { getProjectName } from "../../workspaceConfig";
+import { getProjectMapFilePath } from "../../workspaceConfig";
 import { getVirtualEnvPythonPath } from "../../pythonManager";
 import { OutputCapturingExecution } from "../../taskManager/customExecution";
 import { configureEnvVariables } from "../../common/prepareEnv";
@@ -48,8 +48,7 @@ export class IdfSizeTask {
       this.currentWorkspace
     ) as string;
     await ensureDir(buildDirPath);
-    const projectName = await getProjectName(buildDirPath);
-    const mapFilePath = join(buildDirPath, `${projectName}.map`);
+    const mapFilePath = await getProjectMapFilePath(this.currentWorkspace);
     const currentEnvVars = ESP.ProjectConfiguration.store.get<{
       [key: string]: string;
     }>(ESP.ProjectConfiguration.CURRENT_IDF_CONFIGURATION, {});

--- a/src/espIdf/tracing/appTracePanel.ts
+++ b/src/espIdf/tracing/appTracePanel.ts
@@ -149,7 +149,9 @@ export class AppTracePanel {
               });
             break;
           case "resolveAddresses":
-            this.resolveAddresses({ addresses: JSON.parse(msg.addresses) });
+            this.resolveAddresses({
+              addresses: JSON.parse(msg.addresses),
+            });
             break;
           case "openFileAtLine":
             this.openFileAtLineNumber(msg.filePath, msg.lineNumber);
@@ -236,18 +238,21 @@ export class AppTracePanel {
 
     return funcName;
   }
-  private resolveAddresses({
+  private async resolveAddresses({
     addresses,
   }: {
     addresses: { [key: string]: any };
   }) {
-    const workspaceRoot = vscode.workspace.workspaceFolders?.length
-      ? vscode.workspace.workspaceFolders[0].uri
-      : undefined;
-    if (!workspaceRoot) {
-      throw new Error("Workspace folder is not open");
-    }
-    if (addresses) {
+    try {
+      const workspaceRoot = vscode.workspace.workspaceFolders?.length
+        ? vscode.workspace.workspaceFolders[0].uri
+        : undefined;
+      if (!workspaceRoot) {
+        throw new Error("Workspace folder is not open");
+      }
+      if (!addresses) {
+        return;
+      }
       const promises = Object.keys(addresses).map((add) => {
         const fn = async (address: string) => {
           const addr2line = new Addr2Line(
@@ -271,9 +276,15 @@ export class AppTracePanel {
         };
         return fn(add);
       });
-      Promise.all(promises).then((resp) => {
-        this.sendCommandToWebview("addressesResolved", addresses);
-      });
+      await Promise.all(promises);
+      this.sendCommandToWebview("addressesResolved", addresses);
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      Logger.errorNotify(
+        errMsg,
+        error as Error,
+        "AppTracePanel resolveAddresses"
+      );
     }
   }
   private async parseTraceLogData(): Promise<string> {

--- a/src/espIdf/tracing/appTracePanel.ts
+++ b/src/espIdf/tracing/appTracePanel.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 17th July 2019 3:58:48 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ import AnsiToHtml from "ansi-to-html";
 import * as path from "path";
 import * as vscode from "vscode";
 import { Logger } from "../../logger/logger";
-import { getWebViewFavicon, PreCheck } from "../../utils";
+import { getWebViewFavicon } from "../../utils";
 import { LogTraceProc } from "./tools/logTraceProc";
 import { SysviewTraceProc } from "./tools/sysviewTraceProc";
 import { Addr2Line } from "./tools/xtensa/addr2line";
@@ -184,18 +184,21 @@ export class AppTracePanel {
       });
       // editor.revealRange(selectionRange, vscode.TextEditorRevealType.InCenter);
     } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
       Logger.errorNotify(
-        error.message,
-        error,
+        errMsg,
+        error as Error,
         "AppTracePanel openFileAtLineNumber"
       );
     }
   }
   private async readElf(): Promise<string[][]> {
-    const emptyURI: vscode.Uri = undefined;
-    const workspaceRoot = PreCheck.isWorkspaceFolderOpen()
+    const workspaceRoot = vscode.workspace.workspaceFolders?.length
       ? vscode.workspace.workspaceFolders[0].uri
-      : emptyURI;
+      : undefined;
+    if (!workspaceRoot) {
+      throw new Error("Workspace folder is not open");
+    }
     const elfFile = await getProjectElfFilePath(workspaceRoot);
     if (!elfFile) {
       throw new Error("Select Elf file to process the addresses");
@@ -233,14 +236,20 @@ export class AppTracePanel {
 
     return funcName;
   }
-  private resolveAddresses({ addresses }) {
-    const emptyURI: vscode.Uri = undefined;
-    const workspaceRoot = PreCheck.isWorkspaceFolderOpen()
+  private resolveAddresses({
+    addresses,
+  }: {
+    addresses: { [key: string]: any };
+  }) {
+    const workspaceRoot = vscode.workspace.workspaceFolders?.length
       ? vscode.workspace.workspaceFolders[0].uri
-      : emptyURI;
+      : undefined;
+    if (!workspaceRoot) {
+      throw new Error("Workspace folder is not open");
+    }
     if (addresses) {
       const promises = Object.keys(addresses).map((add) => {
-        const fn = async (address) => {
+        const fn = async (address: string) => {
           const addr2line = new Addr2Line(
             workspaceRoot,
             await getProjectElfFilePath(workspaceRoot),
@@ -268,10 +277,12 @@ export class AppTracePanel {
     }
   }
   private async parseTraceLogData(): Promise<string> {
-    const emptyURI: vscode.Uri = undefined;
-    const workspaceRoot = PreCheck.isWorkspaceFolderOpen()
+    const workspaceRoot = vscode.workspace.workspaceFolders?.length
       ? vscode.workspace.workspaceFolders[0].uri
-      : emptyURI;
+      : undefined;
+    if (!workspaceRoot) {
+      throw new Error("Workspace folder is not open");
+    }
     const logTraceProc = new LogTraceProc(
       workspaceRoot,
       this._traceData.trace.filePath,
@@ -281,10 +292,12 @@ export class AppTracePanel {
     return resp.toString();
   }
   private async parseHeapTraceData(): Promise<any> {
-    const emptyURI: vscode.Uri = undefined;
-    const workspaceRoot = PreCheck.isWorkspaceFolderOpen()
+    const workspaceRoot = vscode.workspace.workspaceFolders?.length
       ? vscode.workspace.workspaceFolders[0].uri
-      : emptyURI;
+      : undefined;
+    if (!workspaceRoot) {
+      throw new Error("Workspace folder is not open");
+    }
     const sysviewTraceProc = new SysviewTraceProc(
       workspaceRoot,
       this._traceData.trace.filePath

--- a/src/espIdf/tracing/appTracePanel.ts
+++ b/src/espIdf/tracing/appTracePanel.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Wednesday, 17th July 2019 3:58:48 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ * 
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,15 +18,15 @@
 
 // tslint:disable: variable-name
 import AnsiToHtml from "ansi-to-html";
-import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { Logger } from "../../logger/logger";
-import { getElfFilePath, getWebViewFavicon, PreCheck } from "../../utils";
+import { getWebViewFavicon, PreCheck } from "../../utils";
 import { LogTraceProc } from "./tools/logTraceProc";
 import { SysviewTraceProc } from "./tools/sysviewTraceProc";
 import { Addr2Line } from "./tools/xtensa/addr2line";
 import { ReadElf } from "./tools/xtensa/readelf";
+import { getProjectElfFilePath } from "../../workspaceConfig";
 
 export class AppTracePanel {
   public static createOrShow(
@@ -196,7 +196,7 @@ export class AppTracePanel {
     const workspaceRoot = PreCheck.isWorkspaceFolderOpen()
       ? vscode.workspace.workspaceFolders[0].uri
       : emptyURI;
-    const elfFile = await getElfFilePath(workspaceRoot);
+    const elfFile = await getProjectElfFilePath(workspaceRoot);
     if (!elfFile) {
       throw new Error("Select Elf file to process the addresses");
     }
@@ -243,7 +243,7 @@ export class AppTracePanel {
         const fn = async (address) => {
           const addr2line = new Addr2Line(
             workspaceRoot,
-            await getElfFilePath(workspaceRoot),
+            await getProjectElfFilePath(workspaceRoot),
             address
           );
           const resp = await addr2line.run();
@@ -275,7 +275,7 @@ export class AppTracePanel {
     const logTraceProc = new LogTraceProc(
       workspaceRoot,
       this._traceData.trace.filePath,
-      await getElfFilePath(workspaceRoot)
+      await getProjectElfFilePath(workspaceRoot)
     );
     const resp = await logTraceProc.parse();
     return resp.toString();

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -23,7 +23,7 @@ import { readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
 import { getToolchainToolName, isBinInPath } from "../../utils";
-import { getProjectName } from "../../workspaceConfig";
+import { getProjectElfFilePath, getProjectName } from "../../workspaceConfig";
 import { OpenOCDManager } from "../openOcd/openOcdManager";
 import { AppTraceArchiveTreeDataProvider } from "./tree/appTraceArchiveTreeDataProvider";
 import {
@@ -76,8 +76,7 @@ export class GdbHeapTraceManager {
         if (!isGdbToolInPath) {
           throw new Error(`${gdbTool} is not available in PATH.`);
         }
-        const projectName = await getProjectName(buildDirPath);
-        const elfFilePath = join(buildDirPath, `${projectName}.elf`);
+        const elfFilePath = await getProjectElfFilePath(workspace);
         const elfFileExists = await pathExists(elfFilePath);
         if (!elfFileExists) {
           throw new Error(`${elfFilePath} doesn't exist.`);

--- a/src/espIdf/tracing/gdbHeapTraceManager.ts
+++ b/src/espIdf/tracing/gdbHeapTraceManager.ts
@@ -23,7 +23,7 @@ import { readParameter } from "../../idfConfiguration";
 import { Logger } from "../../logger/logger";
 import { OutputChannel } from "../../logger/outputChannel";
 import { getToolchainToolName, isBinInPath } from "../../utils";
-import { getProjectElfFilePath, getProjectName } from "../../workspaceConfig";
+import { getProjectElfFilePath } from "../../workspaceConfig";
 import { OpenOCDManager } from "../openOcd/openOcdManager";
 import { AppTraceArchiveTreeDataProvider } from "./tree/appTraceArchiveTreeDataProvider";
 import {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -653,7 +653,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   const updateGuiValues = async (e: vscode.Uri) => {
     if (ConfserverProcess.exists() && !ConfserverProcess.isSavedByUI()) {
-      await ConfserverProcess.loadGuiConfigValues();
+      ConfserverProcess.loadGuiConfigValues();
     }
     ConfserverProcess.resetSavedByUI();
     await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -653,7 +653,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   const updateGuiValues = async (e: vscode.Uri) => {
     if (ConfserverProcess.exists() && !ConfserverProcess.isSavedByUI()) {
-      ConfserverProcess.loadGuiConfigValues();
+      await ConfserverProcess.loadGuiConfigValues();
     }
     ConfserverProcess.resetSavedByUI();
     await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
@@ -1583,14 +1583,14 @@ export async function activate(context: vscode.ExtensionContext) {
       try {
         await covRenderer.renderCoverage();
       } catch (e) {
-        const msg = e && e.message ? e.message : e;
+        const errMsg = e instanceof Error ? e.message : String(e);
         Logger.errorNotify(
           "Error building gcov data from gcda files.\nCheck the ESP-IDF output for more details.",
-          e,
+          e as Error,
           "extension genCoverage"
         );
         OutputChannel.appendLine(
-          msg +
+          errMsg +
             "\nError building gcov data from gcda files.\n\n" +
             "Review the code coverage tutorial https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/coverage.html \n" +
             "or ESP-IDF documentation: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/app_trace.html#gcov-source-code-coverage \n"
@@ -1616,7 +1616,8 @@ export async function activate(context: vscode.ExtensionContext) {
       try {
         return await getProjectName(workspaceRoot);
       } catch (error) {
-        Logger.errorNotify(error.message, error, "extension getProjectName");
+        const errMsg = error instanceof Error ? error.message : String(error);
+        Logger.errorNotify(errMsg, error as Error, "extension getProjectName");
       }
     });
   });
@@ -4342,7 +4343,10 @@ function createClassicMenuconfig(extensionPath: string) {
       "idf.buildPath",
       workspaceRoot
     ) as string;
-    const sdkconfigPath = await getSDKConfigFilePath(workspaceRoot);
+    const sdkconfigFilePath = idfConf.readParameter(
+      "idf.sdkconfigFilePath",
+      workspaceRoot
+    ) as string;
     const sdkconfigDefaults = idfConf.readParameter(
       "idf.sdkconfigDefaults",
       workspaceRoot
@@ -4353,8 +4357,8 @@ function createClassicMenuconfig(extensionPath: string) {
     if (buildDirPath) {
       menuconfigCommand += ` -B "${buildDirPath}"`;
     }
-    if (sdkconfigPath) {
-      menuconfigCommand += ` -DSDKCONFIG='${sdkconfigPath}'`;
+    if (sdkconfigFilePath) {
+      menuconfigCommand += ` -DSDKCONFIG='${sdkconfigFilePath}'`;
     }
     if (sdkconfigDefaults && sdkconfigDefaults.length > 0) {
       menuconfigCommand += ` -DSDKCONFIG_DEFAULTS="${sdkconfigDefaults.join(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3552,8 +3552,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // try to get the partition table name from sdkconfig and if not found create one
         try {
           const sdkconfigFilePath = await getSDKConfigFilePath(workspaceRoot);
-          const sdkconfigFileExists = await pathExists(sdkconfigFilePath);
-          if (!sdkconfigFileExists) {
+          if (!sdkconfigFilePath || !(await pathExists(sdkconfigFilePath))) {
             const buildProject = await vscode.window.showInformationMessage(
               vscode.l10n.t(
                 `Partition table editor requires sdkconfig file. Build the project?`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ import {
   getProjectName,
   initSelectedWorkspace,
   updateIdfComponentsTree,
+  getProjectElfFilePath,
 } from "./workspaceConfig";
 import { SystemViewResultParser } from "./espIdf/tracing/system-view";
 import { Telemetry } from "./telemetry";
@@ -1612,11 +1613,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand("espIdf.getProjectName", () => {
     return PreCheck.perform([openFolderCheck], async () => {
-      const buildDirPath = idfConf.readParameter(
-        "idf.buildPath",
-        workspaceRoot
-      ) as string;
-      return await getProjectName(buildDirPath);
+      try {
+        return await getProjectName(workspaceRoot);
+      } catch (error) {
+        Logger.errorNotify(error.message, error, "extension getProjectName");
+      }
     });
   });
 
@@ -3330,20 +3331,34 @@ export async function activate(context: vscode.ExtensionContext) {
             "extension launchWSServerAndMonitor idf_monitor no access"
           );
         }
-        await installWebsocketClient(workspaceRoot);
-        const buildDirPath = idfConf.readParameter(
-          "idf.buildPath",
-          workspaceRoot
-        ) as string;
+        try {
+          await installWebsocketClient(workspaceRoot);
+        } catch (error) {
+          Logger.errorNotify(
+            "Failed to install websocket client dependencies",
+            error,
+            "extension launchWSServerAndMonitor install websocket client"
+          );
+          return;
+        }
         let idfTarget = await getIdfTargetFromSdkconfig(workspaceRoot);
         if (!idfTarget) {
           Logger.infoNotify("IDF_TARGET is not defined.");
           return;
         }
         const toolchainPrefix = utils.getToolchainToolName(idfTarget, "");
-        const projectName = await getProjectName(buildDirPath);
         const gdbPath = await utils.getToolchainPath(workspaceRoot, "gdb");
-        const elfFilePath = path.join(buildDirPath, `${projectName}.elf`);
+        let elfFilePath: string;
+        try {
+          elfFilePath = await getProjectElfFilePath(workspaceRoot);
+        } catch (error) {
+          Logger.errorNotify(
+            vscode.l10n.t("Failed to get project ELF file path"),
+            error,
+            "extension launchWSServerAndMonitor getProjectElfFilePath"
+          );
+          return;
+        }
         const wsPort = idfConf.readParameter("idf.wssPort", workspaceRoot);
         const idfVersion = await utils.getEspIdfFromCMake(idfPath);
         let sdkMonitorBaudRate: string = await utils.getMonitorBaudRate(
@@ -3418,32 +3433,32 @@ export async function activate(context: vscode.ExtensionContext) {
                 ),
               },
               async (progress) => {
-                const espCoreDumpPyTool = new ESPCoreDumpPyTool(idfPath);
-                const buildDirPath = idfConf.readParameter(
-                  "idf.buildPath",
-                  workspaceRoot
-                ) as string;
-                const projectName = await getProjectName(buildDirPath);
-                const coreElfFilePath = path.join(
-                  buildDirPath,
-                  `${projectName}.coredump.elf`
-                );
-                if (
-                  (await espCoreDumpPyTool.generateCoreELFFile({
-                    coreElfFilePath,
-                    coreInfoFilePath: resp.file,
-                    infoCoreFileFormat: InfoCoreFileFormat.Base64,
-                    progELFFilePath: resp.prog,
-                    pythonBinPath,
-                    workspaceUri: workspaceRoot,
-                  })) === true
-                ) {
-                  progress.report({
-                    message: vscode.l10n.t(
-                      "Successfully created ELF file from the info received (espcoredump.py)"
-                    ),
-                  });
-                  try {
+                try {
+                  const espCoreDumpPyTool = new ESPCoreDumpPyTool(idfPath);
+                  const buildDirPath = idfConf.readParameter(
+                    "idf.buildPath",
+                    workspaceRoot
+                  ) as string;
+                  const projectName = await getProjectName(workspaceRoot);
+                  const coreElfFilePath = path.join(
+                    buildDirPath,
+                    `${projectName}.coredump.elf`
+                  );
+                  if (
+                    (await espCoreDumpPyTool.generateCoreELFFile({
+                      coreElfFilePath,
+                      coreInfoFilePath: resp.file,
+                      infoCoreFileFormat: InfoCoreFileFormat.Base64,
+                      progELFFilePath: resp.prog,
+                      pythonBinPath,
+                      workspaceUri: workspaceRoot,
+                    })) === true
+                  ) {
+                    progress.report({
+                      message: vscode.l10n.t(
+                        "Successfully created ELF file from the info received (espcoredump.py)"
+                      ),
+                    });
                     const workspaceFolder = vscode.workspace.getWorkspaceFolder(
                       workspaceRoot
                     );
@@ -3472,18 +3487,18 @@ export async function activate(context: vscode.ExtensionContext) {
                         wsServer.close();
                       }
                     });
-                  } catch (error) {
-                    Logger.errorNotify(
-                      vscode.l10n.t("Failed to launch debugger for postmortem"),
-                      error,
-                      "extension launchWSServerAndMonitor coredump"
+                  } else {
+                    Logger.warnNotify(
+                      vscode.l10n.t(
+                        "Failed to generate the ELF file from the info received, please close the core-dump monitor terminal manually"
+                      )
                     );
                   }
-                } else {
-                  Logger.warnNotify(
-                    vscode.l10n.t(
-                      "Failed to generate the ELF file from the info received, please close the core-dump monitor terminal manually"
-                    )
+                } catch (error) {
+                  Logger.errorNotify(
+                    vscode.l10n.t("Failed to launch debugger for postmortem"),
+                    error,
+                    "extension launchWSServerAndMonitor coredump"
                   );
                 }
               }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import { showInfoNotificationWithAction } from "./logger/utils";
 import * as utils from "./utils";
 import { PreCheck, shouldDisableMonitorReset } from "./utils";
 import {
+  getSDKConfigFilePath,
   getIdfTargetFromSdkconfig,
   getProjectName,
   initSelectedWorkspace,
@@ -3550,9 +3551,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!args) {
         // try to get the partition table name from sdkconfig and if not found create one
         try {
-          const sdkconfigFilePath = await utils.getSDKConfigFilePath(
-            workspaceRoot
-          );
+          const sdkconfigFilePath = await getSDKConfigFilePath(workspaceRoot);
           const sdkconfigFileExists = await pathExists(sdkconfigFilePath);
           if (!sdkconfigFileExists) {
             const buildProject = await vscode.window.showInformationMessage(
@@ -4329,7 +4328,7 @@ function createClassicMenuconfig(extensionPath: string) {
       "idf.buildPath",
       workspaceRoot
     ) as string;
-    const sdkconfigPath = await utils.getSDKConfigFilePath(workspaceRoot);
+    const sdkconfigPath = await getSDKConfigFilePath(workspaceRoot);
     const sdkconfigDefaults = idfConf.readParameter(
       "idf.sdkconfigDefaults",
       workspaceRoot

--- a/src/flash/flashCmd.ts
+++ b/src/flash/flashCmd.ts
@@ -23,7 +23,7 @@ import * as vscode from "vscode";
 import { FlashTask } from "./flashTask";
 import { BuildTask } from "../build/buildTask";
 import { Logger } from "../logger/logger";
-import { getProjectName } from "../workspaceConfig";
+import { getProjectElfFilePath } from "../workspaceConfig";
 import { getDfuList } from "./dfu";
 import { ESP } from "../config";
 import { OutputChannel } from "../logger/outputChannel";
@@ -63,9 +63,17 @@ export async function verifyCanFlash(
     OutputChannel.appendLineAndShow(errStr, "Flash");
     return Logger.warnNotify(errStr);
   }
-  const projectName = await getProjectName(buildPath);
-  if (!(await pathExists(join(buildPath, `${projectName}.elf`)))) {
-    const errStr = `Can't proceed with flashing, since project elf file (${projectName}.elf) is missing from the build dir. (${buildPath})`;
+  let elfFilePath: string;
+  try {
+    elfFilePath = await getProjectElfFilePath(workspace);
+  } catch (error) {
+    const errStr = "Failed to get project ELF file path";
+    OutputChannel.show();
+    OutputChannel.appendLineAndShow(errStr, "Flash");
+    return Logger.errorNotify(errStr, error, "flashCmd verifyCanFlash getProjectElfFilePath");
+  }
+  if (!(await pathExists(elfFilePath))) {
+    const errStr = `Can't proceed with flashing, since project elf file (${elfFilePath}) is missing from the build dir. (${buildPath})`;
     OutputChannel.show();
     OutputChannel.appendLineAndShow(errStr, "Flash");
     return Logger.warnNotify(errStr);

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -112,7 +112,7 @@ export async function getEnvVarsFromIdfTools(
   }
 }
 
-export async function getVirtualEnvPythonPath() {
+export function getVirtualEnvPythonPath() {
   const currentEnvVars = ESP.ProjectConfiguration.store.get<{
     [key: string]: string;
   }>(ESP.ProjectConfiguration.CURRENT_IDF_CONFIGURATION, {});

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -101,10 +101,13 @@ export async function getEnvVarsFromIdfTools(
     return idfToolsDict;
   } catch (error) {
     const msg =
-      error && error.message
+      error &&
+      typeof error === "object" &&
+      "message" in error &&
+      typeof error.message === "string"
         ? error.message
         : "Error at idf_tools.py export --format key-value";
-    Logger.error(msg, error, "getEnvVarsFromIdfTools");
+    Logger.errorNotify(msg, error as Error, "getEnvVarsFromIdfTools");
     return idfToolsDict;
   }
 }
@@ -140,14 +143,19 @@ export async function checkPythonExists(pythonBin: string, workingDir: string) {
       }
     }
   } catch (error) {
-    if (error && error.message) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "message" in error &&
+      typeof error.message === "string"
+    ) {
       const match = error.message.match(/Python\s\d+.\d+.\d+/g);
       if (match && match.length > 0) {
         return true;
       }
     }
     const newErr =
-      error && error.message
+      error && error instanceof Error
         ? error
         : new Error("Python is not found in current environment");
     Logger.errorNotify(
@@ -200,7 +208,7 @@ export async function getUnixPythonList(workingDir: string) {
   } catch (error) {
     Logger.errorNotify(
       "Error looking for python in system",
-      error,
+      error as Error,
       "pythonManager getUnixPythonList"
     );
     return ["Not found"];
@@ -221,7 +229,7 @@ export async function checkIfNotVirtualEnv(
   } catch (error) {
     Logger.errorNotify(
       "Error checking Python is virtualenv",
-      error,
+      error as Error,
       "pythonManager checkIfNotVirtualEnv"
     );
     return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ import * as vscode from "vscode";
 import { IdfComponent } from "./idfComponent";
 import * as idfConf from "./idfConfiguration";
 import { Logger } from "./logger/logger";
-import { getProjectName, getSDKConfigFilePath } from "./workspaceConfig";
+import { getSDKConfigFilePath } from "./workspaceConfig";
 import { OutputChannel } from "./logger/outputChannel";
 import { ESP } from "./config";
 import * as sanitizedHtml from "sanitize-html";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ import * as vscode from "vscode";
 import { IdfComponent } from "./idfComponent";
 import * as idfConf from "./idfConfiguration";
 import { Logger } from "./logger/logger";
-import { getIdfTargetFromSdkconfig, getProjectName } from "./workspaceConfig";
+import { getProjectName, getSDKConfigFilePath } from "./workspaceConfig";
 import { OutputChannel } from "./logger/outputChannel";
 import { ESP } from "./config";
 import * as sanitizedHtml from "sanitize-html";
@@ -464,49 +464,6 @@ export function getVariableFromCMakeLists(workspacePath: string, key: string) {
   const regexExp = new RegExp(`(?:set|SET)\\(${key} (.*)\\)`);
   const match = cmakeListsContent.match(regexExp);
   return match ? match[1] : "";
-}
-
-export async function getSDKConfigFilePath(workspacePath: vscode.Uri) {
-  let sdkconfigFilePath = "";
-  try {
-    sdkconfigFilePath = getVariableFromCMakeLists(
-      workspacePath.fsPath,
-      "SDKCONFIG"
-    );
-  } catch (error) {
-    const errMsg = error.message
-      ? error.message
-      : `CMakeLists.txt file doesn't exists or can't be read`;
-    Logger.info(errMsg, error);
-  }
-  if (
-    sdkconfigFilePath &&
-    sdkconfigFilePath.indexOf("${CMAKE_BINARY_DIR}") !== -1
-  ) {
-    const buildDirPath = idfConf.readParameter(
-      "idf.buildPath",
-      workspacePath
-    ) as string;
-    sdkconfigFilePath = sdkconfigFilePath
-      .replace("${CMAKE_BINARY_DIR}", buildDirPath)
-      .replace(/"/g, "");
-  }
-  if (!sdkconfigFilePath) {
-    sdkconfigFilePath = idfConf.readParameter(
-      "idf.sdkconfigFilePath",
-      workspacePath
-    ) as string;
-  }
-  if (!workspacePath) {
-    return;
-  }
-  if (!sdkconfigFilePath) {
-    sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig");
-  }
-  if (!sdkconfigFilePath) {
-    sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig.defaults");
-  }
-  return sdkconfigFilePath;
 }
 
 export async function getConfigValueFromSDKConfig(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -705,38 +705,6 @@ export function checkSpacesInPath(pathStr: string) {
   return /\s+/g.test(pathStr);
 }
 
-export async function getElfFilePath(
-  workspaceURI: vscode.Uri
-): Promise<string> {
-  let projectName = "";
-  if (!workspaceURI) {
-    throw new Error("No Workspace open");
-  }
-
-  try {
-    const buildDir = idfConf.readParameter(
-      "idf.buildPath",
-      workspaceURI
-    ) as string;
-    if (!canAccessFile(buildDir, fs.constants.R_OK)) {
-      throw new Error("Build is required once to generate the ELF File");
-    }
-    projectName = await getProjectName(buildDir);
-    const elfFilePath = path.join(buildDir, `${projectName}.elf`);
-    if (!canAccessFile(elfFilePath, fs.constants.R_OK)) {
-      throw new Error(`Failed to access .elf file at ${elfFilePath}`);
-    }
-    return elfFilePath;
-  } catch (error) {
-    Logger.errorNotify(
-      "Failed to read project name while fetching elf file",
-      error,
-      "utils getElfFilePath"
-    );
-    return;
-  }
-}
-
 export function checkIsProjectCmakeLists(dir: string) {
   // Check if folder contain CMakeLists.txt with project(name) call.
   const cmakeListFile = path.join(dir, "CMakeLists.txt");

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -102,6 +102,10 @@ export async function getProjectDescriptionJson(
     workspaceFolder
   ) as string;
   try {
+    const doesBuildPathExists = await pathExists(buildDirPath);
+    if (!doesBuildPathExists) {
+      return undefined;
+    }
     const projDescJsonPath = path.join(
       buildDirPath,
       "project_description.json"

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -23,39 +23,44 @@ import { showInfoNotificationWithAction } from "./logger/utils";
 import { isSettingIDFTarget } from "./espIdf/setTarget";
 import { pathExists } from "fs-extra";
 
+/** Parsed subset of build/project_description.json; fields are optional for partial or evolving schemas. */
 export interface IProjectDescription {
-  version: string;
-  projectName: string;
-  projectVersion: string;
-  projectPath: string;
-  idfPath: string;
-  buildDir: string;
-  configFile: string;
-  configDefaults: string;
-  bootloaderElf: string;
-  appElf: string;
-  appBin: string;
-  buildType: string;
-  gitRevision: string;
-  target: string;
-  rev: string;
-  minRev: string;
-  maxRev: string;
-  phyDataPartition: string;
-  monitorBaud: string;
-  monitorToolPrefix: string;
-  cCompiler: string;
-  configEnvironment: {
-    ComponentKconfigs: string;
-    ComponentKconfigsProjbuild: string;
+  version?: string;
+  projectName?: string;
+  projectVersion?: string;
+  projectPath?: string;
+  idfPath?: string;
+  buildDir?: string;
+  configFile?: string;
+  configDefaults?: string;
+  bootloaderElf?: string;
+  appElf?: string;
+  appBin?: string;
+  buildType?: string;
+  gitRevision?: string;
+  target?: string;
+  rev?: string;
+  minRev?: string;
+  maxRev?: string;
+  phyDataPartition?: string;
+  monitorBaud?: string;
+  monitorToolPrefix?: string;
+  cCompiler?: string;
+  configEnvironment?: {
+    ComponentKconfigs?: string;
+    ComponentKconfigsProjbuild?: string;
   };
-  commonComponentReqs: string[];
-  buildComponents: string[];
-  buildComponentPaths: string[];
-  buildComponentInfo: { [key: string]: any };
-  allComponentInfo: { [key: string]: any };
-  gdbinitFiles: { [key: string]: string };
-  debugArgumentsOpenOCD: string;
+  commonComponentReqs?: string[];
+  buildComponents?: string[];
+  buildComponentPaths?: string[];
+  buildComponentInfo?: { [key: string]: any };
+  allComponentInfo?: { [key: string]: any };
+  gdbinitFiles?: { [key: string]: string };
+  debugArgumentsOpenOCD?: string;
+}
+
+function optString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 export function initSelectedWorkspace(status?: vscode.StatusBarItem) {
@@ -92,41 +97,80 @@ export async function getProjectDescriptionJson(
       return undefined;
     }
     const projDescJsonContent = await fs.promises.readFile(projDescJsonPath);
-    const projDescJson = JSON.parse(projDescJsonContent.toString());
+    const projDescJson = JSON.parse(projDescJsonContent.toString()) as Record<
+      string,
+      unknown
+    >;
+    if (
+      !projDescJson ||
+      typeof projDescJson !== "object" ||
+      Array.isArray(projDescJson)
+    ) {
+      return undefined;
+    }
+    const env = projDescJson.config_environment;
+    const envObj =
+      env !== null && typeof env === "object" && !Array.isArray(env)
+        ? (env as Record<string, unknown>)
+        : undefined;
     const projectDescriptionObj: IProjectDescription = {
-      version: projDescJson.version,
-      projectName: projDescJson.project_name,
-      projectVersion: projDescJson.project_version,
-      projectPath: projDescJson.project_path,
-      idfPath: projDescJson.idf_path,
-      buildDir: projDescJson.build_dir,
-      configFile: projDescJson.config_file,
-      configDefaults: projDescJson.config_defaults,
-      bootloaderElf: projDescJson.bootloader_elf,
-      appElf: projDescJson.app_elf,
-      appBin: projDescJson.app_bin,
-      buildType: projDescJson.build_type,
-      gitRevision: projDescJson.git_revision,
-      target: projDescJson.target,
-      rev: projDescJson.rev,
-      minRev: projDescJson.min_rev,
-      maxRev: projDescJson.max_rev,
-      phyDataPartition: projDescJson.phy_data_partition,
-      monitorBaud: projDescJson.monitor_baud,
-      monitorToolPrefix: projDescJson.monitor_tool_prefix,
-      cCompiler: projDescJson.c_compiler,
-      configEnvironment: {
-        ComponentKconfigs: projDescJson.config_environment.COMPONENT_KCONFIGS,
-        ComponentKconfigsProjbuild:
-          projDescJson.config_environment.COMPONENT_KCONFIGS_PROJBUILD,
-      },
-      commonComponentReqs: projDescJson.common_component_reqs,
-      buildComponents: projDescJson.build_components,
-      buildComponentPaths: projDescJson.build_component_paths,
-      buildComponentInfo: projDescJson.build_component_info,
-      allComponentInfo: projDescJson.all_component_info,
-      gdbinitFiles: projDescJson.gdbinit_files,
-      debugArgumentsOpenOCD: projDescJson.debug_arguments_openocd,
+      version: optString(projDescJson.version),
+      projectName: optString(projDescJson.project_name),
+      projectVersion: optString(projDescJson.project_version),
+      projectPath: optString(projDescJson.project_path),
+      idfPath: optString(projDescJson.idf_path),
+      buildDir: optString(projDescJson.build_dir),
+      configFile: optString(projDescJson.config_file),
+      configDefaults: optString(projDescJson.config_defaults),
+      bootloaderElf: optString(projDescJson.bootloader_elf),
+      appElf: optString(projDescJson.app_elf),
+      appBin: optString(projDescJson.app_bin),
+      buildType: optString(projDescJson.build_type),
+      gitRevision: optString(projDescJson.git_revision),
+      target: optString(projDescJson.target),
+      rev: optString(projDescJson.rev),
+      minRev: optString(projDescJson.min_rev),
+      maxRev: optString(projDescJson.max_rev),
+      phyDataPartition: optString(projDescJson.phy_data_partition),
+      monitorBaud: optString(projDescJson.monitor_baud),
+      monitorToolPrefix: optString(projDescJson.monitor_tool_prefix),
+      cCompiler: optString(projDescJson.c_compiler),
+      configEnvironment: envObj
+        ? {
+            ComponentKconfigs: optString(envObj.COMPONENT_KCONFIGS),
+            ComponentKconfigsProjbuild: optString(
+              envObj.COMPONENT_KCONFIGS_PROJBUILD
+            ),
+          }
+        : undefined,
+      commonComponentReqs: Array.isArray(projDescJson.common_component_reqs)
+        ? (projDescJson.common_component_reqs as string[])
+        : undefined,
+      buildComponents: Array.isArray(projDescJson.build_components)
+        ? (projDescJson.build_components as string[])
+        : undefined,
+      buildComponentPaths: Array.isArray(projDescJson.build_component_paths)
+        ? (projDescJson.build_component_paths as string[])
+        : undefined,
+      buildComponentInfo:
+        projDescJson.build_component_info !== null &&
+        typeof projDescJson.build_component_info === "object" &&
+        !Array.isArray(projDescJson.build_component_info)
+          ? (projDescJson.build_component_info as { [key: string]: any })
+          : undefined,
+      allComponentInfo:
+        projDescJson.all_component_info !== null &&
+        typeof projDescJson.all_component_info === "object" &&
+        !Array.isArray(projDescJson.all_component_info)
+          ? (projDescJson.all_component_info as { [key: string]: any })
+          : undefined,
+      gdbinitFiles:
+        projDescJson.gdbinit_files !== null &&
+        typeof projDescJson.gdbinit_files === "object" &&
+        !Array.isArray(projDescJson.gdbinit_files)
+          ? (projDescJson.gdbinit_files as { [key: string]: string })
+          : undefined,
+      debugArgumentsOpenOCD: optString(projDescJson.debug_arguments_openocd),
     };
     return projectDescriptionObj;
   } catch (error) {
@@ -141,23 +185,20 @@ export async function getProjectDescriptionJson(
 
 export async function getSDKConfigFilePath(
   workspacePath: vscode.Uri
-): Promise<string | undefined> {
+): Promise<string> {
   try {
     if (!workspacePath) {
-      return;
+      return "sdkconfig";
     }
     const buildDir = readParameter("idf.buildPath", workspacePath) as string;
     const projDescObj = await getProjectDescriptionJson(buildDir);
     if (projDescObj && projDescObj.configFile) {
       return projDescObj.configFile;
     }
-    let sdkconfigFilePath = "";
-    if (!sdkconfigFilePath) {
-      sdkconfigFilePath = readParameter(
-        "idf.sdkconfigFilePath",
-        workspacePath
-      ) as string;
-    }
+    let sdkconfigFilePath = readParameter(
+      "idf.sdkconfigFilePath",
+      workspacePath
+    ) as string;
     if (!sdkconfigFilePath) {
       sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig");
     }
@@ -165,18 +206,14 @@ export async function getSDKConfigFilePath(
   } catch (error) {
     const errMsg = error && error.message ? error.message : error;
     Logger.error(errMsg, error, "workspaceConfig getSdkconfigPath");
+    return path.join(workspacePath.fsPath, "sdkconfig");
   }
 }
 
 export async function getProjectName(buildDir: string): Promise<string> {
-  try {
-    const projectDescription = await getProjectDescriptionJson(buildDir);
-    if (projectDescription && projectDescription.projectName) {
-      return projectDescription.projectName;
-    }
-  } catch (error) {
-    const errMsg = error && error.message ? error.message : error;
-    Logger.error(errMsg, error, "workspaceConfig getProjectName");
+  const projectDescription = await getProjectDescriptionJson(buildDir);
+  if (projectDescription && projectDescription.projectName) {
+    return projectDescription.projectName;
   }
   return "";
 }

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -21,6 +21,42 @@ import * as utils from "./utils";
 import { readParameter } from "./idfConfiguration";
 import { showInfoNotificationWithAction } from "./logger/utils";
 import { isSettingIDFTarget } from "./espIdf/setTarget";
+import { pathExists } from "fs-extra";
+
+export interface IProjectDescription {
+  version: string;
+  projectName: string;
+  projectVersion: string;
+  projectPath: string;
+  idfPath: string;
+  buildDir: string;
+  configFile: string;
+  configDefaults: string;
+  bootloaderElf: string;
+  appElf: string;
+  appBin: string;
+  buildType: string;
+  gitRevision: string;
+  target: string;
+  rev: string;
+  minRev: string;
+  maxRev: string;
+  phyDataPartition: string;
+  monitorBaud: string;
+  monitorToolPrefix: string;
+  cCompiler: string;
+  configEnvironment: {
+    ComponentKconfigs: string;
+    ComponentKconfigsProjbuild: string;
+  };
+  commonComponentReqs: string[];
+  buildComponents: string[];
+  buildComponentPaths: string[];
+  buildComponentInfo: { [key: string]: any };
+  allComponentInfo: { [key: string]: any };
+  gdbinitFiles: { [key: string]: string };
+  debugArgumentsOpenOCD: string;
+}
 
 export function initSelectedWorkspace(status?: vscode.StatusBarItem) {
   const workspaceRoot = vscode.workspace.workspaceFolders[0].uri;
@@ -46,41 +82,103 @@ export function updateIdfComponentsTree(workspaceFolder: vscode.Uri) {
   idfDataProvider.refresh(workspaceFolder);
 }
 
-export function getProjectName(buildDir: string): Promise<string> {
-  const projDescJsonPath = path.join(buildDir, "project_description.json");
-  return new Promise((resolve, reject) => {
-    try {
-      if (!utils.fileExists(projDescJsonPath)) {
-        return reject(new Error(`${projDescJsonPath} doesn't exist.`));
-      }
-      fs.readFile(projDescJsonPath, (err, data) => {
-        if (err) {
-          Logger.error(
-            err.message,
-            err,
-            "workspaceConfig getProjectName readFile"
-          );
-          return reject(err);
-        }
-        const projDescJson = JSON.parse(data.toString());
-        if (
-          Object.prototype.hasOwnProperty.call(projDescJson, "project_name")
-        ) {
-          return resolve(projDescJson.project_name);
-        } else {
-          return reject(
-            new Error(
-              `project_name field doesn't exist in ${projDescJsonPath}.`
-            )
-          );
-        }
-      });
-    } catch (error) {
-      const errMsg = error && error.message ? error.message : error;
-      Logger.error(errMsg, error, "workspaceConfig getProjectName");
-      return reject(error);
+export async function getProjectDescriptionJson(
+  buildDir: string
+): Promise<IProjectDescription | undefined> {
+  try {
+    const projDescJsonPath = path.join(buildDir, "project_description.json");
+    const doesExists = await pathExists(projDescJsonPath);
+    if (!doesExists) {
+      return undefined;
     }
-  });
+    const projDescJsonContent = await fs.promises.readFile(projDescJsonPath);
+    const projDescJson = JSON.parse(projDescJsonContent.toString());
+    const projectDescriptionObj: IProjectDescription = {
+      version: projDescJson.version,
+      projectName: projDescJson.project_name,
+      projectVersion: projDescJson.project_version,
+      projectPath: projDescJson.project_path,
+      idfPath: projDescJson.idf_path,
+      buildDir: projDescJson.build_dir,
+      configFile: projDescJson.config_file,
+      configDefaults: projDescJson.config_defaults,
+      bootloaderElf: projDescJson.bootloader_elf,
+      appElf: projDescJson.app_elf,
+      appBin: projDescJson.app_bin,
+      buildType: projDescJson.build_type,
+      gitRevision: projDescJson.git_revision,
+      target: projDescJson.target,
+      rev: projDescJson.rev,
+      minRev: projDescJson.min_rev,
+      maxRev: projDescJson.max_rev,
+      phyDataPartition: projDescJson.phy_data_partition,
+      monitorBaud: projDescJson.monitor_baud,
+      monitorToolPrefix: projDescJson.monitor_tool_prefix,
+      cCompiler: projDescJson.c_compiler,
+      configEnvironment: {
+        ComponentKconfigs: projDescJson.config_environment.COMPONENT_KCONFIGS,
+        ComponentKconfigsProjbuild:
+          projDescJson.config_environment.COMPONENT_KCONFIGS_PROJBUILD,
+      },
+      commonComponentReqs: projDescJson.common_component_reqs,
+      buildComponents: projDescJson.build_components,
+      buildComponentPaths: projDescJson.build_component_paths,
+      buildComponentInfo: projDescJson.build_component_info,
+      allComponentInfo: projDescJson.all_component_info,
+      gdbinitFiles: projDescJson.gdbinit_files,
+      debugArgumentsOpenOCD: projDescJson.debug_arguments_openocd,
+    };
+    return projectDescriptionObj;
+  } catch (error) {
+    Logger.error(
+      `Error reading project description JSON from ${buildDir}`,
+      error,
+      "workspaceConfig getProjectDescriptionJson"
+    );
+    return undefined;
+  }
+}
+
+export async function getSDKConfigFilePath(
+  workspacePath: vscode.Uri
+): Promise<string | undefined> {
+  try {
+    if (!workspacePath) {
+      return;
+    }
+    const buildDir = readParameter("idf.buildPath", workspacePath) as string;
+    const projDescObj = await getProjectDescriptionJson(buildDir);
+    if (projDescObj && projDescObj.configFile) {
+      return projDescObj.configFile;
+    }
+    let sdkconfigFilePath = "";
+    if (!sdkconfigFilePath) {
+      sdkconfigFilePath = readParameter(
+        "idf.sdkconfigFilePath",
+        workspacePath
+      ) as string;
+    }
+    if (!sdkconfigFilePath) {
+      sdkconfigFilePath = path.join(workspacePath.fsPath, "sdkconfig");
+    }
+    return sdkconfigFilePath;
+  } catch (error) {
+    const errMsg = error && error.message ? error.message : error;
+    Logger.error(errMsg, error, "workspaceConfig getSdkconfigPath");
+  }
+}
+
+export async function getProjectName(buildDir: string): Promise<string> {
+  try {
+    const projectDescription = await getProjectDescriptionJson(buildDir);
+    if (projectDescription && projectDescription.projectName) {
+      return projectDescription.projectName;
+    }
+  } catch (error) {
+    const errMsg = error && error.message ? error.message : error;
+    Logger.error(errMsg, error, "workspaceConfig getProjectName");
+  }
+  return "";
 }
 
 export async function getIdfTargetFromSdkconfig(

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -22,7 +22,6 @@ import { readParameter } from "./idfConfiguration";
 import { showInfoNotificationWithAction } from "./logger/utils";
 import { isSettingIDFTarget } from "./espIdf/setTarget";
 import { pathExists } from "fs-extra";
-import { Uri } from "vscode";
 
 /** Parsed subset of build/project_description.json; fields are optional for partial or evolving schemas. */
 export interface IProjectDescription {
@@ -65,18 +64,25 @@ function optString(value: unknown): string | undefined {
 }
 
 export function initSelectedWorkspace(status?: vscode.StatusBarItem) {
-  const workspaceRoot = vscode.workspace.workspaceFolders[0].uri;
-  updateIdfComponentsTree(workspaceRoot);
+  const workspaceRoot =
+    vscode.workspace.workspaceFolders &&
+    vscode.workspace.workspaceFolders.length
+      ? vscode.workspace.workspaceFolders[0]
+      : undefined;
+  if (!workspaceRoot) {
+    return;
+  }
+  updateIdfComponentsTree(workspaceRoot.uri);
   const workspaceFolderInfo = {
     clickCommand: "espIdf.pickAWorkspaceFolder",
-    currentWorkSpace: vscode.workspace.workspaceFolders[0].name,
-    tooltip: vscode.workspace.workspaceFolders[0].uri.fsPath,
+    currentWorkSpace: workspaceRoot.name,
+    tooltip: workspaceRoot.uri.fsPath,
     text: "${file-directory}",
   };
   if (status) {
     utils.updateStatus(status, workspaceFolderInfo);
   }
-  return workspaceRoot;
+  return workspaceRoot.uri;
 }
 
 let idfDataProvider: IdfTreeDataProvider;
@@ -184,7 +190,7 @@ export async function getProjectDescriptionJson(
   } catch (error) {
     Logger.error(
       `Error reading project description JSON from ${buildDirPath}`,
-      error,
+      error as Error,
       "workspaceConfig getProjectDescriptionJson"
     );
     return undefined;
@@ -195,12 +201,14 @@ export async function getSDKConfigFilePath(
   workspacePath: vscode.Uri
 ): Promise<string> {
   try {
-    if (!workspacePath) {
-      return "sdkconfig";
-    }
     const projDescObj = await getProjectDescriptionJson(workspacePath);
-    if (projDescObj && projDescObj.configFile) {
-      return projDescObj.configFile;
+    if (projDescObj?.configFile) {
+      const configFilePath = path.isAbsolute(projDescObj.configFile)
+        ? projDescObj.configFile
+        : path.join(workspacePath.fsPath, projDescObj.configFile);
+      if (await pathExists(configFilePath)) {
+        return configFilePath;
+      }
     }
     let sdkconfigFilePath = readParameter(
       "idf.sdkconfigFilePath",
@@ -211,8 +219,11 @@ export async function getSDKConfigFilePath(
     }
     return sdkconfigFilePath;
   } catch (error) {
-    const errMsg = error && error.message ? error.message : error;
-    Logger.error(errMsg, error, "workspaceConfig getSdkconfigPath");
+    const errMsg =
+      error && typeof error === "object" && "message" in error
+        ? (error as Error).message
+        : String(error);
+    Logger.error(errMsg, error as Error, "workspaceConfig getSdkconfigPath");
     return path.join(workspacePath.fsPath, "sdkconfig");
   }
 }

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -94,6 +94,14 @@ export function updateIdfComponentsTree(workspaceFolder: vscode.Uri) {
   idfDataProvider.refresh(workspaceFolder);
 }
 
+/**
+ * Reads and maps `${idf.buildPath}/project_description.json` into a typed object.
+ *
+ * Returns `undefined` when the build directory or file is missing, content is invalid,
+ * or parsing/reading fails.
+ * @param {vscode.Uri} workspaceFolder - Workspace URI to read the project description JSON from its build directory.
+ * @returns {Promise<IProjectDescription | undefined>}
+ */
 export async function getProjectDescriptionJson(
   workspaceFolder: vscode.Uri
 ): Promise<IProjectDescription | undefined> {
@@ -201,6 +209,16 @@ export async function getProjectDescriptionJson(
   }
 }
 
+/**
+ * Resolves the sdkconfig file path for a workspace.
+ *
+ * Lookup order:
+ * 1) `configFile` from `project_description.json` (if present and exists),
+ * 2) `idf.sdkconfigFilePath` setting for the workspace,
+ * 3) `${workspace}/sdkconfig` fallback.
+ * @param {vscode.Uri} workspacePath - Workspace URI to resolve the sdkconfig file path for.
+ * @returns {Promise<string>}
+ */
 export async function getSDKConfigFilePath(
   workspacePath: vscode.Uri
 ): Promise<string> {
@@ -232,6 +250,12 @@ export async function getSDKConfigFilePath(
   }
 }
 
+/**
+ * Returns `projectName` from `project_description.json`.
+ * Throws if the file cannot be read or `projectName` is missing.
+ * @param {vscode.Uri} workspacePath - Workspace URI to get the project name from its project description.
+ * @returns {Promise<string>}
+ */
 export async function getProjectName(
   workspacePath: vscode.Uri
 ): Promise<string> {
@@ -242,6 +266,12 @@ export async function getProjectName(
   throw new Error("Failed to get project name from project description.");
 }
 
+/**
+ * Returns the full path to the app ELF file using `idf.buildPath` and `appElf` from `project_description.json`.
+ * Throws if `project_description.json` is missing `appElf` or `idf.buildPath` is missing.
+ * @param {vscode.Uri} workspacePath - Workspace URI to get the project ELF file path from its project description json.
+ * @returns {Promise<string>}
+ */
 export async function getProjectElfFilePath(
   workspacePath: vscode.Uri
 ): Promise<string> {
@@ -262,6 +292,13 @@ export async function getProjectElfFilePath(
   );
 }
 
+/**
+ * Returns the full path to `${projectName}.map` using `idf.buildPath`.
+ * Throws if `projectName` cannot be read from `project_description.json`
+ * or if `idf.buildPath` is missing.
+ * @param {vscode.Uri} workspacePath - Workspace URI to get the project MAP file path from its project description json.
+ * @returns {Promise<string>}
+ */
 export async function getProjectMapFilePath(
   workspacePath: vscode.Uri
 ): Promise<string> {
@@ -277,6 +314,14 @@ export async function getProjectMapFilePath(
   return mapFilePath;
 }
 
+/**
+ * Returns the IDF target from `sdkconfig` (`CONFIG_IDF_TARGET`) if available.
+ * If not available, uses `idf.customExtraVars.IDF_TARGET`; if still missing, returns `"esp32"`.
+ * Updates `statusItem.text` with the resolved IDF target when `statusItem` is provided.
+ * @param {vscode.Uri} workspacePath - Workspace URI to get the IDF target from its SDK configuration.
+ * @param {vscode.StatusBarItem} [statusItem] - Optional status bar item to update with the resolved IDF target.
+ * @returns {Promise<string>} - The resolved IDF target.
+ */
 export async function getIdfTargetFromSdkconfig(
   workspacePath: vscode.Uri,
   statusItem?: vscode.StatusBarItem

--- a/src/workspaceConfig.ts
+++ b/src/workspaceConfig.ts
@@ -22,6 +22,7 @@ import { readParameter } from "./idfConfiguration";
 import { showInfoNotificationWithAction } from "./logger/utils";
 import { isSettingIDFTarget } from "./espIdf/setTarget";
 import { pathExists } from "fs-extra";
+import { Uri } from "vscode";
 
 /** Parsed subset of build/project_description.json; fields are optional for partial or evolving schemas. */
 export interface IProjectDescription {
@@ -88,10 +89,17 @@ export function updateIdfComponentsTree(workspaceFolder: vscode.Uri) {
 }
 
 export async function getProjectDescriptionJson(
-  buildDir: string
+  workspaceFolder: vscode.Uri
 ): Promise<IProjectDescription | undefined> {
+  const buildDirPath = readParameter(
+    "idf.buildPath",
+    workspaceFolder
+  ) as string;
   try {
-    const projDescJsonPath = path.join(buildDir, "project_description.json");
+    const projDescJsonPath = path.join(
+      buildDirPath,
+      "project_description.json"
+    );
     const doesExists = await pathExists(projDescJsonPath);
     if (!doesExists) {
       return undefined;
@@ -175,7 +183,7 @@ export async function getProjectDescriptionJson(
     return projectDescriptionObj;
   } catch (error) {
     Logger.error(
-      `Error reading project description JSON from ${buildDir}`,
+      `Error reading project description JSON from ${buildDirPath}`,
       error,
       "workspaceConfig getProjectDescriptionJson"
     );
@@ -190,8 +198,7 @@ export async function getSDKConfigFilePath(
     if (!workspacePath) {
       return "sdkconfig";
     }
-    const buildDir = readParameter("idf.buildPath", workspacePath) as string;
-    const projDescObj = await getProjectDescriptionJson(buildDir);
+    const projDescObj = await getProjectDescriptionJson(workspacePath);
     if (projDescObj && projDescObj.configFile) {
       return projDescObj.configFile;
     }
@@ -210,12 +217,49 @@ export async function getSDKConfigFilePath(
   }
 }
 
-export async function getProjectName(buildDir: string): Promise<string> {
-  const projectDescription = await getProjectDescriptionJson(buildDir);
+export async function getProjectName(
+  workspacePath: vscode.Uri
+): Promise<string> {
+  const projectDescription = await getProjectDescriptionJson(workspacePath);
   if (projectDescription && projectDescription.projectName) {
     return projectDescription.projectName;
   }
-  return "";
+  throw new Error("Failed to get project name from project description.");
+}
+
+export async function getProjectElfFilePath(
+  workspacePath: vscode.Uri
+): Promise<string> {
+  const projectDescription = await getProjectDescriptionJson(workspacePath);
+  if (projectDescription && projectDescription.appElf) {
+    const buildDirPath = readParameter(
+      "idf.buildPath",
+      workspacePath
+    ) as string;
+    if (!buildDirPath) {
+      throw new Error("Failed to get build directory path for ELF file path.");
+    }
+    const elfFilePath = path.join(buildDirPath, projectDescription.appElf);
+    return elfFilePath;
+  }
+  throw new Error(
+    "Failed to get project ELF file name from project description."
+  );
+}
+
+export async function getProjectMapFilePath(
+  workspacePath: vscode.Uri
+): Promise<string> {
+  const projectName = await getProjectName(workspacePath);
+  if (!projectName) {
+    throw new Error("Failed to get project name for MAP file path.");
+  }
+  const buildDirPath = readParameter("idf.buildPath", workspacePath) as string;
+  if (!buildDirPath) {
+    throw new Error("Failed to get build directory path for MAP file path.");
+  }
+  const mapFilePath = path.join(buildDirPath, `${projectName}.map`);
+  return mapFilePath;
 }
 
 export async function getIdfTargetFromSdkconfig(


### PR DESCRIPTION
## Description

SDK config file resolution should always come from project_description.json if available. Fallback are idf.sdkconfigFilePath (default is empty string) and after is `<project root directory>/sdkconfig`. Remove any CMakeLists.txt parsing logic.

Fixes #1746

## Copilot summary

This pull request refactors how the SDK config file path is determined and accessed across the codebase. The main change is moving the `getSDKConfigFilePath` function from `utils.ts` to `workspaceConfig.ts` and updating its implementation to use information from the project's `project_description.json` when available. This improves accuracy and maintainability. All imports and usages of `getSDKConfigFilePath` have been updated accordingly. Additionally, the project description parsing logic is now centralized and more robust.

**Refactoring and centralization of SDK config file logic:**

* Moved and refactored `getSDKConfigFilePath` from `utils.ts` to `workspaceConfig.ts`, updating its logic to first attempt to read the config file path from `project_description.json` for improved accuracy. The function now returns `undefined` if the workspace path is not provided or if errors occur. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L465-L507) [[2]](diffhunk://#diff-fb0bb13db334c106cb7a2b1b9f36dc4af698b68be775f5ef79d2c03d2d25b862L49-R181)
* Updated all imports and usages of `getSDKConfigFilePath` throughout the codebase to import from `workspaceConfig.ts` instead of `utils.ts`. This affects files such as `buildTask.ts`, `confServerProcess.ts`, `task.ts`, and `extension.ts`. [[1]](diffhunk://#diff-6624d580b86018dd10e272455fb29016ba0dc87bb4a7ab175419f7466ac6daa8L26-R31) [[2]](diffhunk://#diff-0da02128563b2f2fca0f433f5c254fd5922bcb68094e714a9accf7c3a901a7c6L28) [[3]](diffhunk://#diff-0da02128563b2f2fca0f433f5c254fd5922bcb68094e714a9accf7c3a901a7c6R36) [[4]](diffhunk://#diff-f18b1f556fa4a4c6dea7cf7d7ab8cc3fa4a4f6c64126230b7d4c54c18a41aa4eL30-R34) [[5]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R43) [[6]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L3567-R3568) [[7]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L4346-R4345) [[8]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L39-R39)

**Project description handling improvements:**

* Introduced `getProjectDescriptionJson` in `workspaceConfig.ts`, which parses and returns a strongly-typed project description object from `project_description.json`. This centralizes and standardizes access to project metadata.
* Updated `getProjectName` in `workspaceConfig.ts` to use the new `getProjectDescriptionJson` function, improving reliability and error handling when retrieving the project name.
* Added an `IProjectDescription` interface to define the structure of the project description object, improving type safety and code clarity.

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Build your project" or "SDK Configuration editor" and it should work as usual.
2. Use a project that defines SDKCONFIG in CMakelists.txt like [multi_config esp-idf example](https://github.com/espressif/esp-idf/tree/master/examples/build_system/cmake/multi_config) the results should be the same.
3. Observe results.

- Expected behaviour:

SDK config file path is always correct for extension commands.

- Expected output:

Build, SDK Config editor and reconfigure tasks should work as normal.

## How has this been tested?

Manual testing following steps above.

**Test Configuration**:
* ESP-IDF Version: 6.0.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized project/SDK config and artifact path resolution so tools consistently locate sdkconfig, ELF and map files.
  * Safer workspace handling and consolidated project description parsing for name/map/ELF discovery.

* **Bug Fixes**
  * Only add SDKCONFIG compiler arg when a valid config file exists; avoid duplicates and two-token forms.
  * Improved error handling and early returns when ELF/config/python resolution fail; better error messages.
  * GUI/menuconfig flows now guard missing processes, await value loads, and avoid crashes on panel/state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->