### PR TITLE
fix(esp_adf):picks adf_examples if present else falls back to examples

### DIFF
--- a/src/newProject/newProjectInit.ts
+++ b/src/newProject/newProjectInit.ts
@@ -97,8 +97,12 @@ export async function getNewProjectArgs(
   }
   const adfExists = await dirExistPromise(espAdfPath);
   if (adfExists) {
-    const adfTemplates = getExamplesList(espAdfPath);
-    templates["ESP-ADF"] = adfTemplates;
+    const adfExamplesDir = (await dirExistPromise(
+      join(espAdfPath, "adf_examples")
+    ))
+      ? "adf_examples"
+      : "examples";
+    templates["ESP-ADF"] = getExamplesList(espAdfPath, [adfExamplesDir]);
   }
 
   const targetsFromIdf = await getTargetsFromEspIdf(


### PR DESCRIPTION
## Description

With [this](https://github.com/espressif/esp-adf/commit/0b0ca42c73a592da4bb7df3acf4e784c5d8c7c5e) examples has renamed to adf_examples on the master.

so the pr changes, picks adf_examples if present else falls back to examples

Fixes #1847 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Steps to test this pull request

1. setup esp-adf and create a new project

- Expected behaviour:
It should create a project without any error reported here #1847 

- Expected output:

## How has this been tested?



**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP-ADF project template initialization to correctly locate and load project examples from the appropriate directory structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/vscode-esp-idf-extension/pull/1848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->