### PR TITLE
fix(langTools): avoid awaiting terminal focus over Remote SSH

### DIFF
--- a/src/langTools/index.ts
+++ b/src/langTools/index.ts
@@ -596,7 +596,7 @@ export function activateLanguageTool(context: vscode.ExtensionContext) {
 
 async function focusOnAppropriateOutput(commandName: string): Promise<void> {
   if (TASK_COMMANDS.has(commandName)) {
-    await focusOnTerminal();
+    void focusOnTerminal();
   } else {
     OutputChannel.show();
   }


### PR DESCRIPTION
## Description

Stop awaiting workbench.action.terminal.focus before ESP-IDF LM tool tasks run, trigger focus without blocking the invoke path.

With Remote SSH, focusing the terminal is a UI command handled on the local window while extension logic runs on the remote host. Awaiting it can delay or stall language-model tool invocations (e.g. Copilot Agent) even though the underlying build still completes.

Fixes #[1825](https://github.com/espressif/vscode-esp-idf-extension/issues/1825)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal focus operations for improved responsiveness and application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->