### PR TITLE
Bugfix/activation script shell

### DIFF
--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -21,7 +21,6 @@ import { IdfSetup } from "./types";
 import { delimiter, join } from "path";
 import { getEnvVariablesFromIdfSetup } from "./migrationTool";
 import { Logger } from "../logger/logger";
-import { env } from "vscode";
 
 export async function getEnvVariables(idfSetup: IdfSetup) {
   if (idfSetup.activationScript) {
@@ -49,7 +48,7 @@ export async function getEnvVariablesFromActivationScript(
     const shellPath =
       process.platform === "win32"
         ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
-        : env.shell;
+        : "/bin/sh";
     const envVarsOutput = await spawn(shellPath, args, {
       maxBuffer: 500 * 1024,
       cwd: process.cwd(),

--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -91,7 +91,7 @@ export async function getEnvVariablesFromActivationScript(
         : "Error getting Env variables from EIM activation script";
     Logger.error(
       errMsg,
-      error as Error, 
+      error as Error,
       "loadSettings getEnvVariablesFromActivationScript",
       undefined,
       false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4273,13 +4273,13 @@ async function createEspIdfTerminal(
   terminalName: string,
   initialCommand?: string,
   location?: vscode.TerminalLocation
-): Promise<vscode.Terminal> {
+) {
   const shellExecutableArgs = idfConf.readParameter(
     "idf.customTerminalExecutableArgs",
     workspaceRoot
   ) as string[];
   const modifiedEnv = await configureEnvVariables(workspaceRoot);
-  let shellArgs = [];
+  let shellArgs: string[] = [];
   if (process.platform === "win32") {
     shellArgs = ["-ExecutionPolicy", "Bypass"];
   } else if (shellExecutableArgs && shellExecutableArgs.length) {
@@ -4294,8 +4294,17 @@ async function createEspIdfTerminal(
       ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
       : shellExecutablePath
       ? shellExecutablePath
-      : vscode.env.shell;
+      : "/bin/sh";
 
+  const currentSetup = await loadIdfSetup(workspaceRoot);
+  if (!currentSetup) {
+    Logger.errorNotify(
+      vscode.l10n.t("Failed to load ESP-IDF setup for terminal activation"),
+      new Error("ESP-IDF setup load failed"),
+      "extension createEspIdfTerminal load setup"
+    );
+    return;
+  }
   const espIdfTerminal = vscode.window.createTerminal({
     name: terminalName,
     env: modifiedEnv,
@@ -4305,8 +4314,6 @@ async function createEspIdfTerminal(
     shellPath,
     location,
   });
-
-  const currentSetup = await loadIdfSetup(workspaceRoot);
   const activationScriptPathExists = await pathExists(
     currentSetup.activationScript
   );


### PR DESCRIPTION
## Description

Use `/bin/sh` on MacOS and Linux instead of vscode.env.shell.

Fixes #1780

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Use FISH as VS Code selected terminal with `Terminal: Select Default Profile` command.

1. Click on "ESP-IDF: Select Current ESP-IDF Version" and choose any EIM created ESP-IDF setup.
2. Execute action. The activation script environment variables should be shown in `ESP-IDF` output channel.
3. Observe results.

- Expected behaviour:

the extension should activate regardless of current vscode selected terminal.

- Expected output:

## How has this been tested?

Manual test based on steps above.

**Test Configuration**:
* ESP-IDF Version: 6.0.0
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Non-Windows activation shell selection now uses a fixed /bin/sh instead of the environment shell.
* **Bug Fixes**
  * Terminal creation now aborts and shows an error notification if required setup is not available, preventing a partially-initialized terminal.
* **Stability**
  * Minor internal typing and import cleanup to reduce runtime inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->