### PR TITLE
[VSC-1931] fix: Preserve user custom args in idf.eimExecutableArgs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4471,7 +4471,7 @@ async function ensureEimAndLaunch(workspaceRoot: vscode.Uri) {
       }
 
       const mode = canLaunchGui ? "gui" : "wizard";
-      const raw = vscode.workspace.getConfiguration("").get<string[]>("idf.eimExecutableArgs");
+      const raw = idfConf.readParameter("idf.eimExecutableArgs");
       const existing = Array.isArray(raw) ? raw : [];
       const merged = [mode, "--idf-features ide", ...existing.filter(
         arg => arg !== "gui" && arg !== "wizard" && arg !== "--idf-features ide"
@@ -4498,7 +4498,7 @@ async function showSnapEimNotification(eimPath: string) {
   );
 
   if (action === runCliLabel) {
-    const raw = vscode.workspace.getConfiguration("").get<string[]>("idf.eimExecutableArgs");
+    const raw = idfConf.readParameter("idf.eimExecutableArgs");
     const existing = Array.isArray(raw) ? raw : [];
     const merged = ["wizard", "--idf-features ide", ...existing.filter(
       arg => arg !== "gui" && arg !== "wizard" && arg !== "--idf-features ide"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4470,14 +4470,13 @@ async function ensureEimAndLaunch(workspaceRoot: vscode.Uri) {
         );
       }
 
-      const argsValue = canLaunchGui
-        ? ["gui", "--idf-features ide"]
-        : ["wizard", "--idf-features ide"];
-      await idfConf.writeParameter(
-        "idf.eimExecutableArgs",
-        argsValue,
-        vscode.ConfigurationTarget.Global
-      );
+      const mode = canLaunchGui ? "gui" : "wizard";
+      const raw = vscode.workspace.getConfiguration("").get<string[]>("idf.eimExecutableArgs");
+      const existing = Array.isArray(raw) ? raw : [];
+      const merged = [mode, "--idf-features ide", ...existing.filter(
+        arg => arg !== "gui" && arg !== "wizard" && arg !== "--idf-features ide"
+      )];
+      await idfConf.writeParameter("idf.eimExecutableArgs", merged, vscode.ConfigurationTarget.Global);
       await launchEimInTerminal(eimPath);
     }
   );
@@ -4499,11 +4498,12 @@ async function showSnapEimNotification(eimPath: string) {
   );
 
   if (action === runCliLabel) {
-    await idfConf.writeParameter(
-      "idf.eimExecutableArgs",
-      ["wizard", "--idf-features ide"],
-      vscode.ConfigurationTarget.Global
-    );
+    const raw = vscode.workspace.getConfiguration("").get<string[]>("idf.eimExecutableArgs");
+    const existing = Array.isArray(raw) ? raw : [];
+    const merged = ["wizard", "--idf-features ide", ...existing.filter(
+      arg => arg !== "gui" && arg !== "wizard" && arg !== "--idf-features ide"
+    )];
+    await idfConf.writeParameter("idf.eimExecutableArgs", merged, vscode.ConfigurationTarget.Global);
     await launchEimInTerminal(eimPath);
   } else if (action === copyPathLabel) {
     await vscode.env.clipboard.writeText(eimPath);


### PR DESCRIPTION
## Description

Fixes #1843

This issue was introduced at the beginning: #1786

The following two issue have been found:
- `ensureEimAndLaunch`
- `showSnapEimNotification` (when clicking "Run in Terminal" in the Snap pop-up)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Add:
```json
    "idf.eimExecutableArgs": [
        "wizard",
        "--idf-features ide",
        "--skip-prerequisites-check true"
    ],
```
in VSCode settings

2. Click on Open EIM in Sidebar
<img width="404" height="503" alt="image" src="https://github.com/user-attachments/assets/bb5bcc69-8a44-49b0-9d2c-c75fe792db5e" />

3. Observe results.

- Expected behaviour:
`idf.eimExecutableArgs` was applied correctly.

## How has this been tested?

**Test Configuration**:
* ESP-IDF Version: unrelated
* OS (Windows,Linux and macOS): Linux

## Dependent components impacted by this PR:

unrelated

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation (unrelated)
- [ ] Added Unit Test (unrelated)
- [ ] Verified on all platforms - Windows,Linux and macOS (unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The ESP-IDF Install Manager launcher now preserves and merges any existing install arguments with required options instead of overwriting them, so user-configured preferences are retained.
  * The same merge behavior was added to the Snap "Run in Terminal" path, ensuring terminal launches also keep prior settings and required options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/vscode-esp-idf-extension/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->