### PR TITLE
Update Docker installation instructions for Windows

### DIFF
--- a/docs_espressif/zh_CN/additionalfeatures/docker-container.rst
+++ b/docs_espressif/zh_CN/additionalfeatures/docker-container.rst
@@ -30,7 +30,13 @@ Docker 桌面应用程序
 
 .. note::
 
-    Docker 的默认安装路径是 C 盘，如果 C 盘空间不足，请使用 ``mklink`` 命令将其移动到其他磁盘。
+    Docker 的默认安装路径是 C 盘，如果 C 盘空间不足，请使用:
+
+    .. code-block::
+    
+        Start-Process 'Docker Desktop Installer.exe' -Wait -ArgumentList 'install', '--accept-license' , '--installation-dir=<path>'
+    
+    命令将其安装到其他磁盘位置 ``<path>`` 。
 
 在 Windows 系统中为 Docker 安装 Ubuntu
 --------------------------------------


### PR DESCRIPTION
Added instructions for changing Docker installation directory on Windows . 

ref :  https://docs.docker.com/desktop/setup/install/windows-install/#installer-flags

## Description

Use offical Docker cli command instead of ``mklink`` manually.

## Type of change

- This change requires a documentation update

## Steps to test this pull request

Observe results.

## How has this been tested?

**Test Configuration**:

* Docker Desktop Installer ver4.76.0
* ESP-IDF Version: release-6.0
* OS (Windows,Linux and macOS): Windows11 ver25h2 26200.8457

## Dependent components impacted by this PR:

- None

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS
