### PR TITLE
Run UI Tests on Self-Hosted Runner

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ui_test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, BrnoUBU0004]
 
     steps:
       - uses: actions/checkout@v6
@@ -32,10 +32,11 @@ jobs:
           yarn
           yarn install
 
-      - name: Run End to End tests script with xvfb
-        run: xvfb-run --auto-servernum yarn ci-test
+      - name: Run End to End tests script
+        run: yarn ci-test
 
       - name: Print UI Test Results
+        if: always()
         run: |
           echo "=== UI Test Results ==="
           if [ -f "./reports/ui-test-results.json" ]; then

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install ESP-IDF
         uses: espressif/install-esp-idf-action@v1
         with:
-          version: "v5.4.2"
+          version: "v5.4"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ui_test:
-    runs-on: [self-hosted, BrnoUBU0004]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -32,11 +32,10 @@ jobs:
           yarn
           yarn install
 
-      - name: Run End to End tests script
-        run: yarn ci-test
+      - name: Run End to End tests script with xvfb
+        run: xvfb-run --auto-servernum yarn ci-test
 
       - name: Print UI Test Results
-        if: always()
         run: |
           echo "=== UI Test Results ==="
           if [ -f "./reports/ui-test-results.json" ]; then
@@ -68,6 +67,68 @@ jobs:
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: failure()
-        with: 
+        with:
           name: screenshots
+          path: ./test-resources/screenshots
+
+  ui_hardware_flash_test:
+    runs-on: [self-hosted, BrnoUBU0004]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
+
+      - name: Install ESP-IDF
+        uses: espressif/install-esp-idf-action@v1
+        with:
+          version: "v5.4"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install Yarn dependencies
+        run: |
+          yarn
+          yarn install
+
+      - name: Run hardware flash UI test
+        run: yarn ci-test-flash
+
+      - name: Print UI Hardware Flash Test Results
+        if: always()
+        run: |
+          echo "=== UI Hardware Flash Test Results ==="
+          if [ -f "./reports/ui-test-hardware-results.json" ]; then
+            echo "UI Hardware Flash Test Results:"
+            cat ./reports/ui-test-hardware-results.json | jq '.' || echo "Could not parse UI hardware flash test results"
+          else
+            echo "No UI hardware flash test results file found"
+            find . -name "*hardware*results*" | head -10
+          fi
+
+      - name: Publish UI Hardware Flash Test Report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: UI Hardware Flash Tests
+          path: ./reports/ui-test-hardware-results.json
+          reporter: mocha-json
+
+      - name: Upload UI hardware flash test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ui-hardware-flash-test-results
+          path: |
+            ./reports/ui-test-hardware-results.json
+            ./test-resources/screenshots/
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ui-hardware-flash-test-screenshots
           path: ./test-resources/screenshots

--- a/package.json
+++ b/package.json
@@ -2599,8 +2599,9 @@
     "clean": "node clean.js",
     "genLocalizationBundle": "npx @vscode/l10n-dev export --outDir ./l10n ./src",
     "webpack": "webpack --mode production",
-    "ui-test": "yarn compile && extest setup-and-run -y -i -u -l DEBUG -o testFiles/testWorkspace/.vscode/settings.json 'out/ui-test/*-test.js'",
-    "ci-test": "yarn compile && extest setup-and-run './out/ui-test/*-test.js' -u -s test-resources -c min -o testFiles/testWorkspace/.vscode/settings.json -l DEBUG -m ./src/ui-test/.mocharc-ci.js"
+    "ui-test": "yarn compile && extest setup-and-run -y -i -u -l DEBUG -o testFiles/testWorkspace/.vscode/settings.json out/ui-test/project-build-test.js out/ui-test/project-menuconfig-test.js out/ui-test/project-test.js",
+    "ci-test": "yarn compile && extest setup-and-run out/ui-test/project-build-test.js out/ui-test/project-menuconfig-test.js out/ui-test/project-test.js -u -s test-resources -c min -o testFiles/testWorkspace/.vscode/settings.json -l DEBUG -m ./src/ui-test/.mocharc-ci.js",
+    "ci-test-flash": "IDF_UI_TEST_SERIAL_PORT=/dev/ttyUSB1 yarn compile && extest setup-and-run out/ui-test/project-flash-test.js -u -s test-resources -c min -o testFiles/testWorkspace/.vscode/settings.json -l DEBUG -m ./src/ui-test/.mocharc-ci-flash.js"
   },
   "devDependencies": {
     "@babel/types": "^7.23.0",

--- a/src/ui-test/.mocharc-ci-flash.js
+++ b/src/ui-test/.mocharc-ci-flash.js
@@ -1,0 +1,7 @@
+module.exports = {
+  timeout: 99999999,
+  reporter: 'json',
+  'reporter-option': {
+    output: './reports/ui-test-hardware-results.json'
+  }
+};

--- a/src/ui-test/project-build-test.ts
+++ b/src/ui-test/project-build-test.ts
@@ -25,6 +25,7 @@ import {
 import { expect } from "chai";
 import { resolve } from "path";
 import { pathExists } from "fs-extra";
+import { openTestProject } from "./ui-test-helpers";
 
 describe("Build testing", async () => {
   let panel: BottomBarPanel;
@@ -102,20 +103,3 @@ describe("Build testing", async () => {
     expect(componentSrcPathExists).to.be.true;
   }).timeout(999999);
 });
-
-export async function openTestProject() {
-  await new Promise((res) => setTimeout(res, 5000));
-  await new Workbench().executeCommand("file: open folder");
-  const testWorkspaceDir = resolve(
-    __dirname,
-    "..",
-    "..",
-    "testFiles",
-    "testWorkspace"
-  );
-  await new Promise((res) => setTimeout(res, 1000));
-  const input = await InputBox.create();
-  await input.setText(testWorkspaceDir);
-  await input.confirm();
-  await new Promise((res) => setTimeout(res, 4000));
-}

--- a/src/ui-test/project-flash-test.ts
+++ b/src/ui-test/project-flash-test.ts
@@ -1,0 +1,189 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Thursday, 28th May 2026
+ * Copyright 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+import { pathExists } from "fs-extra";
+import { resolve } from "path";
+import {
+  BottomBarPanel,
+  By,
+  EditorView,
+  InputBox,
+  WebView,
+  Workbench,
+} from "vscode-extension-tester";
+
+const containerPath = resolve(__dirname, "..", "..", "testFiles");
+const projectName = "testWorkspaceFlash";
+const projectPath = resolve(containerPath, projectName);
+const helloWorldBinPath = resolve(projectPath, "build", `${projectName}.bin`);
+const serialPort = process.env.IDF_UI_TEST_SERIAL_PORT ?? "/dev/ttyUSB1";
+
+const FLASH_SUCCESS_PATTERN =
+  /Hash of data verified|Flash Done|Hard resetting via RTS pin/;
+
+async function dismissNotifications(): Promise<void> {
+  const notifications = await new Workbench().getNotifications();
+  for (const notification of notifications) {
+    await notification.dismiss();
+  }
+}
+
+async function selectQuickPickOption(
+  command: string,
+  option: string | number
+): Promise<void> {
+  await new Workbench().executeCommand(command);
+  await new Promise((res) => setTimeout(res, 2000));
+  const inputBox = await InputBox.create();
+  await inputBox.selectQuickPick(option);
+  await new Promise((res) => setTimeout(res, 1000));
+}
+
+async function confirmProjectOverwriteIfNeeded(): Promise<void> {
+  const notifications = await new Workbench().getNotifications();
+  for (const notification of notifications) {
+    const message = await notification.getMessage();
+    if (message.includes("already exists")) {
+      await notification.takeAction("Yes");
+      await new Promise((res) => setTimeout(res, 2000));
+      return;
+    }
+  }
+}
+
+async function waitForTerminalOutput(
+  pattern: RegExp,
+  timeoutMs: number
+): Promise<string> {
+  const panel = new BottomBarPanel();
+  const terminalView = await panel.openTerminalView();
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const text = await terminalView.getText();
+    if (pattern.test(text)) {
+      return text;
+    }
+    await new Promise((res) => setTimeout(res, 5000));
+  }
+
+  const text = await terminalView.getText();
+  throw new Error(
+    `Timed out waiting for terminal output matching ${pattern}. Last output:\n${text}`
+  );
+}
+
+describe("Flash testing", () => {
+  let view: WebView | undefined;
+
+  before(async function () {
+    this.timeout(120000);
+    await dismissNotifications();
+    await new Workbench().executeCommand("espIdf.newProject.start");
+    const inputBox = await InputBox.create();
+    await inputBox.selectQuickPick(0);
+    await new Promise((res) => setTimeout(res, 2000));
+    view = new WebView();
+    await view.switchToFrame();
+  });
+
+  after(async () => {
+    if (view) {
+      await view.switchBack();
+    }
+    await new EditorView().closeAllEditors();
+  });
+
+  it("creates the hello_world example project", async () => {
+    const espIdfSection = await view!.findWebElement(
+      By.xpath(`.//div[@data-node-name='ESP-IDF Examples']`)
+    );
+    await espIdfSection.click();
+    await new Promise((res) => setTimeout(res, 1000));
+
+    const getStartedSection = await view!.findWebElement(
+      By.xpath(`.//div[@data-node-name='get-started']`)
+    );
+    await getStartedSection.click();
+    await new Promise((res) => setTimeout(res, 1000));
+
+    const helloWorldExample = await view!.findWebElement(
+      By.xpath(`.//div[@data-example-id='hello_world']`)
+    );
+    await helloWorldExample.click();
+    await new Promise((res) => setTimeout(res, 3000));
+
+    const chooseTemplateButton = await view!.findWebElement(
+      By.id("chooseTemplateButton")
+    );
+    expect(await chooseTemplateButton.getText()).to.include(
+      "Create project using template hello_world"
+    );
+    await chooseTemplateButton.click();
+    await new Promise((res) => setTimeout(res, 2000));
+
+    const projectDirInput = await view!.findWebElement(By.id("projectDirectory"));
+    await projectDirInput.clear();
+    await projectDirInput.sendKeys(containerPath);
+    const projectNameInput = await view!.findWebElement(By.id("projectName"));
+    await projectNameInput.clear();
+    await projectNameInput.sendKeys(projectName);
+
+    const createProjectButton = await view!.findWebElement(
+      By.id("createProjectButton")
+    );
+    await createProjectButton.click();
+    await confirmProjectOverwriteIfNeeded();
+    await new Promise((res) => setTimeout(res, 15000));
+
+    const openProjectButton = await view!.findWebElement(
+      By.xpath(`//button[contains(.,'Open Project')]`)
+    );
+    await openProjectButton.click();
+    await new Promise((res) => setTimeout(res, 8000));
+
+    expect(await pathExists(projectPath)).to.be.true;
+    expect(await pathExists(helloWorldBinPath)).to.be.false;
+  }).timeout(120000);
+
+  it("builds, configures UART flash, and flashes the project", async () => {
+    if (view) {
+      await view.switchBack();
+      view = undefined;
+    }
+    await dismissNotifications();
+    await new Promise((res) => setTimeout(res, 5000));
+
+    await new Workbench().executeCommand("ESP-IDF: Build your Project");
+    await new Promise((res) => setTimeout(res, 150000));
+
+    expect(await pathExists(helloWorldBinPath)).to.be.true;
+
+    await selectQuickPickOption("espIdf.selectPort", serialPort);
+    await selectQuickPickOption("espIdf.selectFlashMethodAndFlash", "UART");
+
+    await new Workbench().executeCommand("espIdf.flashDevice");
+    const terminalOutput = await waitForTerminalOutput(
+      FLASH_SUCCESS_PATTERN,
+      180000
+    );
+    console.log(terminalOutput);
+    expect(FLASH_SUCCESS_PATTERN.test(terminalOutput)).to.be.true;
+  }).timeout(999999);
+});

--- a/src/ui-test/project-flash-test.ts
+++ b/src/ui-test/project-flash-test.ts
@@ -19,12 +19,14 @@
 import { expect } from "chai";
 import { pathExists } from "fs-extra";
 import { resolve } from "path";
+import { BottomBarPanel, Workbench } from "vscode-extension-tester";
 import {
-  BottomBarPanel,
-  InputBox,
-  Workbench,
-} from "vscode-extension-tester";
-import { openTestProject, testWorkspaceDir } from "./ui-test-helpers";
+  ESP_IDF_COMMANDS,
+  executeEspIdfCommand,
+  executeEspIdfCommandAndSelectOption,
+  openTestProject,
+  testWorkspaceDir,
+} from "./ui-test-helpers";
 
 const helloWorldBinPath = resolve(
   testWorkspaceDir,
@@ -41,17 +43,6 @@ async function dismissNotifications(): Promise<void> {
   for (const notification of notifications) {
     await notification.dismiss();
   }
-}
-
-async function selectQuickPickOption(
-  command: string,
-  option: string | number
-): Promise<void> {
-  await new Workbench().executeCommand(command);
-  await new Promise((res) => setTimeout(res, 2000));
-  const inputBox = await InputBox.create();
-  await inputBox.selectQuickPick(option);
-  await new Promise((res) => setTimeout(res, 1000));
 }
 
 async function waitForTerminalOutput(
@@ -85,17 +76,23 @@ describe("Flash testing", () => {
 
   it("builds, configures UART flash, and flashes testWorkspace", async () => {
     await new Promise((res) => setTimeout(res, 3000));
-    await new Workbench().executeCommand("ESP-IDF: Full Clean Project");
+    await executeEspIdfCommand(ESP_IDF_COMMANDS.fullClean);
     await new Promise((res) => setTimeout(res, 10000));
-    await new Workbench().executeCommand("ESP-IDF: Build your Project");
+    await executeEspIdfCommand(ESP_IDF_COMMANDS.build);
     await new Promise((res) => setTimeout(res, 150000));
 
     expect(await pathExists(helloWorldBinPath)).to.be.true;
 
-    await selectQuickPickOption("ESP-IDF: Select Port to Use", serialPort);
-    await selectQuickPickOption("ESP-IDF: Select Flash Method", "UART");
+    await executeEspIdfCommandAndSelectOption(
+      ESP_IDF_COMMANDS.selectPort,
+      serialPort
+    );
+    await executeEspIdfCommandAndSelectOption(
+      ESP_IDF_COMMANDS.selectFlashMethod,
+      "UART"
+    );
 
-    await new Workbench().executeCommand("ESP-IDF: Flash Your Project");
+    await executeEspIdfCommand(ESP_IDF_COMMANDS.flash);
     const terminalOutput = await waitForTerminalOutput(
       FLASH_SUCCESS_PATTERN,
       180000

--- a/src/ui-test/project-flash-test.ts
+++ b/src/ui-test/project-flash-test.ts
@@ -21,17 +21,16 @@ import { pathExists } from "fs-extra";
 import { resolve } from "path";
 import {
   BottomBarPanel,
-  By,
-  EditorView,
   InputBox,
-  WebView,
   Workbench,
 } from "vscode-extension-tester";
+import { openTestProject, testWorkspaceDir } from "./ui-test-helpers";
 
-const containerPath = resolve(__dirname, "..", "..", "testFiles");
-const projectName = "testWorkspaceFlash";
-const projectPath = resolve(containerPath, projectName);
-const helloWorldBinPath = resolve(projectPath, "build", `${projectName}.bin`);
+const helloWorldBinPath = resolve(
+  testWorkspaceDir,
+  "build",
+  "hello-world.bin"
+);
 const serialPort = process.env.IDF_UI_TEST_SERIAL_PORT ?? "/dev/ttyUSB1";
 
 const FLASH_SUCCESS_PATTERN =
@@ -53,18 +52,6 @@ async function selectQuickPickOption(
   const inputBox = await InputBox.create();
   await inputBox.selectQuickPick(option);
   await new Promise((res) => setTimeout(res, 1000));
-}
-
-async function confirmProjectOverwriteIfNeeded(): Promise<void> {
-  const notifications = await new Workbench().getNotifications();
-  for (const notification of notifications) {
-    const message = await notification.getMessage();
-    if (message.includes("already exists")) {
-      await notification.takeAction("Yes");
-      await new Promise((res) => setTimeout(res, 2000));
-      return;
-    }
-  }
 }
 
 async function waitForTerminalOutput(
@@ -90,86 +77,16 @@ async function waitForTerminalOutput(
 }
 
 describe("Flash testing", () => {
-  let view: WebView | undefined;
-
   before(async function () {
-    this.timeout(120000);
+    this.timeout(100000);
     await dismissNotifications();
-    await new Workbench().executeCommand("espIdf.newProject.start");
-    const inputBox = await InputBox.create();
-    await inputBox.selectQuickPick(0);
-    await new Promise((res) => setTimeout(res, 2000));
-    view = new WebView();
-    await view.switchToFrame();
+    await openTestProject();
   });
 
-  after(async () => {
-    if (view) {
-      await view.switchBack();
-    }
-    await new EditorView().closeAllEditors();
-  });
-
-  it("creates the hello_world example project", async () => {
-    const espIdfSection = await view!.findWebElement(
-      By.xpath(`.//div[@data-node-name='ESP-IDF Examples']`)
-    );
-    await espIdfSection.click();
-    await new Promise((res) => setTimeout(res, 1000));
-
-    const getStartedSection = await view!.findWebElement(
-      By.xpath(`.//div[@data-node-name='get-started']`)
-    );
-    await getStartedSection.click();
-    await new Promise((res) => setTimeout(res, 1000));
-
-    const helloWorldExample = await view!.findWebElement(
-      By.xpath(`.//div[@data-example-id='hello_world']`)
-    );
-    await helloWorldExample.click();
+  it("builds, configures UART flash, and flashes testWorkspace", async () => {
     await new Promise((res) => setTimeout(res, 3000));
-
-    const chooseTemplateButton = await view!.findWebElement(
-      By.id("chooseTemplateButton")
-    );
-    expect(await chooseTemplateButton.getText()).to.include(
-      "Create project using template hello_world"
-    );
-    await chooseTemplateButton.click();
-    await new Promise((res) => setTimeout(res, 2000));
-
-    const projectDirInput = await view!.findWebElement(By.id("projectDirectory"));
-    await projectDirInput.clear();
-    await projectDirInput.sendKeys(containerPath);
-    const projectNameInput = await view!.findWebElement(By.id("projectName"));
-    await projectNameInput.clear();
-    await projectNameInput.sendKeys(projectName);
-
-    const createProjectButton = await view!.findWebElement(
-      By.id("createProjectButton")
-    );
-    await createProjectButton.click();
-    await confirmProjectOverwriteIfNeeded();
-    await new Promise((res) => setTimeout(res, 15000));
-
-    const openProjectButton = await view!.findWebElement(
-      By.xpath(`//button[contains(.,'Open Project')]`)
-    );
-    await openProjectButton.click();
-    await new Promise((res) => setTimeout(res, 8000));
-
-    expect(await pathExists(projectPath)).to.be.true;
-    expect(await pathExists(helloWorldBinPath)).to.be.false;
-  }).timeout(120000);
-
-  it("builds, configures UART flash, and flashes the project", async () => {
-    if (view) {
-      await view.switchBack();
-      view = undefined;
-    }
-    await dismissNotifications();
-    await new Promise((res) => setTimeout(res, 5000));
-
+    await new Workbench().executeCommand("ESP-IDF: Full Clean Project");
+    await new Promise((res) => setTimeout(res, 10000));
     await new Workbench().executeCommand("ESP-IDF: Build your Project");
     await new Promise((res) => setTimeout(res, 150000));
 

--- a/src/ui-test/project-flash-test.ts
+++ b/src/ui-test/project-flash-test.ts
@@ -92,10 +92,10 @@ describe("Flash testing", () => {
 
     expect(await pathExists(helloWorldBinPath)).to.be.true;
 
-    await selectQuickPickOption("espIdf.selectPort", serialPort);
-    await selectQuickPickOption("espIdf.selectFlashMethodAndFlash", "UART");
+    await selectQuickPickOption("ESP-IDF: Select Port to Use", serialPort);
+    await selectQuickPickOption("ESP-IDF: Select Flash Method", "UART");
 
-    await new Workbench().executeCommand("espIdf.flashDevice");
+    await new Workbench().executeCommand("ESP-IDF: Flash Your Project");
     const terminalOutput = await waitForTerminalOutput(
       FLASH_SUCCESS_PATTERN,
       180000

--- a/src/ui-test/ui-test-helpers.ts
+++ b/src/ui-test/ui-test-helpers.ts
@@ -1,0 +1,37 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * Copyright 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from "path";
+import { InputBox, Workbench } from "vscode-extension-tester";
+
+export const testWorkspaceDir = resolve(
+  __dirname,
+  "..",
+  "..",
+  "testFiles",
+  "testWorkspace"
+);
+
+export async function openTestProject(): Promise<void> {
+  await new Promise((res) => setTimeout(res, 5000));
+  await new Workbench().executeCommand("file: open folder");
+  await new Promise((res) => setTimeout(res, 1000));
+  const input = await InputBox.create();
+  await input.setText(testWorkspaceDir);
+  await input.confirm();
+  await new Promise((res) => setTimeout(res, 4000));
+}

--- a/src/ui-test/ui-test-helpers.ts
+++ b/src/ui-test/ui-test-helpers.ts
@@ -26,6 +26,15 @@ export const testWorkspaceDir = resolve(
   "testWorkspace"
 );
 
+/** Must match command palette labels exactly (category + package.nls title). */
+export const ESP_IDF_COMMANDS = {
+  fullClean: "ESP-IDF: Full Clean Project",
+  build: "ESP-IDF: Build Your Project",
+  selectPort: "ESP-IDF: Select Port to Use (COM, tty, usbserial)",
+  selectFlashMethod: "ESP-IDF: Select Flash Method",
+  flash: "ESP-IDF: Flash Your Project",
+} as const;
+
 export async function openTestProject(): Promise<void> {
   await new Promise((res) => setTimeout(res, 5000));
   await new Workbench().executeCommand("file: open folder");
@@ -34,4 +43,92 @@ export async function openTestProject(): Promise<void> {
   await input.setText(testWorkspaceDir);
   await input.confirm();
   await new Promise((res) => setTimeout(res, 4000));
+}
+
+export async function executeEspIdfCommand(exactCommandLabel: string): Promise<void> {
+  const workbench = new Workbench();
+  const prompt = await workbench.openCommandPrompt();
+  await prompt.setText(`>${exactCommandLabel}`);
+  await new Promise((res) => setTimeout(res, 1500));
+  await selectCommandPaletteItem(exactCommandLabel);
+}
+
+async function selectCommandPaletteItem(exactCommandLabel: string): Promise<void> {
+  const inputBox = await InputBox.create();
+  const pick = await findQuickPickByExactLabel(inputBox, exactCommandLabel);
+  if (pick) {
+    await pick.select();
+    return;
+  }
+
+  if (exactCommandLabel === ESP_IDF_COMMANDS.selectPort) {
+    const flashPortPick = await findSelectPortCommandPick(inputBox);
+    if (flashPortPick) {
+      await flashPortPick.select();
+      return;
+    }
+  }
+
+  const labels = await listQuickPickLabels(inputBox);
+  throw new Error(
+    `Exact command palette match not found: "${exactCommandLabel}". Visible: [${labels.join(" | ")}]`
+  );
+}
+
+async function findSelectPortCommandPick(inputBox: InputBox) {
+  const picks = await inputBox.getQuickPicks();
+  for (const pick of picks) {
+    const label = await pick.getLabel();
+    if (label.includes("Select Port to Use") && !label.includes("Monitor")) {
+      return pick;
+    }
+  }
+  return undefined;
+}
+
+export async function executeEspIdfCommandAndSelectOption(
+  exactCommandLabel: string,
+  option: string | number
+): Promise<void> {
+  await executeEspIdfCommand(exactCommandLabel);
+  await new Promise((res) => setTimeout(res, 2000));
+
+  if (typeof option === "number") {
+    const inputBox = await InputBox.create();
+    await inputBox.selectQuickPick(option);
+  } else {
+    const inputBox = await InputBox.create();
+    await inputBox.setText(option);
+    await new Promise((res) => setTimeout(res, 500));
+    await selectQuickPickByExactLabel(option);
+  }
+
+  await new Promise((res) => setTimeout(res, 1000));
+}
+
+async function selectQuickPickByExactLabel(exactLabel: string): Promise<void> {
+  const inputBox = await InputBox.create();
+  const pick = await findQuickPickByExactLabel(inputBox, exactLabel);
+  if (!pick) {
+    const labels = await listQuickPickLabels(inputBox);
+    throw new Error(
+      `Exact quick pick label not found: "${exactLabel}". Visible: [${labels.join(" | ")}]`
+    );
+  }
+  await pick.select();
+}
+
+async function findQuickPickByExactLabel(inputBox: InputBox, exactLabel: string) {
+  const picks = await inputBox.getQuickPicks();
+  for (const pick of picks) {
+    if ((await pick.getLabel()) === exactLabel) {
+      return pick;
+    }
+  }
+  return undefined;
+}
+
+async function listQuickPickLabels(inputBox: InputBox): Promise<string[]> {
+  const picks = await inputBox.getQuickPicks();
+  return Promise.all(picks.map((pick) => pick.getLabel()));
 }


### PR DESCRIPTION
## Description

1. Separated hardware dependent tests (Flash test) from other UI tests. 
2. Added ui-test-helpers.ts to avoid the code duplication. 



## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
4. Execute action.
5. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [X] PR Self Reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test workflow: moved UI hardware tests to a dedicated runner, streamlined test execution, ensured hardware test results and screenshots are always published, and aligned the tooling version used during setup.
* **Tests**
  * Added a UI/integration test covering project creation, build and flash flow with device selection and success verification, plus helper utilities to automate opening and driving the test workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->