### PR TITLE
[VSC-1928]fix: use python3 binary name consistently for venv on Linux/macOS

### DIFF
--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -19,6 +19,7 @@
 import { spawn } from "../utils";
 import { IdfSetup } from "./types";
 import { delimiter, join } from "path";
+import { pathExists } from "fs-extra";
 import { getEnvVariablesFromIdfSetup } from "./migrationTool";
 import { Logger } from "../logger/logger";
 
@@ -78,7 +79,12 @@ export async function getEnvVariablesFromActivationScript(
       process.platform === "win32"
         ? ["Scripts", "python.exe"]
         : ["bin", "python3"];
-    envDict["PYTHON"] = join(envDict["IDF_PYTHON_ENV_PATH"], ...pyDir);
+    const python3Path = join(envDict["IDF_PYTHON_ENV_PATH"], ...pyDir);
+    if (process.platform !== "win32" && !(await pathExists(python3Path))) {
+      envDict["PYTHON"] = join(envDict["IDF_PYTHON_ENV_PATH"], "bin", "python");
+    } else {
+      envDict["PYTHON"] = python3Path;
+    }
 
     return envDict;
   } catch (error) {

--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -77,7 +77,7 @@ export async function getEnvVariablesFromActivationScript(
     const pyDir =
       process.platform === "win32"
         ? ["Scripts", "python.exe"]
-        : ["bin", "python"];
+        : ["bin", "python3"];
     envDict["PYTHON"] = join(envDict["IDF_PYTHON_ENV_PATH"], ...pyDir);
 
     return envDict;

--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -93,9 +93,11 @@ export async function getEnvVariablesFromActivationScript(
         "bin",
         "python3"
       );
-      envDict["PYTHON"] = (await pathExists(pythonPath))
-        ? pythonPath
-        : python3Path;
+      if (await pathExists(pythonPath)) {
+        envDict["PYTHON"] = pythonPath;
+      } else if (await pathExists(python3Path)) {
+        envDict["PYTHON"] = python3Path;
+      }
     }
 
     return envDict;

--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -75,15 +75,27 @@ export async function getEnvVariablesFromActivationScript(
         .replace(new RegExp(`(^${delimiter}|${delimiter}$)`, "g"), "");
     }
 
-    const pyDir =
-      process.platform === "win32"
-        ? ["Scripts", "python.exe"]
-        : ["bin", "python3"];
-    const python3Path = join(envDict["IDF_PYTHON_ENV_PATH"], ...pyDir);
-    if (process.platform !== "win32" && !(await pathExists(python3Path))) {
-      envDict["PYTHON"] = join(envDict["IDF_PYTHON_ENV_PATH"], "bin", "python");
+    if (process.platform === "win32") {
+      envDict["PYTHON"] = join(
+        envDict["IDF_PYTHON_ENV_PATH"],
+        "Scripts",
+        "python.exe"
+      );
     } else {
-      envDict["PYTHON"] = python3Path;
+      // Prefer 'python' to match the EIM activation script, which hardcodes
+      // /venv/bin/python in the idf.py shell function. idf.py caches
+      // sys.executable at cmake configure time, so the binary name used here
+      // must match the one the activation script invokes, otherwise every
+      // terminal run produces a "python/python3 mismatch" error.
+      const pythonPath = join(envDict["IDF_PYTHON_ENV_PATH"], "bin", "python");
+      const python3Path = join(
+        envDict["IDF_PYTHON_ENV_PATH"],
+        "bin",
+        "python3"
+      );
+      envDict["PYTHON"] = (await pathExists(pythonPath))
+        ? pythonPath
+        : python3Path;
     }
 
     return envDict;

--- a/src/eim/migrationTool.ts
+++ b/src/eim/migrationTool.ts
@@ -87,7 +87,17 @@ export async function getPythonEnvPath(
       : ["bin", "python3"];
   const fullIdfPyEnvPath = join(idfPyEnvPath, ...pyDir);
   const pyEnvPathExists = await pathExists(fullIdfPyEnvPath);
-  return pyEnvPathExists ? fullIdfPyEnvPath : "";
+  if (pyEnvPathExists) {
+    return fullIdfPyEnvPath;
+  }
+  if (process.platform !== "win32") {
+    const pythonFallback = join(idfPyEnvPath, "bin", "python");
+    const pythonFallbackExists = await pathExists(pythonFallback);
+    if (pythonFallbackExists) {
+      return pythonFallback;
+    }
+  }
+  return "";
 }
 
 export async function getEnvVariablesFromIdfSetup(idfSetup: IdfSetup) {

--- a/src/eim/migrationTool.ts
+++ b/src/eim/migrationTool.ts
@@ -84,7 +84,7 @@ export async function getPythonEnvPath(
   const pyDir =
     process.platform === "win32"
       ? ["Scripts", "python.exe"]
-      : ["bin", "python"];
+      : ["bin", "python3"];
   const fullIdfPyEnvPath = join(idfPyEnvPath, ...pyDir);
   const pyEnvPathExists = await pathExists(fullIdfPyEnvPath);
   return pyEnvPathExists ? fullIdfPyEnvPath : "";

--- a/src/eim/migrationTool.ts
+++ b/src/eim/migrationTool.ts
@@ -81,23 +81,20 @@ export async function getPythonEnvPath(
     idfToolsDir,
     pythonBin
   );
-  const pyDir =
-    process.platform === "win32"
-      ? ["Scripts", "python.exe"]
-      : ["bin", "python3"];
-  const fullIdfPyEnvPath = join(idfPyEnvPath, ...pyDir);
-  const pyEnvPathExists = await pathExists(fullIdfPyEnvPath);
-  if (pyEnvPathExists) {
-    return fullIdfPyEnvPath;
+  if (process.platform === "win32") {
+    const winPythonPath = join(idfPyEnvPath, "Scripts", "python.exe");
+    return (await pathExists(winPythonPath)) ? winPythonPath : "";
   }
-  if (process.platform !== "win32") {
-    const pythonFallback = join(idfPyEnvPath, "bin", "python");
-    const pythonFallbackExists = await pathExists(pythonFallback);
-    if (pythonFallbackExists) {
-      return pythonFallback;
-    }
+  // Prefer 'python' to stay consistent with the EIM activation script, which
+  // hardcodes /venv/bin/python in its idf.py shell function. idf.py records
+  // sys.executable in CMakeCache at configure time, so using a different name
+  // on re-runs causes a "python/python3 mismatch" error.
+  const pythonPath = join(idfPyEnvPath, "bin", "python");
+  if (await pathExists(pythonPath)) {
+    return pythonPath;
   }
-  return "";
+  const python3Path = join(idfPyEnvPath, "bin", "python3");
+  return (await pathExists(python3Path)) ? python3Path : "";
 }
 
 export async function getEnvVariablesFromIdfSetup(idfSetup: IdfSetup) {

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -116,16 +116,15 @@ export function getVirtualEnvPythonPath() {
   const currentEnvVars = ESP.ProjectConfiguration.store.get<{
     [key: string]: string;
   }>(ESP.ProjectConfiguration.CURRENT_IDF_CONFIGURATION, {});
+  if (currentEnvVars["PYTHON"]) {
+    return currentEnvVars["PYTHON"];
+  }
   if (currentEnvVars["IDF_PYTHON_ENV_PATH"]) {
     const pyDir =
       process.platform === "win32"
         ? ["Scripts", "python.exe"]
         : ["bin", "python3"];
-    const venvPythonPath = join(
-      currentEnvVars["IDF_PYTHON_ENV_PATH"],
-      ...pyDir
-    );
-    return venvPythonPath;
+    return join(currentEnvVars["IDF_PYTHON_ENV_PATH"], ...pyDir);
   }
 }
 

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -14,7 +14,7 @@
 
 import { CancellationToken } from "vscode";
 import * as utils from "./utils";
-import { pathExists } from "fs-extra";
+import { pathExists, pathExistsSync } from "fs-extra";
 import { Logger } from "./logger/logger";
 import { join } from "path";
 import { OutputChannel } from "./logger/outputChannel";
@@ -120,11 +120,17 @@ export function getVirtualEnvPythonPath() {
     return currentEnvVars["PYTHON"];
   }
   if (currentEnvVars["IDF_PYTHON_ENV_PATH"]) {
-    const pyDir =
-      process.platform === "win32"
-        ? ["Scripts", "python.exe"]
-        : ["bin", "python"];
-    return join(currentEnvVars["IDF_PYTHON_ENV_PATH"], ...pyDir);
+    if (process.platform === "win32") {
+      return join(currentEnvVars["IDF_PYTHON_ENV_PATH"], "Scripts", "python.exe");
+    }
+    const pythonPath = join(currentEnvVars["IDF_PYTHON_ENV_PATH"], "bin", "python");
+    if (pathExistsSync(pythonPath)) {
+      return pythonPath;
+    }
+    const python3Path = join(currentEnvVars["IDF_PYTHON_ENV_PATH"], "bin", "python3");
+    if (pathExistsSync(python3Path)) {
+      return python3Path;
+    }
   }
 }
 

--- a/src/pythonManager.ts
+++ b/src/pythonManager.ts
@@ -123,7 +123,7 @@ export function getVirtualEnvPythonPath() {
     const pyDir =
       process.platform === "win32"
         ? ["Scripts", "python.exe"]
-        : ["bin", "python3"];
+        : ["bin", "python"];
     return join(currentEnvVars["IDF_PYTHON_ENV_PATH"], ...pyDir);
   }
 }


### PR DESCRIPTION
## Description

Fix Python binary naming inconsistency (`python` vs `python3`) in virtual environments on Linux/macOS that caused idf.py to abort with a cmake cache mismatch error.

**Root cause:** idf.py records `sys.executable` into `CMakeCache['PYTHON']` at configure time and asserts it matches `sys.executable` on every subsequent run. Both `venv/bin/python` and `venv/bin/python3` are symlinks to the same binary, but the path string comparison treats them as different. The EIM activation script hardcodes `venv/bin/python` in the `idf.py` shell function it generates, while the extension was deriving `venv/bin/python3` from `IDF_PYTHON_ENV_PATH`. This caused the mismatch:

> `'.../venv/bin/python' is currently active in the environment while the project was configured with '.../venv/bin/python3'. Run 'idf.py fullclean' to start again.`

**Fix:** Align the extension with the EIM activation script by preferring `bin/python` over `bin/python3` when deriving the venv Python path in `getEnvVariablesFromActivationScript`, `getPythonEnvPath`, and the `IDF_PYTHON_ENV_PATH` fallback in `getVirtualEnvPythonPath`. A `bin/python3` fallback is retained for venvs that lack the `python` symlink. `getVirtualEnvPythonPath` is also updated to read the stored `PYTHON` value directly from the project configuration, so the binary name used during build and during menuconfig/confserver is always the same.

**Note:** Projects previously configured with `python3` in CMakeCache will need a one-time `idf.py fullclean` after upgrading.

Fixes [#18573
](https://github.com/espressif/vscode-esp-idf-extension/issues/1841)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

**Prerequisites:** Linux, ESP-IDF installed via EIM (ESP-IDF Installation Manager).

1. Open a project in VS Code with the ESP-IDF extension configured via EIM.
2. Click the **Build** button in the status bar (or run `ESP-IDF: Build your project`).
3. Wait for the build to complete successfully.
4. Without running `idf.py fullclean`, click the **SDK Configuration Editor** button (menuconfig) in the status bar.

- **Expected behaviour:** Menuconfig opens without errors after a build, and build succeeds after closing menuconfig, in any order, without requiring a `fullclean` between them.
- **Expected output:** No `"currently active in the environment while the project was configured with"` error in the ESP-IDF output channel.

## How has this been tested?

As described above.

**Test Configuration**:
* ESP-IDF Version: doesn't matter
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python environment detection on non-Windows by checking whether the expected interpreter exists before using it, with a preference order between `python` and `python3` and a safe fallback.
  * Virtual environment resolution now honors an explicitly set `PYTHON` environment value when available, improving consistency and reducing misdetection.
  * Windows behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->