### PR TITLE
add remaining lpcore targets

### DIFF
--- a/src/espIdf/openOcd/defaultBoards.ts
+++ b/src/espIdf/openOcd/defaultBoards.ts
@@ -176,6 +176,30 @@ export const defaultBoards = [
     ],
   } as IdfBoard,
   {
+    name: "ESP32-C5 chip with LP core (via builtin USB-JTAG)",
+    description: "ESP32-C5 with LP core debugging via builtin USB-JTAG",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-lpcore-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C5 chip with LP core (via ESP-PROG)",
+    description: "ESP32-C5 with LP core debugging via ESP-PROG board",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-lpcore-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-C5 chip with LP core (via ESP-PROG-2)",
+    description: "ESP32-C5 with LP core debugging via ESP-PROG-2 board",
+    target: "esp32c5",
+    configFiles: [
+      "board/esp32c5-lpcore-bridge.cfg"
+    ],
+  } as IdfBoard,
+  {
     name: "ESP32-C6 chip (via builtin USB-JTAG)",
     description: "ESP32-C6 debugging via builtin USB-JTAG",
     target: "esp32c6",
@@ -317,6 +341,30 @@ export const defaultBoards = [
     target: "esp32p4",
     configFiles: [
       "board/esp32p4-bridge.cfg"
+    ],
+  } as IdfBoard,
+    {
+    name: "ESP32-P4 chip with LP core (via builtin USB-JTAG)",
+    description: "ESP32-P4 with LP core debugging via builtin USB-JTAG",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-lpcore-builtin.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-P4 chip with LP core (via ESP-PROG)",
+    description: "ESP32-P4 with LP core debugging via ESP-PROG board",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-lpcore-ftdi.cfg"
+    ],
+  } as IdfBoard,
+  {
+    name: "ESP32-P4 chip with LP core (via ESP-PROG-2)",
+    description: "ESP32-P4 with LP core debugging via ESP-PROG-2 board",
+    target: "esp32p4",
+    configFiles: [
+      "board/esp32p4-lpcore-bridge.cfg"
     ],
   } as IdfBoard,
 ]; 


### PR DESCRIPTION
## Description

Adds lpcore configurations for esp32c5 and esp32p4

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Select new ESP32-P4 LP core or ESP32-C5 LP core configuration
2. run OpenOCD server

- Expected behaviour:

OpenOCD started with esp32*-lpcore-*.cfg configuration file, enabling lpcore debug

## How has this been tested?

lpcore configs tested on openocd/idf side, same functionality present for esp32c6

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32-C5 LP core debugging board variants (builtin USB-JTAG, ESP-PROG, ESP-PROG-2)
  * Added support for ESP32-P4 LP core debugging board variants (builtin USB-JTAG, ESP-PROG, ESP-PROG-2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->