### PR TITLE
ui hardware debug test for ESP32 target

### DIFF
--- a/src/ui-test/project-hardware-e2e-test.ts
+++ b/src/ui-test/project-hardware-e2e-test.ts
@@ -17,86 +17,315 @@
  */
 
 import { expect } from "chai";
+import { resolve } from "path";
+import {
+  BottomBarPanel,
+  DebugToolbar,
+  EditorView,
+  TextEditor,
+  Workbench,
+} from "vscode-extension-tester";
 import {
   ESP_IDF_COMMANDS,
   dismissNotifications,
   executeEspIdfCommand,
   executeEspIdfCommandAndSelectOption,
   helloWorldBinPath,
+  killDebugProcesses,
   openTestProject,
+  selectFromCurrentPicker,
+  setBreakpointInFile,
   testHardwareSerialPort,
+  testWorkspaceDir,
   waitForBuildComplete,
+  waitForOutputChannelText,
   waitForPathAbsent,
+  waitForPausedLineChange,
   waitForTerminalOutput,
 } from "./ui-test-helpers";
+
+// ─── patterns ────────────────────────────────────────────────────────────────
 
 const FLASH_SUCCESS_PATTERN =
   /Hash of data verified|Flash Done|Hard resetting via RTS pin/;
 
 const MONITOR_OUTPUT_PATTERN = /UI test monitor output check/;
 
-const hardwareE2eState = {
+const SET_TARGET_COMPLETE_PATTERN =
+  /Target .* Set Successfully|idf\.py set-target.*done|Project targets have been set/i;
+
+const DEBUG_FATAL_ERROR_PATTERN =
+  /Target failure|Error: .*failed to halt|OpenOCD failed|LIBUSB_ERROR|failed to connect/i;
+
+// Breakpoint at a volatile assignment so the compiler cannot optimise it away.
+// Line 8: volatile int a = 1;  → GDB halts here
+// Line 9: volatile int b = a+1 → expected after step-over
+const BREAKPOINT_LINE = 8;
+const STEP_OVER_TARGET_LINE = BREAKPOINT_LINE + 1;
+const SOURCE_FILE_NAME = "hello_world_main.c";
+const SOURCE_FILE_PATH = resolve(testWorkspaceDir, "main", SOURCE_FILE_NAME);
+
+// ─── shared state ────────────────────────────────────────────────────────────
+
+const state = {
   buildSucceeded: false,
   flashSucceeded: false,
+  monitorSucceeded: false,
+  activeDebugToolbar: undefined as DebugToolbar | undefined,
 };
 
-describe("Hardware E2E: build → flash → monitor", () => {
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+async function step(
+  stepName: string,
+  action: () => Promise<void>
+): Promise<void> {
+  console.log(`  → [step] ${stepName}`);
+  try {
+    await action();
+    console.log(`  ✓ [step] ${stepName}`);
+  } catch (err) {
+    const orig = err instanceof Error ? err.message : String(err);
+    console.log(`  ✗ [step] ${stepName}\n${orig}`);
+    throw new Error(`Test failed at: ${stepName}\n${orig}`);
+  }
+}
+
+/** Stops any active debug session and force-kills OpenOCD / GDB processes. */
+async function stopDebugSession(toolbar?: DebugToolbar): Promise<void> {
+  if (toolbar) {
+    const alive = await toolbar.isDisplayed().catch(() => false);
+    if (alive) {
+      await toolbar.stop().catch(() => undefined);
+      await new Promise((res) => setTimeout(res, 3000));
+    }
+  }
+  await new Workbench()
+    .executeCommand("workbench.action.debug.stop")
+    .catch(() => undefined);
+  await new Promise((res) => setTimeout(res, 2000));
+  await killDebugProcesses();
+}
+
+// ─── test suite ──────────────────────────────────────────────────────────────
+
+describe("Hardware E2E: build → flash → monitor → debug", () => {
   before(async function () {
     this.timeout(100000);
     await dismissNotifications();
     await openTestProject();
   });
 
-  it("builds testWorkspace", async function () {
-    await new Promise((res) => setTimeout(res, 3000));
-    await executeEspIdfCommand(ESP_IDF_COMMANDS.fullClean);
-    await waitForPathAbsent(helloWorldBinPath, 60000);
+  after(async function () {
+    this.timeout(30000);
+    console.log("[after] Cleanup: stopping debug session and killing processes");
+    await stopDebugSession(state.activeDebugToolbar);
+    state.activeDebugToolbar = undefined;
+    await new BottomBarPanel().toggle(false).catch(() => undefined);
+    console.log("[after] Cleanup complete");
+  });
 
-    await executeEspIdfCommand(ESP_IDF_COMMANDS.build);
-    const buildOutput = await waitForBuildComplete(helloWorldBinPath, 300000);
-    console.log(buildOutput);
-    hardwareE2eState.buildSucceeded = true;
+  // ── build ──────────────────────────────────────────────────────────────────
+
+  it("builds testWorkspace", async function () {
+    await step("Full clean", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.fullClean);
+      await waitForPathAbsent(helloWorldBinPath, 60000);
+    });
+
+    await step("Build project", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.build);
+      const buildOutput = await waitForBuildComplete(helloWorldBinPath, 300000);
+      console.log(buildOutput);
+    });
+
+    state.buildSucceeded = true;
   }).timeout(999999);
+
+  // ── flash ──────────────────────────────────────────────────────────────────
 
   it("flashes testWorkspace", async function () {
-    if (!hardwareE2eState.buildSucceeded) {
+    if (!state.buildSucceeded) {
       this.skip();
     }
 
-    await executeEspIdfCommandAndSelectOption(
-      ESP_IDF_COMMANDS.selectPort,
-      testHardwareSerialPort
-    );
-    await executeEspIdfCommandAndSelectOption(
-      ESP_IDF_COMMANDS.selectFlashMethod,
-      "UART"
-    );
+    await step(`Select serial port ${testHardwareSerialPort}`, async () => {
+      await executeEspIdfCommandAndSelectOption(
+        ESP_IDF_COMMANDS.selectPort,
+        testHardwareSerialPort
+      );
+    });
 
-    await executeEspIdfCommand(ESP_IDF_COMMANDS.flash);
-    const flashOutput = await waitForTerminalOutput(
-      FLASH_SUCCESS_PATTERN,
-      180000
-    );
-    console.log(flashOutput);
-    expect(FLASH_SUCCESS_PATTERN.test(flashOutput)).to.be.true;
-    hardwareE2eState.flashSucceeded = true;
+    await step("Select UART flash method", async () => {
+      await executeEspIdfCommandAndSelectOption(
+        ESP_IDF_COMMANDS.selectFlashMethod,
+        "UART"
+      );
+    });
+
+    await step("Flash project and verify success", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.flash);
+      const flashOutput = await waitForTerminalOutput(
+        FLASH_SUCCESS_PATTERN,
+        180000
+      );
+      console.log(flashOutput);
+      expect(FLASH_SUCCESS_PATTERN.test(flashOutput)).to.be.true;
+    });
+
+    state.flashSucceeded = true;
   }).timeout(999999);
 
+  // ── monitor ────────────────────────────────────────────────────────────────
+
   it("shows expected monitor output", async function () {
-    if (!hardwareE2eState.flashSucceeded) {
+    if (!state.flashSucceeded) {
       this.skip();
     }
 
-    await executeEspIdfCommandAndSelectOption(
-      ESP_IDF_COMMANDS.selectMonitorPort,
-      testHardwareSerialPort
+    await step(`Select monitor port ${testHardwareSerialPort}`, async () => {
+      await executeEspIdfCommandAndSelectOption(
+        ESP_IDF_COMMANDS.selectMonitorPort,
+        testHardwareSerialPort
+      );
+    });
+
+    await step("Start monitor and verify expected output", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.monitor);
+      const monitorOutput = await waitForTerminalOutput(
+        MONITOR_OUTPUT_PATTERN,
+        120000
+      );
+      console.log(monitorOutput);
+      expect(MONITOR_OUTPUT_PATTERN.test(monitorOutput)).to.be.true;
+    });
+
+    await step("Kill monitor terminal", async () => {
+      await new Workbench().executeCommand("workbench.action.terminal.kill");
+      await new Promise((res) => setTimeout(res, 2000));
+    });
+
+    state.monitorSucceeded = true;
+  }).timeout(999999);
+
+  // ── debug ──────────────────────────────────────────────────────────────────
+
+  it("debugs testWorkspace via JTAG on ESP32 ETHERNET KIT", async function () {
+    if (!state.flashSucceeded || !state.monitorSucceeded) {
+      this.skip();
+    }
+
+    await dismissNotifications();
+
+    await step("Select JTAG flash method", async () => {
+      await executeEspIdfCommandAndSelectOption(
+        ESP_IDF_COMMANDS.selectFlashMethod,
+        "JTAG"
+      );
+    });
+
+    await step("Set target esp32 and board ESP32-ETHERNET-KIT", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.setTarget);
+      await new Promise((res) => setTimeout(res, 1000));
+      await selectFromCurrentPicker("esp32", 15000);
+      await new Promise((res) => setTimeout(res, 1000));
+      await selectFromCurrentPicker("ESP32-ETHERNET-KIT", 15000);
+    });
+
+    await step("Wait for idf.py set-target to complete", async () => {
+      await waitForOutputChannelText(
+        "ESP-IDF",
+        SET_TARGET_COMPLETE_PATTERN,
+        120000
+      );
+    });
+
+    await step("Rebuild project for the new target", async () => {
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.fullClean);
+      await waitForPathAbsent(helloWorldBinPath, 60000);
+      await executeEspIdfCommand(ESP_IDF_COMMANDS.build);
+      await waitForBuildComplete(helloWorldBinPath, 300000);
+    });
+
+    // Set an explicit breakpoint so GDB halts at a known line rather than the
+    // default entry point, making step-over deterministic.
+    await step(
+      `Set breakpoint at ${SOURCE_FILE_NAME}:${BREAKPOINT_LINE}`,
+      async () => {
+        await setBreakpointInFile(SOURCE_FILE_PATH, BREAKPOINT_LINE);
+      }
     );
-    await executeEspIdfCommand(ESP_IDF_COMMANDS.monitor);
-    const monitorOutput = await waitForTerminalOutput(
-      MONITOR_OUTPUT_PATTERN,
-      120000
+
+    let debugToolbar: DebugToolbar;
+
+    await step("Launch debugger", async () => {
+      await new Workbench().executeCommand("workbench.action.debug.start");
+      debugToolbar = await DebugToolbar.create(60000);
+      state.activeDebugToolbar = debugToolbar;
+    });
+
+    // Declared here so the summary block at the end can reference both values.
+    let haltedLine: number | undefined;
+    let lineAfterStep: number | undefined;
+
+    await step(
+      `Wait for GDB to halt at ${SOURCE_FILE_NAME}:${BREAKPOINT_LINE}`,
+      async () => {
+        await debugToolbar!.waitForBreakPoint(60000);
+
+        // OpenOCD errors appear in the ESP-IDF channel, not in the terminal.
+        const openocdLog = await waitForOutputChannelText("ESP-IDF", /.*/, 5000).catch(() => "");
+        if (DEBUG_FATAL_ERROR_PATTERN.test(openocdLog)) {
+          throw new Error(`Fatal OpenOCD error.\nESP-IDF output:\n${openocdLog}`);
+        }
+
+        const editor = (await new EditorView().openEditor(SOURCE_FILE_NAME)) as TextEditor;
+        const paused = await editor.getPausedBreakpoint();
+        if (!paused) {
+          throw new Error(
+            `No pause indicator in ${SOURCE_FILE_NAME}. ` +
+              "OpenOCD may not have connected or GDB did not set the breakpoint."
+          );
+        }
+        haltedLine = await paused.getLineNumber();
+        expect(haltedLine, `GDB halted at ${haltedLine}, expected ${BREAKPOINT_LINE}`).to.equal(
+          BREAKPOINT_LINE
+        );
+      }
     );
-    console.log(monitorOutput);
-    expect(MONITOR_OUTPUT_PATTERN.test(monitorOutput)).to.be.true;
+
+    await step("Step Over and verify program counter advanced", async () => {
+      await debugToolbar!.stepOver();
+
+      lineAfterStep = await waitForPausedLineChange(SOURCE_FILE_NAME, BREAKPOINT_LINE, 30000);
+
+      if (typeof lineAfterStep !== "number") {
+        throw new Error(
+          `GDB pause indicator did not move from line ${BREAKPOINT_LINE} within 30 s after Step Over.`
+        );
+      }
+
+      expect(
+        lineAfterStep,
+        `Expected step ${BREAKPOINT_LINE} → ${STEP_OVER_TARGET_LINE}, got ${lineAfterStep}`
+      ).to.equal(STEP_OVER_TARGET_LINE);
+    });
+
+    await step("Verify debug session still active after Step Over", async () => {
+      const sessionAlive = await debugToolbar!.isDisplayed().catch(() => false);
+      expect(sessionAlive, "Debug toolbar disappeared — session may have crashed").to.be.true;
+
+      const openocdLog = await waitForOutputChannelText("ESP-IDF", /.*/, 5000).catch(() => "");
+      if (DEBUG_FATAL_ERROR_PATTERN.test(openocdLog)) {
+        throw new Error(`Fatal OpenOCD error after Step Over.\nESP-IDF output:\n${openocdLog}`);
+      }
+    });
+
+    await step("Stop debug session", async () => {
+      await stopDebugSession(debugToolbar!);
+      state.activeDebugToolbar = undefined;
+      await new BottomBarPanel().toggle(false);
+    });
+
   }).timeout(999999);
 });

--- a/src/ui-test/ui-test-helpers.ts
+++ b/src/ui-test/ui-test-helpers.ts
@@ -15,9 +15,23 @@
  * limitations under the License.
  */
 
+import { exec } from "child_process";
 import { pathExists } from "fs-extra";
 import { resolve } from "path";
-import { BottomBarPanel, InputBox, Workbench } from "vscode-extension-tester";
+import { promisify } from "util";
+import {
+  ActivityBar,
+  BottomBarPanel,
+  DebugConsoleView,
+  DebugView,
+  EditorView,
+  InputBox,
+  OutputView,
+  TextEditor,
+  Workbench,
+} from "vscode-extension-tester";
+
+const execAsync = promisify(exec);
 
 const BUILD_FAILURE_PATTERN =
   /ninja: build stopped|CMake Error|FAILED:|ninja: error|Compilation failed/i;
@@ -134,6 +148,7 @@ export const ESP_IDF_COMMANDS = {
   selectMonitorPort:
     "ESP-IDF: Select Monitor Port to Use (COM, tty, usbserial)",
   selectFlashMethod: "ESP-IDF: Select Flash Method",
+  setTarget: "ESP-IDF: Set Espressif Device Target",
   flash: "ESP-IDF: Flash Your Project",
   monitor: "ESP-IDF: Monitor Device",
   buildFlashMonitor:
@@ -236,4 +251,274 @@ async function findQuickPickByExactLabel(inputBox: InputBox, exactLabel: string)
 async function listQuickPickLabels(inputBox: InputBox): Promise<string[]> {
   const picks = await inputBox.getQuickPicks();
   return Promise.all(picks.map((pick) => pick.getLabel()));
+}
+
+/**
+ * Polls until a quick pick containing `option` appears and selects it.
+ * Used for pickers that open asynchronously after a command (e.g. the OpenOCD
+ * board-config picker shown by Set Espressif Device Target).
+ */
+export async function selectFromCurrentPicker(
+  option: string,
+  timeoutMs = 20000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastVisibleLabels: string[] = [];
+
+  while (Date.now() < deadline) {
+    try {
+      const inputBox = await InputBox.create(2000);
+      const rawPicks = await inputBox.getQuickPicks();
+      if (rawPicks.length === 0) {
+        await new Promise((res) => setTimeout(res, 1000));
+        continue;
+      }
+      await inputBox.setText(option);
+      await new Promise((res) => setTimeout(res, 500));
+      const filtered = await inputBox.getQuickPicks();
+      for (const pick of filtered) {
+        if ((await pick.getLabel()) === option) {
+          await pick.select();
+          await new Promise((res) => setTimeout(res, 1000));
+          return;
+        }
+      }
+      // Option not yet visible — the list may still be loading. Record what
+      // was visible for the timeout error message, then keep polling.
+      lastVisibleLabels = await Promise.all(filtered.map((p) => p.getLabel()));
+    } catch {
+      // InputBox not ready yet — keep polling.
+    }
+    await new Promise((res) => setTimeout(res, 1000));
+  }
+
+  throw new Error(
+    `Quick pick option "${option}" did not appear within ${timeoutMs} ms.` +
+      (lastVisibleLabels.length
+        ? ` Last visible: [${lastVisibleLabels.join(" | ")}]`
+        : "")
+  );
+}
+
+/** Returns a snapshot of the active terminal text without waiting. */
+export async function readCurrentTerminalText(): Promise<string> {
+  const panel = new BottomBarPanel();
+  const terminalView = await panel.openTerminalView();
+  return terminalView.getText();
+}
+
+/**
+ * Opens `filePath` in the editor via Quick Open and sets a breakpoint at
+ * `lineNumber`.
+ *
+ * `EditorView.openEditor()` only works on already-open tabs, so we first open
+ * the file through the Quick Open palette using its full absolute path.  This
+ * also guarantees we open the workspace copy of the file rather than any
+ * same-named file from the ESP-IDF installation.
+ *
+ * Idempotent: any pre-existing breakpoint on that line is removed first.
+ */
+export async function setBreakpointInFile(
+  filePath: string,
+  lineNumber: number
+): Promise<void> {
+  await new Workbench().executeCommand("workbench.action.quickOpen");
+  const input = await InputBox.create(5000);
+  await input.setText(filePath);
+  await new Promise((res) => setTimeout(res, 1000));
+  await input.confirm();
+  await new Promise((res) => setTimeout(res, 1500));
+
+  const fileName = filePath.split("/").pop() ?? filePath;
+  const editor = (await new EditorView().openEditor(fileName)) as TextEditor;
+
+  const existing = await editor.getBreakpoint(lineNumber);
+  if (existing) {
+    await existing.remove();
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  await editor.toggleBreakpoint(lineNumber);
+  await new Promise((res) => setTimeout(res, 500));
+}
+
+/**
+ * Polls `TextEditor.getPausedBreakpoint().getLineNumber()` until the reported
+ * line differs from `previousLine` and returns the new line number.
+ *
+ * `getPausedBreakpoint()` reads the yellow-arrow gutter element VS Code renders
+ * on every GDB halt — the canonical vscode-extension-tester API for this.
+ * It requires no DOM hacks, no aria-hidden workarounds, and no regex parsing.
+ *
+ * Returns `undefined` if the pause indicator does not move within `timeoutMs`.
+ */
+export async function waitForPausedLineChange(
+  fileName: string,
+  previousLine: number,
+  timeoutMs: number
+): Promise<number | undefined> {
+  const editor = (await new EditorView().openEditor(fileName)) as TextEditor;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const paused = await editor.getPausedBreakpoint();
+      if (paused) {
+        const line = await paused.getLineNumber();
+        if (line !== previousLine) {
+          return line;
+        }
+      }
+    } catch {
+      // getPausedBreakpoint throws when 0 or >1 pause indicators are present;
+      // swallow and retry until the gutter settles.
+    }
+    await new Promise((res) => setTimeout(res, 1000));
+  }
+
+  return undefined;
+}
+
+/**
+ * Opens the Run and Debug sidebar and reads the current source line from the
+ * top Call Stack frame.
+ *
+ * Reads the raw text of the entire CALL STACK section element — VS Code
+ * renders each frame as visible text ("app_main  hello_world_main.c 11"),
+ * and `WebElement.getText()` collects it all.  The first `.c N` / `.c:N`
+ * match in that text is always frame 0 (the innermost / most-recent frame).
+ *
+ * Unlike the Debug Console, the call stack IS updated after every GDB halt,
+ * including step-over halts that emit no new source listing to the console.
+ *
+ * Returns `undefined` if no frame with a `.c` file reference is visible.
+ */
+export async function readCallStackTopFrameLine(): Promise<number | undefined> {
+  const debugControl = await new ActivityBar().getViewControl("Run and Debug");
+  if (!debugControl) {
+    return undefined;
+  }
+  const debugView = (await debugControl.openView()) as DebugView;
+  const callStackSection = await debugView.getCallStackSection();
+
+  // Read the full visible text of the section; ANSI codes are not present here
+  // because the sidebar uses normal DOM rendering, not a terminal emulator.
+  const rawText = await callStackSection.getText();
+
+  // First ".c N" or ".c:N" occurrence = frame 0 (app_main after step-over)
+  const m = rawText.match(/\.c[:\s]+(\d+)/);
+  if (!m) {
+    return undefined;
+  }
+  return parseInt(m[1], 10);
+}
+
+/**
+ * Removes ANSI/VT100 escape sequences from a string.
+ * `WebElement.getText()` on terminal-like views (Debug Console, Terminal) can
+ * return raw bytes including colour codes that break regex matching.
+ */
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1B\[[0-9;]*[A-Za-z]/g, "");
+}
+
+/**
+ * Returns a clean (ANSI-stripped) snapshot of the Debug Console text.
+ * GDB output appears in the Debug Console, not in the Terminal view.
+ * `DebugConsoleView` inherits `getText()` from Selenium's `WebElement`, which
+ * returns raw DOM text including ANSI codes — we strip them here so callers
+ * can use plain-text regex patterns.
+ */
+export async function readDebugConsoleText(): Promise<string> {
+  const panel = new BottomBarPanel();
+  const debugConsole: DebugConsoleView = await panel.openDebugConsoleView();
+  return stripAnsi(await debugConsole.getText());
+}
+
+/**
+ * Polls the named VS Code Output channel until `pattern` matches or the
+ * timeout expires.  Used to detect long-running background operations that
+ * write their completion status to an Output channel (e.g. idf.py set-target).
+ */
+export async function waitForOutputChannelText(
+  channel: string,
+  pattern: RegExp,
+  timeoutMs: number
+): Promise<string> {
+  const panel = new BottomBarPanel();
+  const outputView: OutputView = await panel.openOutputView();
+  await outputView.selectChannel(channel);
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const text = await outputView.getText();
+    if (pattern.test(text)) {
+      return text;
+    }
+    await new Promise((res) => setTimeout(res, 2000));
+  }
+
+  const text = await outputView.getText();
+  throw new Error(
+    `Timed out waiting for output channel "${channel}" to match ${pattern}.\nLast output:\n${text}`
+  );
+}
+
+/**
+ * Like `waitForTerminalOutput` but only matches text that is NEW since
+ * `snapshot` was captured.  Pass `readCurrentTerminalText()` taken just before
+ * issuing the action to avoid a false-positive match on pre-existing output.
+ */
+export async function waitForNewTerminalOutput(
+  snapshot: string,
+  pattern: RegExp,
+  timeoutMs: number
+): Promise<string> {
+  const panel = new BottomBarPanel();
+  const terminalView = await panel.openTerminalView();
+  const deadline = Date.now() + timeoutMs;
+
+  // Use the last 200 characters of the snapshot as an anchor instead of
+  // slicing at snapshot.length.  This survives scrollback truncation (where
+  // the leading part of the snapshot may have been dropped from the buffer)
+  // and avoids scanning an arbitrarily large snapshot string on every poll.
+  const anchor = snapshot.slice(-200);
+
+  function newTextSince(full: string): string {
+    const idx = full.lastIndexOf(anchor);
+    return idx >= 0 ? full.slice(idx + anchor.length) : full;
+  }
+
+  while (Date.now() < deadline) {
+    const full = await terminalView.getText();
+    if (pattern.test(newTextSince(full))) {
+      return full;
+    }
+    await new Promise((res) => setTimeout(res, 2000));
+  }
+
+  const full = await terminalView.getText();
+  throw new Error(
+    `Timed out waiting for NEW terminal output matching ${pattern}.\nNew text since snapshot:\n${newTextSince(full)}`
+  );
+}
+
+/**
+ * Force-terminates OpenOCD and GDB processes left behind by a debug session.
+ *
+ * Called from both the normal "stop" path inside the test AND from the suite's
+ * `after` hook so that stale processes never block the next CI iteration.
+ * `pkill -f` matches the full argv string, catching every chip-specific GDB
+ * variant.  Exit code 1 ("no process matched") is silently swallowed.
+ */
+export async function killDebugProcesses(): Promise<void> {
+  const patterns = [
+    "openocd",
+    "xtensa-esp.*-gdb",
+    "riscv32-esp.*-gdb",
+  ];
+  await Promise.all(
+    patterns.map((p) => execAsync(`pkill -f "${p}"`).catch(() => undefined))
+  );
+  await new Promise((res) => setTimeout(res, 1500));
 }

--- a/testFiles/testWorkspace/main/hello_world_main.c
+++ b/testFiles/testWorkspace/main/hello_world_main.c
@@ -5,5 +5,8 @@ static const char *TAG = "hello_world";
 
 void app_main(void)
 {
+    volatile int a = 1;
+    volatile int b = a + 1;
     ESP_LOGI(TAG, "UI test monitor output check");
+    printf("Result: %d\n", b);
 }


### PR DESCRIPTION
## Description

Adds a complete JTAG debug end-to-end test. The test runs after the existing build → flash → monitor chain and verifies that the ESP-IDF extension can launch a JTAG debug session, halt at a known breakpoint, and perform a Step Over with the program counter advancing to the expected next line.

## What is tested
The debug test (skipped automatically if flash or monitor failed):

Switches the flash method to JTAG via the Command Palette
Sets the chip target to esp32 and board config to ESP32-ETHERNET-KIT
Waits for idf.py set-target to complete (polls the ESP-IDF output channel)
Performs a full clean + rebuild so the binary matches the new target
Opens hello_world_main.c and places an explicit breakpoint at line 8 (volatile int a = 1;)
Launches the debugger via VS Code's built-in workbench.action.debug.start
Waits for GDB to halt and verifies it stopped at exactly line 8 using TextEditor.getPausedBreakpoint().getLineNumber() — the purpose-built vscode-extension-tester API for this
Executes Step Over and verifies the program counter moved to exactly line 9 (volatile int b = a + 1;)
Confirms the debug session is still alive and no fatal OpenOCD errors appeared in the ESP-IDF output channel
Stops the session cleanly: toolbar stop → workbench.action.debug.stop → pkill openocd/gdb


## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Click on "Command"
2. Execute action.
3. Observe results.

- Expected behaviour:

- Expected output:

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A
- Test B

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded hardware end-to-end coverage to include build → flash → monitor → debug, with automated debug stepping and source-line verification.
  * Added UI-test support for “Set Espressif Device Target”.

* **Bug Fixes**
  * Improved debug stop/cleanup by tracking the active debug toolbar and force-killing lingering OpenOCD/GDB processes.
  * Enhanced GDB stop-location parsing and added more resilient step sequencing.

* **Tests**
  * Improved UI-test helpers with deterministic quick-pick selection, ANSI-stripped console/terminal assertions, and polling utilities for output channels and new terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->