### PR TITLE
use env var collection to add env vars to terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1281,6 +1281,8 @@ export async function activate(context: vscode.ExtensionContext) {
           );
         }
       }
+      await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
+      await configureClangSettings(workspaceRoot);
       ESP.URL.Docs.IDF_INDEX = undefined;
     } else if (e.affectsConfiguration("idf.port" + winFlag)) {
       if (statusBarItems && statusBarItems["port"]) {
@@ -1318,9 +1320,6 @@ export async function activate(context: vscode.ExtensionContext) {
       updateIdfComponentsTree(workspaceRoot);
       await configureClangSettings(workspaceRoot);
       handleCompileCommandsUpdate(workspaceRoot, context);
-    } else if (e.affectsConfiguration("idf.customExtraVars")) {
-      await getIdfTargetFromSdkconfig(workspaceRoot, statusBarItems["target"]);
-      await configureClangSettings(workspaceRoot);
     } else if (e.affectsConfiguration("idf.unitTestFilePattern")) {
       const cancelTokenSource = new vscode.CancellationTokenSource();
       try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1268,6 +1268,19 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       }
     } else if (e.affectsConfiguration("idf.customExtraVars")) {
+      const customExtraVars = idfConf.readParameter(
+        "idf.customExtraVars",
+        workspaceRoot
+      ) as { [key: string]: string };
+      for (const envVar in customExtraVars) {
+        if (envVar.toUpperCase() !== "PATH") {
+          context.environmentVariableCollection.replace(
+            envVar,
+            customExtraVars[envVar],
+            { applyAtProcessCreation: true }
+          );
+        }
+      }
       ESP.URL.Docs.IDF_INDEX = undefined;
     } else if (e.affectsConfiguration("idf.port" + winFlag)) {
       if (statusBarItems && statusBarItems["port"]) {


### PR DESCRIPTION
## Description

When `idf.customExtraVars` is updated, we use `context.environmentVariableCollection.replace` to update terminal variables to make sure changes are visible in the terminal

Fixes #1802
Fixes #1809

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request


1. Click on "ESP-IDF: Monitor Device" command after setting adding a new variable to idf.customExtraVars in settings.json.
2. Execute action. See that the terminal does indeed contribute the environment variable doing echo $VARNAME in terminal or using the `Terminal: Show Environment Contributions` VS Code command.
3. Observe results.

- Expected behaviour:

Variables are actually updated in terminal environment.

- Expected output:

Variables are actually updated in terminal environment.

## How has this been tested?

Manual steps as described above.

**Test Configuration**:
* ESP-IDF Version: 5.5.3
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom environment variables so changes in workspace settings now update the editor's environment (excluding PATH) and apply at process-creation time.
  * Automatically refreshes project target detection and C/C++ tooling settings after env updates.
  * Resets local documentation index to ensure docs reflect the latest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->