### PR TITLE
[VSC-1816/VSC-1918/VSC-1757] Enhance/openocd board config usb location

### DIFF
--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -27,6 +27,8 @@
   "Show notifications and focus tasks output.": "Muestra notificaciones y resultados de tareas de enfoque.",
   "OpenOCD Adaptor (serial & location)": "Adaptador OpenOCD (serie y ubicación)",
   "Set Target": "Establecer objetivo",
+  "Default Boards": "Placas predeterminadas",
+  "Other Boards": "Otras placas",
   "Multiple connected boards were detected, but no OpenOCD adapter is selected (serial/location). To avoid flashing the wrong device, set the target for the connected board and rebuild.": "Se detectaron varias placas conectadas, pero no se ha seleccionado ningún adaptador OpenOCD (serie/ubicación). Para evitar flashear el dispositivo incorrecto, establezca el objetivo de la placa conectada y vuelva a compilar.",
   "Select the output and notification mode": "Seleccione el modo de salida y notificación",
   "Notification mode has changed to {mode}": "El modo de notificación ha cambiado a {mode}",

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -27,6 +27,8 @@
   "Show notifications and focus tasks output.": "Mostre notificações e concentre a saída das tarefas.",
   "OpenOCD Adaptor (serial & location)": "Adaptador OpenOCD (serial e localização)",
   "Set Target": "Definir alvo",
+  "Default Boards": "Placas padrão",
+  "Other Boards": "Outras placas",
   "Multiple connected boards were detected, but no OpenOCD adapter is selected (serial/location). To avoid flashing the wrong device, set the target for the connected board and rebuild.": "Várias placas conectadas foram detectadas, mas nenhum adaptador OpenOCD foi selecionado (serial/localização). Para evitar gravar o dispositivo errado, defina o alvo da placa conectada e reconstrua o projeto.",
   "Select the output and notification mode": "Selecione o modo de saída e notificação",
   "Notification mode has changed to {mode}": "O modo de notificação mudou para {mode}",

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -27,6 +27,8 @@
   "Show notifications and focus tasks output.": "Показывать уведомления и фокусировать вывод задач.",
   "OpenOCD Adaptor (serial & location)": "Адаптер OpenOCD (серийный номер и расположение)",
   "Set Target": "Задать цель",
+  "Default Boards": "Платы по умолчанию",
+  "Other Boards": "Другие платы",
   "Multiple connected boards were detected, but no OpenOCD adapter is selected (serial/location). To avoid flashing the wrong device, set the target for the connected board and rebuild.": "Обнаружено несколько подключённых плат, но не выбран адаптер OpenOCD (серийный номер/расположение). Чтобы избежать прошивки неправильного устройства, задайте цель для подключённой платы и пересоберите проект.",
   "Select the output and notification mode": "Выберите режим вывода и уведомления",
   "Notification mode has changed to {mode}": "Режим уведомлений изменен на {mode}",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -27,6 +27,8 @@
   "Show notifications and focus tasks output.": "同时显示通知和任务输出。",
   "OpenOCD Adaptor (serial & location)": "OpenOCD 适配器（序列号与位置）",
   "Set Target": "设置目标",
+  "Default Boards": "默认开发板",
+  "Other Boards": "其他开发板",
   "Multiple connected boards were detected, but no OpenOCD adapter is selected (serial/location). To avoid flashing the wrong device, set the target for the connected board and rebuild.": "检测到多个已连接的开发板，但未选择 OpenOCD 适配器（序列号/位置）。为避免烧录到错误的设备，请为已连接的开发板设置目标并重新构建项目。",
   "Select the output and notification mode": "选择输出和通知模式",
   "Notification mode has changed to {mode}": "通知模式已改为 {mode}",

--- a/src/espIdf/openOcd/adapterSerial.ts
+++ b/src/espIdf/openOcd/adapterSerial.ts
@@ -19,6 +19,7 @@
 import * as vscode from "vscode";
 import { ESP } from "../../config";
 import { Logger } from "../../logger/logger";
+import { PreCheck } from "../../utils";
 
 /**
  * Key used to store the OpenOCD USB adapter serial number in the extension workspace state
@@ -117,6 +118,17 @@ export function clearAdapterSerial(
       "clearAdapterSerial"
     );
   }
+}
+
+const ADAPTER_USB_LOCATION_MIN_VERSION = "v0.12.0-esp32-20260424";
+
+/**
+ * Returns true when the detected OpenOCD build supports the
+ * `adapter usb location <location>` command (>= v0.12.0-esp32-20260424).
+ * Older builds require the OPENOCD_USB_ADAPTER_LOCATION environment variable instead.
+ */
+export function supportsAdapterUsbLocationCommand(version: string): boolean {
+  return PreCheck.openOCDVersionValidator(ADAPTER_USB_LOCATION_MIN_VERSION, version);
 }
 
 /**

--- a/src/espIdf/openOcd/adapterSerial.ts
+++ b/src/espIdf/openOcd/adapterSerial.ts
@@ -136,28 +136,3 @@ const ADAPTER_SERIAL_FROM_DETECT_MIN_VERSION = "v0.12.0-esp32-20260304";
 export function supportsSerialFromDetectConfig(version: string): boolean {
   return PreCheck.openOCDVersionValidator(ADAPTER_SERIAL_FROM_DETECT_MIN_VERSION, version);
 }
-
-/**
- * Gets the OpenOCD USB adapter identifier to use, preferring serial number over location
- * @param workspaceFolder The workspace folder URI
- * @param customExtraVars Custom extra variables that may contain OPENOCD_USB_ADAPTER_LOCATION
- * @returns The adapter serial number if available, otherwise the location, or undefined
- */
-export function getOpenOcdAdapterIdentifier(
-  workspaceFolder: vscode.Uri,
-  customExtraVars?: { [key: string]: string }
-): string | undefined {
-  // First, try to get the stored serial number
-  const serialNumber = getStoredAdapterSerial(workspaceFolder);
-  if (serialNumber) {
-    return serialNumber;
-  }
-
-  // Fallback to OPENOCD_USB_ADAPTER_LOCATION if available
-  if (customExtraVars && customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"]) {
-    return customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
-  }
-
-  return undefined;
-}
-

--- a/src/espIdf/openOcd/adapterSerial.ts
+++ b/src/espIdf/openOcd/adapterSerial.ts
@@ -131,6 +131,12 @@ export function supportsAdapterUsbLocationCommand(version: string): boolean {
   return PreCheck.openOCDVersionValidator(ADAPTER_USB_LOCATION_MIN_VERSION, version);
 }
 
+const ADAPTER_SERIAL_FROM_DETECT_MIN_VERSION = "v0.12.0-esp32-20260304";
+
+export function supportsSerialFromDetectConfig(version: string): boolean {
+  return PreCheck.openOCDVersionValidator(ADAPTER_SERIAL_FROM_DETECT_MIN_VERSION, version);
+}
+
 /**
  * Gets the OpenOCD USB adapter identifier to use, preferring serial number over location
  * @param workspaceFolder The workspace folder URI

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -34,7 +34,12 @@ import { getIdfTargetFromSdkconfig } from "../../workspaceConfig";
 import { configureEnvVariables } from "../../common/prepareEnv";
 import { DevkitsCommand } from "../setTarget/DevkitsCommand";
 import { OpenOCDManager } from "./openOcdManager";
-import { clearAdapterSerial } from "./adapterSerial";
+import {
+  clearAdapterSerial,
+  storeAdapterSerial,
+  supportsSerialFromDetectConfig,
+} from "./adapterSerial";
+import { updateOpenOcdAdapterStatusBarItem } from "../../statusBar";
 
 export interface IdfBoard {
   name: string;
@@ -50,6 +55,7 @@ interface BoardQuickPickItem extends QuickPickItem {
   boardInfo?: {
     location: string;
     config_files: string[];
+    serial_number?: string;
   };
 }
 
@@ -145,11 +151,12 @@ export async function selectOpenOcdConfigFiles(
     }
 
     let connectedBoardItems: BoardQuickPickItem[] = [];
+    let openOCDVersion: string | undefined;
     const isDebugging = debug.activeDebugSession !== undefined;
     if (!isDebugging) {
       try {
         const openOCDManager = OpenOCDManager.init();
-        const openOCDVersion = await openOCDManager.version();
+        openOCDVersion = await openOCDManager.version();
         const devkitsCmd = new DevkitsCommand(workspaceFolder);
         const scriptPath = await devkitsCmd.getScriptPath(openOCDVersion);
         if (scriptPath) {
@@ -173,6 +180,7 @@ export async function selectOpenOcdConfigFiles(
                     boardInfo: {
                       location: b.location,
                       config_files: b.config_files,
+                      serial_number: b.serial_number,
                     },
                     picked: false,
                   })
@@ -251,6 +259,16 @@ export async function selectOpenOcdConfigFiles(
             workspaceFolder
           ) as { [key: string]: string };
           clearAdapterSerial(workspaceFolder);
+
+          if (
+            selectedBoard.isConnected &&
+            selectedBoard.boardInfo?.serial_number &&
+            openOCDVersion &&
+            supportsSerialFromDetectConfig(openOCDVersion)
+          ) {
+            storeAdapterSerial(workspaceFolder, selectedBoard.boardInfo.serial_number);
+            updateOpenOcdAdapterStatusBarItem(workspaceFolder);
+          }
 
           if (selectedBoard.isConnected && selectedBoard.boardInfo) {
             const configFiles = selectedBoard.boardInfo.config_files || [];

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -173,7 +173,6 @@ export async function selectOpenOcdConfigFiles(
                 .map(
                   (b: any): BoardQuickPickItem => ({
                     label: b.name,
-                    description: b.description,
                     detail: `Status: CONNECTED${
                       b.location ? `   Location: ${b.location}` : ""
                     }`,
@@ -212,7 +211,6 @@ export async function selectOpenOcdConfigFiles(
       return;
     }
     const staticChoices: BoardQuickPickItem[] = boards.map((b) => ({
-      description: b.description,
       detail: b.configFiles.join(", "),
       label: b.name,
       target: b,

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -19,16 +19,38 @@ import { join } from "path";
 import { readParameter, writeParameter } from "../../idfConfiguration";
 import { readJSON } from "fs-extra";
 import { Logger } from "../../logger/logger";
-import { commands, ConfigurationTarget, l10n, Uri, window } from "vscode";
+import {
+  commands,
+  ConfigurationTarget,
+  debug,
+  l10n,
+  QuickPickItem,
+  QuickPickItemKind,
+  Uri,
+  window,
+} from "vscode";
 import { defaultBoards } from "./defaultBoards";
 import { getIdfTargetFromSdkconfig } from "../../workspaceConfig";
 import { configureEnvVariables } from "../../common/prepareEnv";
+import { DevkitsCommand } from "../setTarget/DevkitsCommand";
+import { OpenOCDManager } from "./openOcdManager";
+import { clearAdapterSerial } from "./adapterSerial";
 
 export interface IdfBoard {
   name: string;
   description: string;
   target: string;
   configFiles: string[];
+}
+
+interface BoardQuickPickItem extends QuickPickItem {
+  target?: IdfBoard;
+  picked?: boolean;
+  isConnected?: boolean;
+  boardInfo?: {
+    location: string;
+    config_files: string[];
+  };
 }
 
 export async function getOpenOcdScripts(workspace: Uri): Promise<string> {
@@ -121,6 +143,48 @@ export async function selectOpenOcdConfigFiles(
     if (idfTarget === "linux") {
       return;
     }
+
+    let connectedBoardItems: BoardQuickPickItem[] = [];
+    const isDebugging = debug.activeDebugSession !== undefined;
+    if (!isDebugging) {
+      try {
+        const openOCDManager = OpenOCDManager.init();
+        const openOCDVersion = await openOCDManager.version();
+        const devkitsCmd = new DevkitsCommand(workspaceFolder);
+        const scriptPath = await devkitsCmd.getScriptPath(openOCDVersion);
+        if (scriptPath) {
+          const devkitsOutput = await devkitsCmd.runDevkitsScript(
+            openOCDVersion
+          );
+          if (devkitsOutput) {
+            const parsed = JSON.parse(devkitsOutput);
+            if (parsed && Array.isArray(parsed.boards)) {
+              connectedBoardItems = parsed.boards
+                .filter(
+                  (b: any) => !idfTarget || b.target === idfTarget
+                )
+                .map(
+                  (b: any): BoardQuickPickItem => ({
+                    label: b.name,
+                    description: `${b.description}${
+                      b.location ? `   Location: ${b.location}` : ""
+                    }`,
+                    isConnected: true,
+                    boardInfo: {
+                      location: b.location,
+                      config_files: b.config_files,
+                    },
+                    picked: false,
+                  })
+                );
+            }
+          }
+        }
+      } catch (_) {
+        // fall back to static board list
+      }
+    }
+
     const currentOpenOcdConfigs = readParameter(
       "idf.openOcdConfigs",
       workspaceFolder
@@ -138,26 +202,30 @@ export async function selectOpenOcdConfigFiles(
       );
       return;
     }
-    const choices = boards.map((b) => {
-      return {
-        description: `${b.description} (${b.configFiles})`,
-        label: b.name,
-        target: b,
-        picked: currentOpenOcdConfigs
-          .join(",")
-          .includes(b.configFiles.join(",")),
-      };
-    });
+    const staticChoices: BoardQuickPickItem[] = boards.map((b) => ({
+      description: `${b.description} (${b.configFiles})`,
+      label: b.name,
+      target: b,
+      picked: currentOpenOcdConfigs
+        .join(",")
+        .includes(b.configFiles.join(",")),
+      isConnected: false,
+    }));
+
+    const allChoices: BoardQuickPickItem[] =
+      connectedBoardItems.length > 0
+        ? [
+            ...connectedBoardItems,
+            { kind: QuickPickItemKind.Separator, label: "Default Boards" },
+            ...staticChoices,
+          ]
+        : staticChoices;
+
     const selectOpenOCdConfigsMsg = l10n.t(
       "Enter OpenOCD Configuration File Paths list"
     );
-    const boardQuickPick = window.createQuickPick<{
-      description: string;
-      label: string;
-      target: IdfBoard;
-      picked: boolean;
-    }>();
-    boardQuickPick.items = choices;
+    const boardQuickPick = window.createQuickPick<BoardQuickPickItem>();
+    boardQuickPick.items = allChoices;
     boardQuickPick.placeholder = selectOpenOCdConfigsMsg;
     boardQuickPick.onDidHide(() => {
       boardQuickPick.dispose();
@@ -177,27 +245,66 @@ export async function selectOpenOcdConfigFiles(
           Logger.infoNotify(
             `ESP-IDF board not selected. Remember to set the configuration files for OpenOCD with idf.openOcdConfigs`
           );
-        } else if (selectedBoard && selectedBoard.target) {
-          if (selectedBoard.label.indexOf("Custom board") !== -1) {
-            const inputBoard = await window.showInputBox({
-              placeHolder: "Enter comma-separated configuration files",
-              value: selectedBoard.target.configFiles.join(","),
-            });
-            if (inputBoard) {
-              selectedBoard.target.configFiles = inputBoard.split(",");
-            }
-          }
-          await writeParameter(
-            "idf.openOcdConfigs",
-            selectedBoard.target.configFiles,
-            ConfigurationTarget.WorkspaceFolder,
+        } else {
+          const customExtraVars = readParameter(
+            "idf.customExtraVars",
             workspaceFolder
-          );
-          Logger.infoNotify(
-            l10n.t(`OpenOCD Board configuration files set to {boards}.`, {
-              boards: selectedBoard.target.configFiles.join(","),
-            })
-          );
+          ) as { [key: string]: string };
+          clearAdapterSerial(workspaceFolder);
+
+          if (selectedBoard.isConnected && selectedBoard.boardInfo) {
+            const configFiles = selectedBoard.boardInfo.config_files || [];
+            await writeParameter(
+              "idf.openOcdConfigs",
+              configFiles,
+              ConfigurationTarget.WorkspaceFolder,
+              workspaceFolder
+            );
+            if (selectedBoard.boardInfo.location) {
+              customExtraVars[
+                "OPENOCD_USB_ADAPTER_LOCATION"
+              ] = selectedBoard.boardInfo.location.replace("usb://", "");
+            }
+            await writeParameter(
+              "idf.customExtraVars",
+              customExtraVars,
+              ConfigurationTarget.WorkspaceFolder,
+              workspaceFolder
+            );
+            Logger.infoNotify(
+              l10n.t(`OpenOCD Board configuration files set to {boards}.`, {
+                boards: configFiles.join(","),
+              })
+            );
+          } else if (selectedBoard.target) {
+            if (selectedBoard.label.indexOf("Custom board") !== -1) {
+              const inputBoard = await window.showInputBox({
+                placeHolder: "Enter comma-separated configuration files",
+                value: selectedBoard.target.configFiles.join(","),
+              });
+              if (inputBoard) {
+                selectedBoard.target.configFiles = inputBoard.split(",");
+              }
+            }
+            delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
+            await writeParameter(
+              "idf.openOcdConfigs",
+              selectedBoard.target.configFiles,
+              ConfigurationTarget.WorkspaceFolder,
+              workspaceFolder
+            );
+            await writeParameter(
+              "idf.customExtraVars",
+              customExtraVars,
+              ConfigurationTarget.WorkspaceFolder,
+              workspaceFolder
+            );
+            Logger.infoNotify(
+              l10n.t(`OpenOCD Board configuration files set to {boards}.`, {
+                boards: selectedBoard.target.configFiles.join(","),
+              })
+            );
+          }
           boardQuickPick.dispose();
           resolve();
         }

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -173,7 +173,8 @@ export async function selectOpenOcdConfigFiles(
                 .map(
                   (b: any): BoardQuickPickItem => ({
                     label: b.name,
-                    description: `${b.description}${
+                    description: b.description,
+                    detail: `Status: CONNECTED${
                       b.location ? `   Location: ${b.location}` : ""
                     }`,
                     isConnected: true,
@@ -211,7 +212,8 @@ export async function selectOpenOcdConfigFiles(
       return;
     }
     const staticChoices: BoardQuickPickItem[] = boards.map((b) => ({
-      description: `${b.description} (${b.configFiles})`,
+      description: b.description,
+      detail: b.configFiles.join(", "),
       label: b.name,
       target: b,
       picked: currentOpenOcdConfigs
@@ -220,12 +222,23 @@ export async function selectOpenOcdConfigFiles(
       isConnected: false,
     }));
 
+    const connectedKeys = new Set(
+      connectedBoardItems
+        .filter((c) => c.boardInfo?.config_files)
+        .map((c) => [...c.boardInfo.config_files].sort().join(","))
+    );
+    const filteredStaticChoices = staticChoices.filter(
+      (s) =>
+        !s.target ||
+        !connectedKeys.has([...s.target.configFiles].sort().join(","))
+    );
+
     const allChoices: BoardQuickPickItem[] =
       connectedBoardItems.length > 0
         ? [
             ...connectedBoardItems,
-            { kind: QuickPickItemKind.Separator, label: "Default Boards" },
-            ...staticChoices,
+            { kind: QuickPickItemKind.Separator, label: l10n.t("Other Boards") },
+            ...filteredStaticChoices,
           ]
         : staticChoices;
 

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -282,6 +282,8 @@ export async function selectOpenOcdConfigFiles(
               customExtraVars[
                 "OPENOCD_USB_ADAPTER_LOCATION"
               ] = selectedBoard.boardInfo.location.replace("usb://", "");
+            } else {
+              delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
             }
             await writeParameter(
               "idf.customExtraVars",

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -265,11 +265,13 @@ export async function selectOpenOcdConfigFiles(
             `ESP-IDF board not selected. Remember to set the configuration files for OpenOCD with idf.openOcdConfigs`
           );
         } else {
-          const customExtraVars = readParameter(
+          const customExtraVarsRead = readParameter(
             "idf.customExtraVars",
             workspaceFolder
           ) as { [key: string]: string };
+          const customExtraVars = { ...customExtraVarsRead };
           clearAdapterSerial(workspaceFolder);
+          delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
 
           if (
             selectedBoard.isConnected &&
@@ -293,8 +295,6 @@ export async function selectOpenOcdConfigFiles(
               customExtraVars[
                 "OPENOCD_USB_ADAPTER_LOCATION"
               ] = selectedBoard.boardInfo.location.replace("usb://", "");
-            } else {
-              delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
             }
             await writeParameter(
               "idf.customExtraVars",
@@ -317,7 +317,6 @@ export async function selectOpenOcdConfigFiles(
                 selectedBoard.target.configFiles = inputBoard.split(",");
               }
             }
-            delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
             await writeParameter(
               "idf.openOcdConfigs",
               selectedBoard.target.configFiles,

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -61,10 +61,9 @@ interface BoardQuickPickItem extends QuickPickItem {
 
 export async function getOpenOcdScripts(workspace: Uri): Promise<string> {
   const modifiedEnv = await configureEnvVariables(workspace);
-  const userExtraVars = readParameter(
-    "idf.customExtraVars",
-    workspace
-  ) as { [key: string]: string };
+  const userExtraVars = readParameter("idf.customExtraVars", workspace) as {
+    [key: string]: string;
+  };
   let openOcdScriptsPath: string;
   try {
     openOcdScriptsPath = modifiedEnv.hasOwnProperty("OPENOCD_SCRIPTS")
@@ -167,9 +166,7 @@ export async function selectOpenOcdConfigFiles(
             const parsed = JSON.parse(devkitsOutput);
             if (parsed && Array.isArray(parsed.boards)) {
               connectedBoardItems = parsed.boards
-                .filter(
-                  (b: any) => !idfTarget || b.target === idfTarget
-                )
+                .filter((b: any) => !idfTarget || b.target === idfTarget)
                 .map(
                   (b: any): BoardQuickPickItem => ({
                     label: b.name,
@@ -214,9 +211,7 @@ export async function selectOpenOcdConfigFiles(
       detail: b.configFiles.join(", "),
       label: b.name,
       target: b,
-      picked: currentOpenOcdConfigs
-        .join(",")
-        .includes(b.configFiles.join(",")),
+      picked: currentOpenOcdConfigs.join(",").includes(b.configFiles.join(",")),
       isConnected: false,
     }));
 
@@ -235,7 +230,10 @@ export async function selectOpenOcdConfigFiles(
       connectedBoardItems.length > 0
         ? [
             ...connectedBoardItems,
-            { kind: QuickPickItemKind.Separator, label: l10n.t("Other Boards") },
+            {
+              kind: QuickPickItemKind.Separator,
+              label: l10n.t("Other Boards"),
+            },
             ...filteredStaticChoices,
           ]
         : staticChoices;
@@ -279,7 +277,10 @@ export async function selectOpenOcdConfigFiles(
             openOCDVersion &&
             supportsSerialFromDetectConfig(openOCDVersion)
           ) {
-            storeAdapterSerial(workspaceFolder, selectedBoard.boardInfo.serial_number);
+            storeAdapterSerial(
+              workspaceFolder,
+              selectedBoard.boardInfo.serial_number
+            );
             updateOpenOcdAdapterStatusBarItem(workspaceFolder);
           }
 

--- a/src/espIdf/openOcd/boardConfiguration.ts
+++ b/src/espIdf/openOcd/boardConfiguration.ts
@@ -157,7 +157,12 @@ export async function selectOpenOcdConfigFiles(
         const openOCDManager = OpenOCDManager.init();
         openOCDVersion = await openOCDManager.version();
         const devkitsCmd = new DevkitsCommand(workspaceFolder);
-        const scriptPath = await devkitsCmd.getScriptPath(openOCDVersion);
+        const modifiedEnv = await configureEnvVariables(workspaceFolder);
+        const openOcdPath = await OpenOCDManager.getOpenOcdPath(
+          workspaceFolder,
+          modifiedEnv
+        );
+        const scriptPath = await devkitsCmd.getScriptPath(openOcdPath);
         if (scriptPath) {
           const devkitsOutput = await devkitsCmd.runDevkitsScript(
             openOCDVersion

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -43,6 +43,7 @@ import {
   storeAdapterSerial,
   getStoredAdapterSerial,
   supportsAdapterUsbLocationCommand,
+  supportsSerialFromDetectConfig,
 } from "./adapterSerial";
 import { configureEnvVariables } from "../../common/prepareEnv";
 
@@ -212,6 +213,7 @@ export class OpenOCDManager extends EventEmitter {
 
     const versionString = await this.version(true);
     const useLocationCommand = supportsAdapterUsbLocationCommand(versionString);
+    const useDetectConfigSerial = supportsSerialFromDetectConfig(versionString);
     const adapterLocation = modifiedEnv["OPENOCD_USB_ADAPTER_LOCATION"];
     if (useLocationCommand && adapterLocation) {
       delete modifiedEnv["OPENOCD_USB_ADAPTER_LOCATION"];
@@ -224,7 +226,7 @@ export class OpenOCDManager extends EventEmitter {
     ) as string[];
 
     const storedSerial = getStoredAdapterSerial(this.workspace);
-    const needsSerialDiscovery = !storedSerial;
+    const needsSerialDiscovery = !storedSerial && !useDetectConfigSerial;
 
     if (openOcdLaunchArgs && openOcdLaunchArgs.length > 0) {
       openOcdArgs.push(...openOcdLaunchArgs);
@@ -305,11 +307,12 @@ export class OpenOCDManager extends EventEmitter {
       data = typeof data === "string" ? Buffer.from(data) : data;
       this.sendToOutputChannel(data);
 
-      // Parse adapter serial number from log output
-      const serialNumber = parseAdapterSerialFromLog(data);
-      if (serialNumber && this.workspace) {
-        storeAdapterSerial(this.workspace, serialNumber);
-        updateOpenOcdAdapterStatusBarItem(this.workspace);
+      if (!useDetectConfigSerial) {
+        const serialNumber = parseAdapterSerialFromLog(data);
+        if (serialNumber && this.workspace) {
+          storeAdapterSerial(this.workspace, serialNumber);
+          updateOpenOcdAdapterStatusBarItem(this.workspace);
+        }
       }
 
       const regex = /Error:.*/i;
@@ -333,11 +336,12 @@ export class OpenOCDManager extends EventEmitter {
       data = typeof data === "string" ? Buffer.from(data) : data;
       this.sendToOutputChannel(data);
 
-      // Parse adapter serial number from log output
-      const serialNumber = parseAdapterSerialFromLog(data);
-      if (serialNumber && this.workspace) {
-        storeAdapterSerial(this.workspace, serialNumber);
-        updateOpenOcdAdapterStatusBarItem(this.workspace);
+      if (!useDetectConfigSerial) {
+        const serialNumber = parseAdapterSerialFromLog(data);
+        if (serialNumber && this.workspace) {
+          storeAdapterSerial(this.workspace, serialNumber);
+          updateOpenOcdAdapterStatusBarItem(this.workspace);
+        }
       }
 
       this.emit("data", this.chan);

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -42,6 +42,7 @@ import {
   parseAdapterSerialFromLog,
   storeAdapterSerial,
   getStoredAdapterSerial,
+  supportsAdapterUsbLocationCommand,
 } from "./adapterSerial";
 import { configureEnvVariables } from "../../common/prepareEnv";
 
@@ -209,6 +210,13 @@ export class OpenOCDManager extends EventEmitter {
       );
     }
 
+    const versionString = await this.version(true);
+    const useLocationCommand = supportsAdapterUsbLocationCommand(versionString);
+    const adapterLocation = modifiedEnv["OPENOCD_USB_ADAPTER_LOCATION"];
+    if (useLocationCommand && adapterLocation) {
+      delete modifiedEnv["OPENOCD_USB_ADAPTER_LOCATION"];
+    }
+
     const openOcdArgs: string[] = [];
     const openOcdLaunchArgs = idfConf.readParameter(
       "idf.openOcdLaunchArgs",
@@ -228,6 +236,13 @@ export class OpenOCDManager extends EventEmitter {
         !openOcdArgs.some((a) => typeof a === "string" && a.match(/^-d-?\d+$/))
       ) {
         openOcdArgs.unshift("-d2");
+      }
+
+      const alreadyHasLocation = openOcdArgs.some(
+        (a) => typeof a === "string" && a.includes("adapter usb location")
+      );
+      if (useLocationCommand && adapterLocation && !alreadyHasLocation) {
+        openOcdArgs.unshift("-c", `adapter usb location ${adapterLocation}`);
       }
     } else {
       const openOcdConfigFilesList = idfConf.readParameter(
@@ -264,6 +279,10 @@ export class OpenOCDManager extends EventEmitter {
       // Inject adapter serial command if we have a stored serial number
       if (storedSerial) {
         openOcdArgs.push("-c", `adapter serial ${storedSerial}`);
+      }
+
+      if (useLocationCommand && adapterLocation) {
+        openOcdArgs.push("-c", `adapter usb location ${adapterLocation}`);
       }
 
       openOcdConfigFilesList.forEach((configFile) => {

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -41,6 +41,8 @@ import { updateCurrentProfileIdfTarget } from "../../project-conf";
 import { DevkitsCommand } from "./DevkitsCommand";
 import {
   clearAdapterSerial,
+  storeAdapterSerial,
+  supportsSerialFromDetectConfig,
 } from "../openOcd/adapterSerial";
 import { SerialPort } from "../serial/serialPort";
 import { updateOpenOcdAdapterStatusBarItem } from "../../statusBar";
@@ -54,6 +56,7 @@ export interface ISetTargetQuickPickItems {
   boardInfo?: {
     location: string;
     config_files: string[];
+    serial_number?: string;
   };
   description?: string;
   isConnected?: boolean;
@@ -97,13 +100,14 @@ export async function setIdfTarget(
       try {
         const targetsFromIdf = await getTargetsFromEspIdf(workspaceFolder.uri);
         let connectedBoards: ISetTargetQuickPickItems[] = [];
+        let openOCDVersion: string | undefined;
 
         const isDebugging = debug.activeDebugSession !== undefined;
 
         if (!isDebugging) {
           try {
             const openOCDManager = OpenOCDManager.init();
-            const openOCDVersion = await openOCDManager.version();
+            openOCDVersion = await openOCDManager.version();
             const devkitsCmd = new DevkitsCommand(workspaceFolder.uri);
             const modifiedEnv = await configureEnvVariables(workspaceFolder.uri);
             const openOcdPath = await OpenOCDManager.getOpenOcdPath(
@@ -185,6 +189,16 @@ export async function setIdfTarget(
         // Clear stored adapter serial and location when target changes
         clearAdapterSerial(workspaceFolder.uri);
         delete customExtraVars["OPENOCD_USB_ADAPTER_LOCATION"];
+
+        if (
+          selectedTarget.isConnected &&
+          selectedTarget.boardInfo?.serial_number &&
+          openOCDVersion &&
+          supportsSerialFromDetectConfig(openOCDVersion)
+        ) {
+          storeAdapterSerial(workspaceFolder.uri, selectedTarget.boardInfo.serial_number);
+          updateOpenOcdAdapterStatusBarItem(workspaceFolder.uri);
+        }
 
         if (selectedTarget.isConnected && selectedTarget.boardInfo) {
           // Directly set OpenOCD configs for connected board

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -168,7 +168,7 @@ export async function setIdfTarget(
           connectedBoards.length > 0
             ? [
                 ...connectedBoards,
-                { kind: QuickPickItemKind.Separator, label: "Default Boards" },
+                { kind: QuickPickItemKind.Separator, label: l10n.t("Default Boards") },
                 ...defaultBoards,
               ]
             : defaultBoards;

--- a/src/espIdf/setTarget/index.ts
+++ b/src/espIdf/setTarget/index.ts
@@ -128,7 +128,6 @@ export async function setIdfTarget(
                         idfTarget: targetsFromIdf.find(
                           (t) => t.target === b.target
                         ),
-                        description: b.description,
                         detail: `Status: CONNECTED${
                           b.location ? `   Location: ${b.location}` : ""
                         }`,


### PR DESCRIPTION
## Description

This PR improves OpenOCD USB adapter handling when selecting a connected board.

**1) Allow USB adapter re-pinning via OpenOCD board configuration**
- Runs `esp_detect_config.py` from **Select OpenOCD Board Configuration** so connected boards appear in the quick pick (same as Set Target).
- Lets users update `OPENOCD_USB_ADAPTER_LOCATION` and OpenOCD config files without re-running **Set Espressif Device Target** (which triggers a full SDK Config rebuild).
- On OpenOCD **≥ v0.12.0-esp32-20260424**, passes the USB location via the `adapter usb location` OpenOCD command instead of relying on the `OPENOCD_USB_ADAPTER_LOCATION` environment variable alone.

**2) Get adapter serial from `esp_detect_config.py`**
- Reads `serial_number` from `esp_detect_config.py` output when a connected board is chosen in **Set Target** or **Select OpenOCD Board Configuration**, instead of parsing OpenOCD logs.
- On OpenOCD **≥ v0.12.0-esp32-20260304**, skips log-based serial discovery and the extra `-d2` debug-level launch arg used for that path.
- Older OpenOCD builds keep the existing log-parsing and env-var behavior

## Type of change

- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output.

### A. USB location re-pinning (new OpenOCD ≥ v0.12.0-esp32-20260424)

1. Connect an ESP board via USB.
2. Open the Command Palette and run **ESP-IDF: Select OpenOCD Board Configuration**.
3. Pick a connected board from the top of the list (above the “Default Boards” separator).
4. Start a debug session or launch OpenOCD.

- **Expected behaviour:** `idf.openOcdConfigs` and `idf.customExtraVars.OPENOCD_USB_ADAPTER_LOCATION` are updated without running Set Target. OpenOCD is launched with `-c adapter usb location <location>` (location without the `usb://` prefix). The env var is not passed to OpenOCD on new builds.

- **Expected output:** Notification: “OpenOCD Board configuration files set to …”. OpenOCD output channel shows successful adapter attach; no need to re-run Set Target or rebuild sdkconfig.

### B. Adapter serial from detect config (new OpenOCD ≥ v0.12.0-esp32-20260304)

1. Connect a board and run **ESP-IDF: Set Espressif Device Target** or **ESP-IDF: Select OpenOCD Board Configuration**.
2. Select a connected board that reports a `serial_number` from `esp_detect_config.py`.
3. Launch OpenOCD / start debugging.

- **Expected behaviour:** Adapter serial is stored from board detection (status bar reflects it). OpenOCD is **not** launched with `-d2` solely for serial discovery. Serial is **not** parsed from OpenOCD stdout on new builds.

- **Expected output:** OpenOCD starts with `-c adapter serial <serial>` when a stored serial exists. No `-d2` bump for serial discovery on supported versions.

### C. Backward compatibility (older OpenOCD)

1. Use an OpenOCD build **older than** v0.12.0-esp32-20260304.
2. Select a connected board and launch OpenOCD.

- **Expected behaviour:** Previous behavior is preserved: `OPENOCD_USB_ADAPTER_LOCATION` stays in the environment, serial may still be discovered from OpenOCD logs with `-d2` when needed.

- **Expected output:** OpenOCD attaches as before; no regression on older toolchains.

### D. Static / default board selection

1. Run **ESP-IDF: Select OpenOCD Board Configuration**.
2. Choose a board under **Default Boards** (not a connected entry).

- **Expected behaviour:** `OPENOCD_USB_ADAPTER_LOCATION` is cleared from `idf.customExtraVars`. Stored adapter serial is cleared. Only the selected default config files are written.

- **Expected output:** Notification with the chosen config file list; no stale USB location or serial from a previous connected-board selection.

## How has this been tested?

As described above.

**Test Configuration**:
* ESP-IDF Version: 6.0
* OS (Windows,Linux and macOS): Windows 11

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic detection of connected boards shown first, with a fallback to other/default boards.
  * Conditional injection of the OpenOCD USB-adapter-location command when the detected OpenOCD version supports it.

* **Refactor**
  * Improved persistence and handling of adapter location and serial state; status updated more reliably.
  * Smarter serial handling: store/discover serials only when supported and avoid redundant parsing.

* **Localization**
  * Added translations for “Default Boards” and “Other Boards”.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/vscode-esp-idf-extension/pull/1850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->