### PR TITLE
Activation script in ESP IDF Terminal uses bash as default

### DIFF
--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -48,7 +48,7 @@ export async function getEnvVariablesFromActivationScript(
     const shellPath =
       process.platform === "win32"
         ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
-        : "/bin/bash";
+        : "bash";
     const envVarsOutput = await spawn(shellPath, args, {
       maxBuffer: 500 * 1024,
       cwd: process.cwd(),

--- a/src/eim/loadSettings.ts
+++ b/src/eim/loadSettings.ts
@@ -48,7 +48,7 @@ export async function getEnvVariablesFromActivationScript(
     const shellPath =
       process.platform === "win32"
         ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
-        : "/bin/sh";
+        : "/bin/bash";
     const envVarsOutput = await spawn(shellPath, args, {
       maxBuffer: 500 * 1024,
       cwd: process.cwd(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4285,7 +4285,7 @@ async function createEspIdfTerminal(
       ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
       : shellExecutablePath
       ? shellExecutablePath
-      : "/bin/bash";
+      : "bash";
 
   const currentSetup = await loadIdfSetup(workspaceRoot);
   if (!currentSetup) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4285,7 +4285,7 @@ async function createEspIdfTerminal(
       ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
       : shellExecutablePath
       ? shellExecutablePath
-      : "/bin/sh";
+      : "/bin/bash";
 
   const currentSetup = await loadIdfSetup(workspaceRoot);
   if (!currentSetup) {


### PR DESCRIPTION
## Description

This pull request updates the default shell used for certain operations from `sh` to `bash` on non-Windows platforms. This change ensures better compatibility with scripts that may use Bash-specific syntax.

Shell configuration updates:

* In `src/eim/loadSettings.ts`, the default shell used in `getEnvVariablesFromActivationScript` is changed from `/bin/sh` to `/bin/bash` for non-Windows systems.
* In `src/extension.ts`, the default shell used in `createEspIdfTerminal` is also updated from `/bin/sh` to `/bin/bash` for non-Windows systems.

Fixes #1839
Fix #1859

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "ESP-IDF: Open ESP-IDF Terminal"
2. Execute action. The terminal used should be bash instead of sh
3. Observe results.

- Expected behaviour:
Bash instead of sh

- Expected output:

## How has this been tested?

Manual steps as described as above.

**Test Configuration**:
* ESP-IDF Version: 6.0.1
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated non-Windows shell to use bash instead of sh for activation script execution and integrated terminal initialization on Linux/macOS, improving script compatibility and terminal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espressif/vscode-esp-idf-extension/pull/1853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->