### PR TITLE
add gdbinit files in debug config resolution

### DIFF
--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -153,12 +153,26 @@ You can modify the configuration to suit your needs. Let's describe the configur
 
 - ``type``: The type of the debug configuration. It should be set to ``gdbtarget``.
 - ``program``: ELF file of your project build directory to execute the debug session. You can use the command ``${command:espIdf.getProjectName}`` to query the extension to find the current build directory project name.
-- ``initCommands``: GDB Commands to initialize GDB and target. The default value is ``["set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM", "mon reset halt", "maintenance flush register-cache"]``.
-- ``initialBreakpoint``: When ``initCommands`` is not defined, this command will add to default ``initCommands`` a hardware breakpoint at the given function name. For example app_main, the default value, will add ``thb app_main`` to default initCommmands. If set to "", an empty string, no initial breakpoint will be set and if let undefined it will use the default thb app_main.
+- ``initCommands``: Optional GDB commands run **after** the target is connected via ``target.connectCommands``. The extension does not inject a default ``initCommands`` list.
+- ``initialBreakpoint``: When set to a non-empty string (for example ``app_main``), the extension appends ``thb <value>`` to ``initCommands``. If set to ``""`` (empty string) or omitted, no breakpoint is added from this setting.
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` is resolved by the extension from ``CONFIG_SOC_CPU_WATCHPOINTS_NUM`` in your project's ``sdkconfig``, for both default and user-defined ``initCommands``. If the value is missing, it falls back to ``2``. The braced form of this placeholder is also supported.
+     **GDB command order.** The Eclipse CDT GDB Adapter runs ``target.connectCommands`` first to attach to the target, then runs ``initCommands``.
+
+     When files exist under ``idf.buildPath``, the extension **prepends** commands to ``target.connectCommands`` (before any user-defined ``connectCommands``), in this order:
+
+     1. ``gdbinit/gdbinit`` — ESP-IDF aggregate script (typically sources symbols and connect; available from ESP-IDF v5.3.3). If this file is missing, the extension prepends the same connect sequence as ESP-IDF's ``gdbinit/connect``:
+
+        - ``set remotetimeout 10``
+        - ``target remote :3333``
+        - ``monitor reset halt``
+        - ``maintenance flush register-cache``
+        - ``thbreak app_main``
+
+     2. ``gdbinit/prefix_map``, or fallback ``prefix_map_gdbinit`` — path remapping for reproducible builds. This is a separate file and is **not** included inside ``gdbinit/gdbinit``.
+
+     On ESP-IDF ≥ 5.3.3, ``build/gdbinit/gdbinit`` usually already connects to OpenOCD, so extra user ``connectCommands`` are optional and additive. If ``CONFIG_APP_REPRODUCIBLE_BUILD`` is enabled and no prefix map file is found, the extension shows an information message.
 
 Some additional arguments you might use are:
 
@@ -200,11 +214,11 @@ Some additional arguments you might use are:
             "host": "Target host to connect to (defaults to 'localhost', ignored if parameters is set)",
             "port": "Target port to connect to (defaults to value captured by serverPortRegExp, ignored if parameters is set)",
             "parameters": "Target parameters for the type of target. Normally something like localhost:12345. (defaults to `${host}:${port}`)",
-            "connectCommands": "Replace all previous parameters to specify an array of commands to establish connection"
+            "connectCommands": "Array of GDB commands to establish the connection. Auto-sourced gdbinit ``source`` lines are prepended before these user-defined commands"
         }
     }
 
-An example of a modified launch.json file is shown below:
+An example of a customized ``launch.json`` is shown below. The minimal default configuration above is enough for most projects when ESP-IDF has generated ``build/gdbinit/gdbinit``. Optional fields can be added as needed:
 
 .. code-block:: JSON
 
@@ -215,23 +229,19 @@ An example of a modified launch.json file is shown below:
                 "request": "attach",
                 "name": "Eclipse CDT GDB Adapter",
                 "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
-                "initCommands": [
-                    "set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM",
-                    "mon reset halt",
-                    "maintenance flush register-cache"
-                ],
                 "gdb": "${command:espIdf.getToolchainGdb}",
+                "initialBreakpoint": "app_main",
+                "initCommands": [
+                    "set remote hardware-watchpoint-limit 2"
+                ],
                 "target": {
                     "connectCommands": [
-                        "set remotetimeout 20",
-                        "target remote localhost:3333"
+                        "set remotetimeout 20"
                     ]
                 }
             }
         ]
     }
-
-While the previous example is explicitly using the default values, it can be customized to suit your needs.
 
 There are other, less used arguments documented in the ESP-IDF VS Code extension's package.json gdbtarget debugger contribution.
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -154,25 +154,31 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``type``: The type of the debug configuration. It should be set to ``gdbtarget``.
 - ``program``: ELF file of your project build directory to execute the debug session. You can use the command ``${command:espIdf.getProjectName}`` to query the extension to find the current build directory project name.
 - ``initCommands``: Optional GDB commands run **after** the target is connected via ``target.connectCommands``. The extension does not inject a default ``initCommands`` list.
-- ``initialBreakpoint``: When set to a non-empty string (for example ``app_main``), the extension appends ``thb <value>`` to ``initCommands``. If set to ``""`` (empty string) or omitted, no breakpoint is added from this setting.
+- ``initialBreakpoint``: When set to a non-empty string (for example ``app_main``), the extension appends ``thb <value>`` to ``initCommands``. When set to ``""`` (empty string), the session does not stop on an initial breakpoint. When omitted, the extension adds ``thbreak app_main`` to the connect sequence.
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
      **GDB command order.** The Eclipse CDT GDB Adapter runs ``target.connectCommands`` first to attach to the target, then runs ``initCommands``.
 
-     When files exist under ``idf.buildPath``, the extension **prepends** commands to ``target.connectCommands`` (before any user-defined ``connectCommands``), in this order:
+     The extension **prepends** commands to ``target.connectCommands`` (before any user-defined ``connectCommands``), in this order:
 
-     1. ``gdbinit/gdbinit`` — ESP-IDF aggregate script (typically sources symbols and connect; available from ESP-IDF v5.3.3). If this file is missing, the extension prepends the same connect sequence as ESP-IDF's ``gdbinit/connect``:
+     1. A ``source`` line for each ESP-IDF generated gdbinit file listed in ``gdbinit_files`` of ``build/project_description.json``, using the same order as ``idf.py gdb``: ``symbols``, ``prefix_map`` and ``py_extensions``. ``py_extensions`` is skipped when the configured GDB has no Python support. When ``gdbinit_files`` is unavailable, the extension looks for those files under ``${idf.buildPath}/gdbinit`` and falls back to ``prefix_map_gdbinit`` for path remapping.
+
+     2. The commands from ESP-IDF's ``gdbinit/connect`` file, replayed one by one instead of being sourced, with these adjustments:
+
+        - The trailing ``continue`` is dropped. Connect commands run before the debug session is initialized, so resuming the target here would run past breakpoints the editor has not inserted yet and the resulting stop would not be reported.
+        - ``thbreak app_main`` is dropped when ``initialBreakpoint`` is defined in the launch configuration, so that setting alone decides where the session first stops.
+        - ``target remote :3333`` is rewritten when ``target.host`` or ``target.port`` are defined.
+
+        When the file is missing or has a shape the extension cannot expand, such as the ``CONFIG_IDF_TARGET_LINUX`` variant that has no remote target, the extension falls back to an equivalent sequence:
 
         - ``set remotetimeout 10``
-        - ``target remote :3333``
+        - ``target remote :3333`` — uses ``target.host`` and ``target.port`` when they are defined
         - ``monitor reset halt``
         - ``maintenance flush register-cache``
-        - ``thbreak app_main``
+        - ``thbreak app_main`` — only when ``initialBreakpoint`` is omitted from the launch configuration
 
-     2. ``gdbinit/prefix_map``, or fallback ``prefix_map_gdbinit`` — path remapping for reproducible builds. This is a separate file and is **not** included inside ``gdbinit/gdbinit``.
-
-     On ESP-IDF ≥ 5.3.3, ``build/gdbinit/gdbinit`` usually already connects to OpenOCD, so extra user ``connectCommands`` are optional and additive. If ``CONFIG_APP_REPRODUCIBLE_BUILD`` is enabled and no prefix map file is found, the extension shows an information message.
+     Core dump and GDB Stub post-mortem sessions get only the ``source`` lines, since they provide their own ``connectCommands``. If ``CONFIG_APP_REPRODUCIBLE_BUILD`` is enabled and no prefix map file is found, the extension shows an information message.
 
 Some additional arguments you might use are:
 
@@ -214,11 +220,11 @@ Some additional arguments you might use are:
             "host": "Target host to connect to (defaults to 'localhost', ignored if parameters is set)",
             "port": "Target port to connect to (defaults to value captured by serverPortRegExp, ignored if parameters is set)",
             "parameters": "Target parameters for the type of target. Normally something like localhost:12345. (defaults to `${host}:${port}`)",
-            "connectCommands": "Array of GDB commands to establish the connection. Auto-sourced gdbinit ``source`` lines are prepended before these user-defined commands"
+            "connectCommands": "Array of GDB commands to establish the connection. The gdbinit ``source`` lines and the connect sequence are prepended before these user-defined commands"
         }
     }
 
-An example of a customized ``launch.json`` is shown below. The minimal default configuration above is enough for most projects when ESP-IDF has generated ``build/gdbinit/gdbinit``. Optional fields can be added as needed:
+An example of a customized ``launch.json`` is shown below. The minimal default configuration above is enough for most projects, since the extension resolves the ESP-IDF generated gdbinit files and the connect sequence on its own. Optional fields can be added as needed:
 
 .. code-block:: JSON
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -158,7 +158,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     **IDF_TARGET_CPU_WATCHPOINT_NUM** is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.).
+     **IDF_TARGET_CPU_WATCHPOINT_NUM** (or ``{IDF_TARGET_CPU_WATCHPOINT_NUM}``) is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``.
 
 Some additional arguments you might use are:
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -158,7 +158,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` (or ``\{IDF_TARGET_CPU_WATCHPOINT_NUM\}``) is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``.
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``. The braced form of this placeholder is also supported.
 
 Some additional arguments you might use are:
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -158,7 +158,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     **IDF_TARGET_CPU_WATCHPOINT_NUM** (or ``{IDF_TARGET_CPU_WATCHPOINT_NUM}``) is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``.
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` (or ``\{IDF_TARGET_CPU_WATCHPOINT_NUM\}``) is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``.
 
 Some additional arguments you might use are:
 

--- a/docs_espressif/en/debugproject.rst
+++ b/docs_espressif/en/debugproject.rst
@@ -158,7 +158,7 @@ You can modify the configuration to suit your needs. Let's describe the configur
 - ``gdb``: GDB executable to be used. By default "${command:espIdf.getToolchainGdb}" will query the extension to find the ESP-IDF toolchain GDB for the current IDF_TARGET of your esp-idf project (esp32, esp32c6, etc.).
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` is resolved by the extension according to the current ``IDF_TARGET`` of your esp-idf project (esp32, esp32c6, etc.), for both default and user-defined ``initCommands``. The braced form of this placeholder is also supported.
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` is resolved by the extension from ``CONFIG_SOC_CPU_WATCHPOINTS_NUM`` in your project's ``sdkconfig``, for both default and user-defined ``initCommands``. If the value is missing, it falls back to ``2``. The braced form of this placeholder is also supported.
 
 Some additional arguments you might use are:
 
@@ -224,7 +224,7 @@ An example of a modified launch.json file is shown below:
                 "target": {
                     "connectCommands": [
                         "set remotetimeout 20",
-                        "-target-select extended-remote localhost:3333"
+                        "target remote localhost:3333"
                     ]
                 }
             }
@@ -589,7 +589,7 @@ Another recommended debug extension is the `Native Debug <https://marketplace.vi
                 "type": "gdb",
                 "request": "attach",
                 "name": "NativeDebug",
-                "target": "extended-remote :3333",
+                "target": "target remote localhost:3333",
                 "executable": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
                 "gdbpath": "${command:espIdf.getToolchainGdb}",
                 "cwd": "${workspaceRoot}",

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -599,7 +599,7 @@ ESP-IDF 扩展提供了 **ESP-IDF：图像查看器** 功能，允许你在调�
                 "type": "gdb",
                 "request": "attach",
                 "name": "NativeDebug",
-                "target": "target remote :3333",
+                "target": "target remote localhost:3333",
                 "executable": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
                 "gdbpath": "${command:espIdf.getToolchainGdb}",
                 "cwd": "${workspaceRoot}",

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -158,7 +158,7 @@
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` 由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。该占位符的花括号形式同样受支持。
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` 由扩展从项目 ``sdkconfig`` 中的 ``CONFIG_SOC_CPU_WATCHPOINTS_NUM`` 解析，适用于默认和用户自定义的 ``initCommands``。如果该值缺失，则回退为 ``2``。该占位符的花括号形式同样受支持。
 
 你可能使用的其他参数包括：
 
@@ -224,7 +224,7 @@
                 "target": {
                     "connectCommands": [
                         "set remotetimeout 20",
-                        "-target-select extended-remote localhost:3333"
+                        "target remote localhost:3333"
                     ]
                 }
             }
@@ -589,7 +589,7 @@ ESP-IDF 扩展提供了 **ESP-IDF：图像查看器** 功能，允许你在调�
                 "type": "gdb",
                 "request": "attach",
                 "name": "NativeDebug",
-                "target": "extended-remote :3333",
+                "target": "target remote :3333",
                 "executable": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
                 "gdbpath": "${command:espIdf.getToolchainGdb}",
                 "cwd": "${workspaceRoot}",

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -154,7 +154,7 @@
 - ``type``: 调试配置的类型。应设置为 ``gdbtarget``。
 - ``program``: 项目构建目录中的 ELF 文件，用于执行调试会话。可以使用命令 ``${command:espIdf.getProjectName}`` 查询扩展以查找当前构建目录的项目名称。
 - ``initCommands``: 可选的 GDB 命令，在通过 ``target.connectCommands`` **连接目标之后** 执行。扩展不会注入默认的 ``initCommands`` 列表。
-- ``initialBreakpoint``: 当设置为非空字符串（例如 ``app_main``）时，扩展会向 ``initCommands`` 追加 ``thb <value>``。如果设置为 ``""``（空字符串）或省略，则不会通过此设置添加断点。
+- ``initialBreakpoint``: 当设置为非空字符串（例如 ``app_main``）时，扩展会向 ``initCommands`` 追加 ``thb <value>``\ 。如果设置为 ``""``\ （空字符串）或省略，则不会通过此设置添加断点。
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -158,7 +158,7 @@
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
-     **IDF_TARGET_CPU_WATCHPOINT_NUM**（或 ``{IDF_TARGET_CPU_WATCHPOINT_NUM}``）由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` （或 ``\{IDF_TARGET_CPU_WATCHPOINT_NUM\}``）由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。
 
 你可能使用的其他参数包括：
 

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -158,7 +158,7 @@
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
-     **IDF_TARGET_CPU_WATCHPOINT_NUM** 由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析。
+     **IDF_TARGET_CPU_WATCHPOINT_NUM**（或 ``{IDF_TARGET_CPU_WATCHPOINT_NUM}``）由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。
 
 你可能使用的其他参数包括：
 

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -158,7 +158,7 @@
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` （或 ``\{IDF_TARGET_CPU_WATCHPOINT_NUM\}``）由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。
+     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` 由扩展根据当前 ESP-IDF 项目的 ``IDF_TARGET`` （esp32、esp32c6 等）解析，适用于默认和用户自定义的 ``initCommands``。该占位符的花括号形式同样受支持。
 
 你可能使用的其他参数包括：
 

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -154,25 +154,31 @@
 - ``type``: 调试配置的类型。应设置为 ``gdbtarget``。
 - ``program``: 项目构建目录中的 ELF 文件，用于执行调试会话。可以使用命令 ``${command:espIdf.getProjectName}`` 查询扩展以查找当前构建目录的项目名称。
 - ``initCommands``: 可选的 GDB 命令，在通过 ``target.connectCommands`` **连接目标之后** 执行。扩展不会注入默认的 ``initCommands`` 列表。
-- ``initialBreakpoint``: 当设置为非空字符串（例如 ``app_main``）时，扩展会向 ``initCommands`` 追加 ``thb <value>``\ 。如果设置为 ``""``\ （空字符串）或省略，则不会通过此设置添加断点。
+- ``initialBreakpoint``: 当设置为非空字符串（例如 ``app_main``）时，扩展会向 ``initCommands`` 追加 ``thb <value>``\ 。当设置为 ``""``\ （空字符串）时，会话不会在初始断点处停止。当省略该字段时，扩展会向连接命令序列添加 ``thbreak app_main``\ 。
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
      **GDB 命令顺序。** Eclipse CDT GDB 适配器会先执行 ``target.connectCommands`` 以附加到目标，然后再执行 ``initCommands``。
 
-     当 ``idf.buildPath`` 下存在相应路径时，扩展会将这些命令 **前置** 到 ``target.connectCommands``（位于任何用户定义的 ``connectCommands`` 之前），顺序如下：
+     扩展会将这些命令 **前置** 到 ``target.connectCommands``（位于任何用户定义的 ``connectCommands`` 之前），顺序如下：
 
-     1. ``gdbinit/gdbinit`` — ESP-IDF 聚合脚本（通常会 source symbols 和 connect；自 ESP-IDF v5.3.3 起可用）。如果该文件缺失，扩展会前置与 ESP-IDF ``gdbinit/connect`` 相同的连接命令序列：
+     1. 为 ``build/project_description.json`` 中 ``gdbinit_files`` 列出的每个 ESP-IDF 生成的 gdbinit 文件添加一条 ``source`` 命令，顺序与 ``idf.py gdb`` 相同：``symbols``\ 、``prefix_map`` 和 ``py_extensions``\ 。当所配置的 GDB 不支持 Python 时，会跳过 ``py_extensions``\ 。当 ``gdbinit_files`` 不可用时，扩展会在 ``${idf.buildPath}/gdbinit`` 下查找这些文件，并回退到 ``prefix_map_gdbinit`` 作为路径重映射文件。
+
+     2. ESP-IDF ``gdbinit/connect`` 文件中的命令。扩展会逐条重放这些命令，而不是 source 该文件，并进行以下调整：
+
+        - 删除结尾的 ``continue``\ 。连接命令在调试会话初始化完成之前执行，此时恢复目标运行会越过编辑器尚未插入的断点，并且产生的停止事件不会被上报。
+        - 当启动配置中定义了 ``initialBreakpoint`` 时，删除 ``thbreak app_main``\ ，使该设置成为决定会话首次停止位置的唯一依据。
+        - 当定义了 ``target.host`` 或 ``target.port`` 时，重写 ``target remote :3333``\ 。
+
+        当该文件缺失，或其结构无法被扩展展开时（例如没有远程目标的 ``CONFIG_IDF_TARGET_LINUX`` 变体），扩展会回退到等效的命令序列：
 
         - ``set remotetimeout 10``
-        - ``target remote :3333``
+        - ``target remote :3333`` — 当定义了 ``target.host`` 和 ``target.port`` 时会使用这些值
         - ``monitor reset halt``
         - ``maintenance flush register-cache``
-        - ``thbreak app_main``
+        - ``thbreak app_main`` — 仅当启动配置中省略了 ``initialBreakpoint`` 时添加
 
-     2. ``gdbinit/prefix_map``，或回退到 ``prefix_map_gdbinit`` — 用于可复现构建的路径重映射。这是单独的文件，**不会** 包含在 ``gdbinit/gdbinit`` 中。
-
-     在 ESP-IDF ≥ 5.3.3 上，``build/gdbinit/gdbinit`` 通常已连接到 OpenOCD，因此额外的用户 ``connectCommands`` 是可选且可叠加的。如果启用了 ``CONFIG_APP_REPRODUCIBLE_BUILD`` 但未找到 prefix map 文件，扩展会显示一条提示信息。
+     核心转储和 GDB Stub 事后调试会话只会前置 ``source`` 命令行，因为它们会提供各自的 ``connectCommands``\ 。如果启用了 ``CONFIG_APP_REPRODUCIBLE_BUILD`` 但未找到 prefix map 文件，扩展会显示一条提示信息。
 
 你可能使用的其他参数包括：
 
@@ -214,11 +220,11 @@
             "host": "要连接的目标主机（默认为 'localhost'，如果设置了 parameters 则忽略）",
             "port": "要连接的目标端口（默认为 serverPortRegExp 捕获的值，如果设置了 parameters 则忽略）",
             "parameters": "目标类型的目标参数。通常是类似 localhost:12345 的内容。（默认为 `${host}:${port}`）",
-            "connectCommands": "用于建立连接的 GDB 命令数组。自动 source 的 gdbinit ``source`` 行会前置到这些用户定义的命令之前"
+            "connectCommands": "用于建立连接的 GDB 命令数组。gdbinit ``source`` 命令行和连接命令序列会前置到这些用户定义的命令之前"
         }
     }
 
-下面显示了一个自定义的 ``launch.json`` 示例。当 ESP-IDF 已生成 ``build/gdbinit/gdbinit`` 时，上面的最小默认配置对大多数项目已足够。可按需添加可选字段：
+下面显示了一个自定义的 ``launch.json`` 示例。由于扩展会自行解析 ESP-IDF 生成的 gdbinit 文件和连接命令序列，上面的最小默认配置对大多数项目已足够。可按需添加可选字段：
 
 .. code-block:: JSON
 

--- a/docs_espressif/zh_CN/debugproject.rst
+++ b/docs_espressif/zh_CN/debugproject.rst
@@ -153,12 +153,26 @@
 
 - ``type``: 调试配置的类型。应设置为 ``gdbtarget``。
 - ``program``: 项目构建目录中的 ELF 文件，用于执行调试会话。可以使用命令 ``${command:espIdf.getProjectName}`` 查询扩展以查找当前构建目录的项目名称。
-- ``initCommands``: 用于初始化 GDB 和目标设备的 GDB 命令。默认值为 ``["set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM", "mon reset halt", "maintenance flush register-cache"]``。
-- ``initialBreakpoint``: 当未定义 ``initCommands`` 时，此命令将在默认 ``initCommands`` 中添加指定函数名的硬件断点。例如 app_main（默认值）将在默认 initCommands 中添加 ``thb app_main``。如果设置为 ""（空字符串），则不会设置初始断点；如果未定义，则使用默认值 thb app_main。
+- ``initCommands``: 可选的 GDB 命令，在通过 ``target.connectCommands`` **连接目标之后** 执行。扩展不会注入默认的 ``initCommands`` 列表。
+- ``initialBreakpoint``: 当设置为非空字符串（例如 ``app_main``）时，扩展会向 ``initCommands`` 追加 ``thb <value>``。如果设置为 ``""``（空字符串）或省略，则不会通过此设置添加断点。
 - ``gdb``: 要使用的 GDB 可执行文件。默认情况下，"${command:espIdf.getToolchainGdb}" 将查询扩展以查找当前 ESP-IDF 项目的 IDF_TARGET（esp32、esp32c6 等）对应的 ESP-IDF 工具链 GDB。
 
 .. note::
-     ``IDF_TARGET_CPU_WATCHPOINT_NUM`` 由扩展从项目 ``sdkconfig`` 中的 ``CONFIG_SOC_CPU_WATCHPOINTS_NUM`` 解析，适用于默认和用户自定义的 ``initCommands``。如果该值缺失，则回退为 ``2``。该占位符的花括号形式同样受支持。
+     **GDB 命令顺序。** Eclipse CDT GDB 适配器会先执行 ``target.connectCommands`` 以附加到目标，然后再执行 ``initCommands``。
+
+     当 ``idf.buildPath`` 下存在相应路径时，扩展会将这些命令 **前置** 到 ``target.connectCommands``（位于任何用户定义的 ``connectCommands`` 之前），顺序如下：
+
+     1. ``gdbinit/gdbinit`` — ESP-IDF 聚合脚本（通常会 source symbols 和 connect；自 ESP-IDF v5.3.3 起可用）。如果该文件缺失，扩展会前置与 ESP-IDF ``gdbinit/connect`` 相同的连接命令序列：
+
+        - ``set remotetimeout 10``
+        - ``target remote :3333``
+        - ``monitor reset halt``
+        - ``maintenance flush register-cache``
+        - ``thbreak app_main``
+
+     2. ``gdbinit/prefix_map``，或回退到 ``prefix_map_gdbinit`` — 用于可复现构建的路径重映射。这是单独的文件，**不会** 包含在 ``gdbinit/gdbinit`` 中。
+
+     在 ESP-IDF ≥ 5.3.3 上，``build/gdbinit/gdbinit`` 通常已连接到 OpenOCD，因此额外的用户 ``connectCommands`` 是可选且可叠加的。如果启用了 ``CONFIG_APP_REPRODUCIBLE_BUILD`` 但未找到 prefix map 文件，扩展会显示一条提示信息。
 
 你可能使用的其他参数包括：
 
@@ -200,11 +214,11 @@
             "host": "要连接的目标主机（默认为 'localhost'，如果设置了 parameters 则忽略）",
             "port": "要连接的目标端口（默认为 serverPortRegExp 捕获的值，如果设置了 parameters 则忽略）",
             "parameters": "目标类型的目标参数。通常是类似 localhost:12345 的内容。（默认为 `${host}:${port}`）",
-            "connectCommands": "替换所有先前的参数，指定用于建立连接的命令数组"
+            "connectCommands": "用于建立连接的 GDB 命令数组。自动 source 的 gdbinit ``source`` 行会前置到这些用户定义的命令之前"
         }
     }
 
-下面显示了一个修改后的 launch.json 文件示例：
+下面显示了一个自定义的 ``launch.json`` 示例。当 ESP-IDF 已生成 ``build/gdbinit/gdbinit`` 时，上面的最小默认配置对大多数项目已足够。可按需添加可选字段：
 
 .. code-block:: JSON
 
@@ -215,23 +229,19 @@
                 "request": "attach",
                 "name": "Eclipse CDT GDB Adapter",
                 "program": "${workspaceFolder}/build/${command:espIdf.getProjectName}.elf",
-                "initCommands": [
-                    "set remote hardware-watchpoint-limit IDF_TARGET_CPU_WATCHPOINT_NUM",
-                    "mon reset halt",
-                    "maintenance flush register-cache"
-                ],
                 "gdb": "${command:espIdf.getToolchainGdb}",
+                "initialBreakpoint": "app_main",
+                "initCommands": [
+                    "set remote hardware-watchpoint-limit 2"
+                ],
                 "target": {
                     "connectCommands": [
-                        "set remotetimeout 20",
-                        "target remote localhost:3333"
+                        "set remotetimeout 20"
                     ]
                 }
             }
         ]
     }
-
-虽然前面的示例明确使用了默认值，但可以根据需要进行自定义。
 
 ESP-IDF VS Code 扩展的 package.json gdbtarget 调试器贡献中记录了其他较少使用的参数。
 

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -275,5 +275,9 @@
   "No project configuration selected. Click to select one": "No se seleccionó ninguna configuración de proyecto. Haga clic para seleccionar una",
   "Legacy Configs ({0})": "Configuraciones heredadas ({0})",
   "Found legacy project configurations: {0}. Click to migrate to the new CMakePresets.json format.": "Se encontraron configuraciones de proyecto heredadas: {0}. Haga clic para migrar al nuevo formato CMakePresets.json.",
-  "Project Configuration changes have been saved": "Se han guardado los cambios de configuración del proyecto"
+  "Project Configuration changes have been saved": "Se han guardado los cambios de configuración del proyecto",
+  "Update launch.json": "Actualizar launch.json",
+  "runOpenOCD is now true for '{0}'. Start the debug session again.": "runOpenOCD ahora es true para '{0}'. Inicie la sesión de depuración de nuevo.",
+  "The debug session failed and 'runOpenOCD' is false in your launch.json, so the extension did not start OpenOCD and none is listening. Set 'runOpenOCD' to true to let the extension start it, or start OpenOCD yourself before debugging.": "La sesión de depuración falló y 'runOpenOCD' es false en su launch.json, por lo que la extensión no inició OpenOCD y no hay ninguno escuchando. Establezca 'runOpenOCD' en true para que la extensión lo inicie, o inicie OpenOCD usted mismo antes de depurar.",
+  "Failed to update runOpenOCD in launch.json": "No se pudo actualizar runOpenOCD en launch.json"
 }

--- a/l10n/bundle.l10n.pt.json
+++ b/l10n/bundle.l10n.pt.json
@@ -276,5 +276,9 @@
   "No project configuration selected. Click to select one": "Nenhuma configuração de projeto selecionada. Clique para selecionar uma",
   "Legacy Configs ({0})": "Configurações legadas ({0})",
   "Found legacy project configurations: {0}. Click to migrate to the new CMakePresets.json format.": "Foram encontradas configurações de projeto legadas: {0}. Clique para migrar para o novo formato CMakePresets.json.",
-  "Project Configuration changes have been saved": "As alterações na configuração do projeto foram salvas"
+  "Project Configuration changes have been saved": "As alterações na configuração do projeto foram salvas",
+  "Update launch.json": "Atualizar launch.json",
+  "runOpenOCD is now true for '{0}'. Start the debug session again.": "runOpenOCD agora é true para '{0}'. Inicie a sessão de depuração novamente.",
+  "The debug session failed and 'runOpenOCD' is false in your launch.json, so the extension did not start OpenOCD and none is listening. Set 'runOpenOCD' to true to let the extension start it, or start OpenOCD yourself before debugging.": "A sessão de depuração falhou e 'runOpenOCD' é false no seu launch.json, então a extensão não iniciou o OpenOCD e nenhum está escutando. Defina 'runOpenOCD' como true para que a extensão o inicie, ou inicie o OpenOCD você mesmo antes de depurar.",
+  "Failed to update runOpenOCD in launch.json": "Falha ao atualizar runOpenOCD em launch.json"
 }

--- a/l10n/bundle.l10n.ru.json
+++ b/l10n/bundle.l10n.ru.json
@@ -276,5 +276,9 @@
   "No project configuration selected. Click to select one": "Конфигурация проекта не выбрана. Нажмите, чтобы выбрать",
   "Legacy Configs ({0})": "Унаследованные конфигурации ({0})",
   "Found legacy project configurations: {0}. Click to migrate to the new CMakePresets.json format.": "Найдены устаревшие конфигурации проекта: {0}. Нажмите, чтобы выполнить миграцию в новый формат CMakePresets.json.",
-  "Project Configuration changes have been saved": "Изменения конфигурации проекта сохранены"
+  "Project Configuration changes have been saved": "Изменения конфигурации проекта сохранены",
+  "Update launch.json": "Обновить launch.json",
+  "runOpenOCD is now true for '{0}'. Start the debug session again.": "runOpenOCD теперь true для '{0}'. Запустите сеанс отладки снова.",
+  "The debug session failed and 'runOpenOCD' is false in your launch.json, so the extension did not start OpenOCD and none is listening. Set 'runOpenOCD' to true to let the extension start it, or start OpenOCD yourself before debugging.": "Сеанс отладки завершился с ошибкой, а 'runOpenOCD' имеет значение false в launch.json, поэтому расширение не запустило OpenOCD и никто не прослушивает. Установите 'runOpenOCD' в true, чтобы расширение запустило его, или запустите OpenOCD самостоятельно перед отладкой.",
+  "Failed to update runOpenOCD in launch.json": "Не удалось обновить runOpenOCD в launch.json"
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -276,5 +276,9 @@
   "No project configuration selected. Click to select one": "未选择项目配置。单击选择一个",
   "Legacy Configs ({0})": "旧版配置（{0}）",
   "Found legacy project configurations: {0}. Click to migrate to the new CMakePresets.json format.": "发现旧版项目配置：{0}。单击迁移到新的 CMakePresets.json 格式。",
-  "Project Configuration changes have been saved": "项目配置更改已保存"
+  "Project Configuration changes have been saved": "项目配置更改已保存",
+  "Update launch.json": "更新 launch.json",
+  "runOpenOCD is now true for '{0}'. Start the debug session again.": "已将 '{0}' 的 runOpenOCD 设置为 true。请重新启动调试会话。",
+  "The debug session failed and 'runOpenOCD' is false in your launch.json, so the extension did not start OpenOCD and none is listening. Set 'runOpenOCD' to true to let the extension start it, or start OpenOCD yourself before debugging.": "调试会话失败，且 launch.json 中的 'runOpenOCD' 为 false，因此扩展未启动 OpenOCD，且当前没有 OpenOCD 在监听。将 'runOpenOCD' 设为 true 以让扩展启动它，或在调试前自行启动 OpenOCD。",
+  "Failed to update runOpenOCD in launch.json": "无法更新 launch.json 中的 runOpenOCD"
 }

--- a/package.json
+++ b/package.json
@@ -1988,7 +1988,7 @@
                 "default": {
                   "connectCommands": [
                     "set remotetimeout 20",
-                    "-target-select extended-remote localhost:3333"
+                    "target remote localhost:3333"
                   ]
                 },
                 "properties": {
@@ -2007,13 +2007,13 @@
                   },
                   "connectCommands": {
                     "type": "array",
-                    "description": "Commands to execute for target connection. Normally something like [`-target-select extended-remote localhost:3333`]",
+                    "description": "Commands to execute for target connection. Normally something like [`target remote localhost:3333`]",
                     "items": {
                       "type": "string"
                     },
                     "default": [
                       "set remotetimeout 20",
-                      "-target-select extended-remote localhost:3333"
+                      "target remote localhost:3333"
                     ]
                   },
                   "host": {
@@ -2262,7 +2262,7 @@
                 "default": {
                   "connectCommands": [
                     "set remotetimeout 20",
-                    "-target-select extended-remote localhost:3333"
+                    "target remote localhost:3333"
                   ]
                 },
                 "properties": {
@@ -2363,13 +2363,13 @@
                   },
                   "connectCommands": {
                     "type": "array",
-                    "description": "Commands to execute for target connection. Normally something like [`-target-select extended-remote localhost:3333`]",
+                    "description": "Commands to execute for target connection. Normally something like [`target remote localhost:3333`]",
                     "items": {
                       "type": "string"
                     },
                     "default": [
                       "set remotetimeout 20",
-                      "-target-select extended-remote localhost:3333"
+                      "target remote localhost:3333"
                     ]
                   }
                 }

--- a/package.json
+++ b/package.json
@@ -2007,7 +2007,7 @@
                   },
                   "connectCommands": {
                     "type": "array",
-                    "description": "Commands to execute for target connection. Normally something like [`target remote localhost:3333`]",
+                    "description": "%debug.target.connectCommands.description%",
                     "items": {
                       "type": "string"
                     },
@@ -2363,7 +2363,7 @@
                   },
                   "connectCommands": {
                     "type": "array",
-                    "description": "Commands to execute for target connection. Normally something like [`target remote localhost:3333`]",
+                    "description": "%debug.target.connectCommands.description%",
                     "items": {
                       "type": "string"
                     },

--- a/package.json
+++ b/package.json
@@ -1946,7 +1946,7 @@
               },
               "initialBreakpoint": {
                 "type": "string",
-                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined it will use the default 'thb app_main'. Ignored if user defines initCommands argument.",
+                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined the extension adds 'thbreak app_main' to the connect commands.",
                 "default": "app_main"
               },
               "preRunCommands": {
@@ -2220,7 +2220,7 @@
               },
               "initialBreakpoint": {
                 "type": "string",
-                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined it will use the default 'thb app_main'. Ignored if user defines initCommands argument.",
+                "description": "Initial hardware breakpoint being set as 'thb <value>'. For a value 'app_main' result in 'thb app_main' in initCommands. If user set an empty string '' no initial breakpoint will be set and if let undefined the extension adds 'thbreak app_main' to the connect commands.",
                 "default": "app_main"
               },
               "preRunCommands": {

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -17,6 +17,7 @@
 	"configuration.section.other": "Otros",
 	"debug.initConfig.description": "Una nueva configuración para lanzar proyectos ESP-IDF",
 	"debug.initConfig.name": "Depuración de ESP-IDF: Lanzamiento",
+	"debug.target.connectCommands.description": "Comandos a ejecutar para la conexión con el destino. Normalmente algo como [`target remote localhost:3333`]",
 	"esp.component-manager.cli.addDependencyError": "Se encontró un error al agregar una dependencia al componente",
 	"esp.component-manager.ui.show.title": "Mostrar Registro de Componentes ESP",
 	"esp.component-manager.url.description": "URL del registro de componentes",

--- a/package.nls.json
+++ b/package.nls.json
@@ -17,6 +17,7 @@
   "configuration.section.other": "Other",
   "debug.initConfig.description": "A new configuration for launch ESP-IDF projects",
   "debug.initConfig.name": "ESP-IDF Debug: Launch",
+  "debug.target.connectCommands.description": "Commands to execute for target connection. Normally something like [`target remote localhost:3333`]",
   "esp.component-manager.cli.addDependencyError": "Error encountered while adding dependency to the component",
   "esp.component-manager.ui.show.title": "Show ESP Component Registry",
   "esp.component-manager.url.description": "ESP Component Registry URL",

--- a/package.nls.pt.json
+++ b/package.nls.pt.json
@@ -17,6 +17,7 @@
 	"configuration.section.other": "Outros",
 	"debug.initConfig.description": "Uma nova configuração para lançamento de projetos ESP-IDF",
 	"debug.initConfig.name": "Depuração ESP-IDF: lançamento",
+	"debug.target.connectCommands.description": "Comandos a executar para conexão com o destino. Normalmente algo como [`target remote localhost:3333`]",
 	"esp.component-manager.cli.addDependencyError": "Erro encontrado ao adicionar dependência ao componente",
 	"esp.component-manager.ui.show.title": "Mostrar registro de componentes ESP",
 	"esp.component-manager.url.description": "URL de registro do componente",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -17,6 +17,7 @@
 	"configuration.section.other": "Прочее",
 	"debug.initConfig.description": "Новая конфигурация для запуска проектов ESP-IDF",
 	"debug.initConfig.name": "ESP-IDF Отладка: Запуск",
+	"debug.target.connectCommands.description": "Команды для подключения к целевому устройству. Обычно что-то вроде [`target remote localhost:3333`]",
 	"esp.component-manager.cli.addDependencyError": "Произошла ошибка при добавлении зависимости к компоненту.",
 	"esp.component-manager.ui.show.title": "Показать Реестр Компонентов ESP",
 	"esp.component-manager.url.description": "URL-адрес Реестра Компонентов",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -17,6 +17,7 @@
 	"configuration.section.other": "其他",
 	"debug.initConfig.description": "为启动 ESP-IDF 项目创建新配置",
 	"debug.initConfig.name": "ESP-IDF 调试：启动",
+	"debug.target.connectCommands.description": "用于建立目标连接的命令。通常类似 [`target remote localhost:3333`]",
 	"esp.component-manager.cli.addDependencyError": "添加依赖到组件时出错",
 	"esp.component-manager.ui.show.title": "乐鑫组件注册表",
 	"esp.component-manager.url.description": "乐鑫组件注册表 URL",

--- a/src/cdtDebugAdapter/adapter/GDBDebugSession.ts
+++ b/src/cdtDebugAdapter/adapter/GDBDebugSession.ts
@@ -204,8 +204,6 @@ export class GDBDebugSession extends LoggingDebugSession {
   // therefore be resumed after breakpoints are inserted.
   protected waitPausedNeeded = false;
   protected isInitialized = false;
-  protected pendingInitialBreakpointStop?: any;
-  protected stopAtInitialBreakpoint = false;
 
   constructor() {
     super();
@@ -478,9 +476,9 @@ export class GDBDebugSession extends LoggingDebugSession {
       const ref = this.variableHandles.get(args.variablesReference);
       const parentVarname = ref.type === "object" ? ref.varobjName : "";
       const varname =
-      parentVarname +
-      (parentVarname === "" ? "" : ".") +
-      args.name.replace(/^\[(\d+)\]/, "$1");
+        parentVarname +
+        (parentVarname === "" ? "" : ".") +
+        args.name.replace(/^\[(\d+)\]/, "$1");
       response.body.dataId = varname;
       response.body.description = varname;
       response.body.accessTypes = ["read", "write", "readWrite"];
@@ -674,7 +672,6 @@ export class GDBDebugSession extends LoggingDebugSession {
         vsbp: DebugProtocol.SourceBreakpoint,
         gdbbp: mi.MIBreakpointInfo
       ): DebugProtocol.Breakpoint => {
-        this.matchInitialBreakpointStop(gdbbp);
         if (vsbp.logMessage) {
           this.logPointMessages[gdbbp.number] = vsbp.logMessage;
         }
@@ -746,9 +743,6 @@ export class GDBDebugSession extends LoggingDebugSession {
             file,
             line,
             options
-          );
-          gdbbp.multiple?.forEach((location) =>
-            this.matchInitialBreakpointStop(location)
           );
           actual.push(createState(vsbp, gdbbp.bkpt));
         } catch (err) {
@@ -963,9 +957,7 @@ export class GDBDebugSession extends LoggingDebugSession {
           "console"
         )
       );
-      if (this.stopAtInitialBreakpoint && this.pendingInitialBreakpointStop) {
-        this.handleGDBStopped(this.pendingInitialBreakpointStop);
-      } else if (!this.isPostMortem) {
+      if (!this.isPostMortem) {
         if (this.isAttach) {
           await mi.sendExecContinue(this.gdb);
         } else {
@@ -974,8 +966,6 @@ export class GDBDebugSession extends LoggingDebugSession {
       } else {
         this.sendEvent(new StoppedEvent("exception", 1, true));
       }
-      this.pendingInitialBreakpointStop = undefined;
-      this.stopAtInitialBreakpoint = false;
       this.sendResponse(response);
     } catch (err) {
       this.sendErrorResponse(
@@ -1806,26 +1796,6 @@ export class GDBDebugSession extends LoggingDebugSession {
     }
   }
 
-  private matchInitialBreakpointStop(breakpoint: mi.MIBreakpointInfo) {
-    const stopAddress = this.pendingInitialBreakpointStop?.frame?.addr;
-    if (!stopAddress) {
-      return;
-    }
-    const breakpointAddresses = [
-      breakpoint.addr,
-      ...(breakpoint.locations?.map((location) => location.addr) ?? [])
-    ];
-    this.stopAtInitialBreakpoint ||= breakpointAddresses.some((address) => address && this.addressesEqual(address, stopAddress));
-  }
-
-  private addressesEqual(left: string, right: string): boolean {
-    try {
-      return BigInt(left) === BigInt(right);
-    } catch {
-      return left.toLowerCase() === right.toLowerCase();
-    }
-  }
-
   protected handleGDBAsync(resultClass: string, resultData: any) {
     const updateIsRunning = () => {
       this.isRunning = this.threads.length ? true : false;
@@ -1852,9 +1822,6 @@ export class GDBDebugSession extends LoggingDebugSession {
         updateIsRunning();
         break;
       case "stopped": {
-        if (!this.isInitialized && resultData.reason === "breakpoint-hit") {
-          this.pendingInitialBreakpointStop = resultData;
-        }
         let suppressHandleGDBStopped = false;
         if (this.gdb.isNonStopMode()) {
           const id = parseInt(resultData["thread-id"], 10);

--- a/src/cdtDebugAdapter/adapter/GDBDebugSession.ts
+++ b/src/cdtDebugAdapter/adapter/GDBDebugSession.ts
@@ -204,6 +204,8 @@ export class GDBDebugSession extends LoggingDebugSession {
   // therefore be resumed after breakpoints are inserted.
   protected waitPausedNeeded = false;
   protected isInitialized = false;
+  protected pendingInitialBreakpointStop?: any;
+  protected stopAtInitialBreakpoint = false;
 
   constructor() {
     super();
@@ -472,15 +474,17 @@ export class GDBDebugSession extends LoggingDebugSession {
       accessTypes: undefined,
       canPersist: false,
     };
-    const ref = this.variableHandles.get(args.variablesReference);
-    const parentVarname = ref.type === "object" ? ref.varobjName : "";
-    const varname =
+    if (args.variablesReference) {
+      const ref = this.variableHandles.get(args.variablesReference);
+      const parentVarname = ref.type === "object" ? ref.varobjName : "";
+      const varname =
       parentVarname +
       (parentVarname === "" ? "" : ".") +
       args.name.replace(/^\[(\d+)\]/, "$1");
-    response.body.dataId = varname;
-    response.body.description = varname;
-    response.body.accessTypes = ["read", "write", "readWrite"];
+      response.body.dataId = varname;
+      response.body.description = varname;
+      response.body.accessTypes = ["read", "write", "readWrite"];
+    }
 
     this.sendResponse(response);
   }
@@ -670,6 +674,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         vsbp: DebugProtocol.SourceBreakpoint,
         gdbbp: mi.MIBreakpointInfo
       ): DebugProtocol.Breakpoint => {
+        this.matchInitialBreakpointStop(gdbbp);
         if (vsbp.logMessage) {
           this.logPointMessages[gdbbp.number] = vsbp.logMessage;
         }
@@ -741,6 +746,9 @@ export class GDBDebugSession extends LoggingDebugSession {
             file,
             line,
             options
+          );
+          gdbbp.multiple?.forEach((location) =>
+            this.matchInitialBreakpointStop(location)
           );
           actual.push(createState(vsbp, gdbbp.bkpt));
         } catch (err) {
@@ -838,7 +846,7 @@ export class GDBDebugSession extends LoggingDebugSession {
       ): DebugProtocol.Breakpoint => ({
         id: parseInt(breakpoint.number, 10),
         verified: true,
-        line: parseInt(breakpoint.line, 10),
+        line: breakpoint.line ? parseInt(breakpoint.line, 10) : undefined,
         source: {
           name: breakpoint.file,
           path: breakpoint.fullname,
@@ -955,7 +963,9 @@ export class GDBDebugSession extends LoggingDebugSession {
           "console"
         )
       );
-      if (!this.isPostMortem) {
+      if (this.stopAtInitialBreakpoint && this.pendingInitialBreakpointStop) {
+        this.handleGDBStopped(this.pendingInitialBreakpointStop);
+      } else if (!this.isPostMortem) {
         if (this.isAttach) {
           await mi.sendExecContinue(this.gdb);
         } else {
@@ -964,6 +974,8 @@ export class GDBDebugSession extends LoggingDebugSession {
       } else {
         this.sendEvent(new StoppedEvent("exception", 1, true));
       }
+      this.pendingInitialBreakpointStop = undefined;
+      this.stopAtInitialBreakpoint = false;
       this.sendResponse(response);
     } catch (err) {
       this.sendErrorResponse(
@@ -1245,9 +1257,9 @@ export class GDBDebugSession extends LoggingDebugSession {
         parentVarname +
         (parentVarname === "" ? "" : ".") +
         args.name.replace(/^\[(\d+)\]/, "$1");
-        if (ref.type === "registers") {
-          varname = "$" + args.name;
-        }
+      if (ref.type === "registers") {
+        varname = "$" + args.name;
+      }
       const depth =
         ref.type === "registers"
           ? this.getRegisterVarDepth()
@@ -1333,7 +1345,11 @@ export class GDBDebugSession extends LoggingDebugSession {
           ref.varobjName
         );
         if (isRegisterVariable) {
-          this.sendInvalidatedEvent(["variables"], frame.threadId, frame.frameId);
+          this.sendInvalidatedEvent(
+            ["variables"],
+            frame.threadId,
+            frame.frameId
+          );
         }
       }
       response.body = {
@@ -1790,6 +1806,26 @@ export class GDBDebugSession extends LoggingDebugSession {
     }
   }
 
+  private matchInitialBreakpointStop(breakpoint: mi.MIBreakpointInfo) {
+    const stopAddress = this.pendingInitialBreakpointStop?.frame?.addr;
+    if (!stopAddress) {
+      return;
+    }
+    const breakpointAddresses = [
+      breakpoint.addr,
+      ...(breakpoint.locations?.map((location) => location.addr) ?? [])
+    ];
+    this.stopAtInitialBreakpoint ||= breakpointAddresses.some((address) => address && this.addressesEqual(address, stopAddress));
+  }
+
+  private addressesEqual(left: string, right: string): boolean {
+    try {
+      return BigInt(left) === BigInt(right);
+    } catch {
+      return left.toLowerCase() === right.toLowerCase();
+    }
+  }
+
   protected handleGDBAsync(resultClass: string, resultData: any) {
     const updateIsRunning = () => {
       this.isRunning = this.threads.length ? true : false;
@@ -1816,6 +1852,9 @@ export class GDBDebugSession extends LoggingDebugSession {
         updateIsRunning();
         break;
       case "stopped": {
+        if (!this.isInitialized && resultData.reason === "breakpoint-hit") {
+          this.pendingInitialBreakpointStop = resultData;
+        }
         let suppressHandleGDBStopped = false;
         if (this.gdb.isNonStopMode()) {
           const id = parseInt(resultData["thread-id"], 10);
@@ -1972,14 +2011,13 @@ export class GDBDebugSession extends LoggingDebugSession {
               value: displayValue,
               type: varobj.type,
               memoryReference: `&(${varobj.expression})`,
-              variablesReference:
-                hasChildren
-                  ? this.variableHandles.create({
-                      type: "object",
-                      frameHandle: ref.frameHandle,
-                      varobjName: varobj.varname,
-                    })
-                  : 0,
+              variablesReference: hasChildren
+                ? this.variableHandles.create({
+                    type: "object",
+                    frameHandle: ref.frameHandle,
+                    varobjName: varobj.varname,
+                  })
+                : 0,
             });
           }
         }
@@ -2049,14 +2087,13 @@ export class GDBDebugSession extends LoggingDebugSession {
           value: displayValue,
           type: varobj.type,
           memoryReference: `&(${varobj.expression})`,
-          variablesReference:
-            hasChildren
-              ? this.variableHandles.create({
-                  type: "object",
-                  frameHandle: ref.frameHandle,
-                  varobjName: varobj.varname,
-                })
-              : 0,
+          variablesReference: hasChildren
+            ? this.variableHandles.create({
+                type: "object",
+                frameHandle: ref.frameHandle,
+                varobjName: varobj.varname,
+              })
+            : 0,
         });
       }
     }
@@ -2125,20 +2162,16 @@ export class GDBDebugSession extends LoggingDebugSession {
             name: objChild.exp,
             evaluateName: `${parentClassName}.${objChild.exp}`,
             value: hasChildren
-              ? this.valueForVariableWithChildren(
-                  objChild.value,
-                  objChild.type
-                )
-              : (objChild.value ?? objChild.type),
+              ? this.valueForVariableWithChildren(objChild.value, objChild.type)
+              : objChild.value ?? objChild.type,
             type: objChild.type,
-            variablesReference:
-              hasChildren
-                ? this.variableHandles.create({
-                    type: "object",
-                    frameHandle: ref.frameHandle,
-                    varobjName: childName,
-                  })
-                : 0,
+            variablesReference: hasChildren
+              ? this.variableHandles.create({
+                  type: "object",
+                  frameHandle: ref.frameHandle,
+                  varobjName: childName,
+                })
+              : 0,
           });
         }
       } else {
@@ -2213,14 +2246,13 @@ export class GDBDebugSession extends LoggingDebugSession {
           evaluateName,
           value: displayValue,
           type: child.type,
-          variablesReference:
-            hasChildren
-              ? this.variableHandles.create({
-                  type: "object",
-                  frameHandle: ref.frameHandle,
-                  varobjName,
-                })
-              : 0,
+          variablesReference: hasChildren
+            ? this.variableHandles.create({
+                type: "object",
+                frameHandle: ref.frameHandle,
+                varobjName,
+              })
+            : 0,
         });
       }
     }
@@ -2241,7 +2273,12 @@ export class GDBDebugSession extends LoggingDebugSession {
     const v = (rawValue ?? "").trim();
     const isUnion = /union\s/i.test(type);
     const fullUnionStr = (flatVal ?? "").trim();
-    if (isUnion && fullUnionStr.length > 0 && fullUnionStr !== "{}" && fullUnionStr !== "{...}") {
+    if (
+      isUnion &&
+      fullUnionStr.length > 0 &&
+      fullUnionStr !== "{}" &&
+      fullUnionStr !== "{...}"
+    ) {
       const scalarMatch = fullUnionStr.match(
         /\w+\s*=\s*(0x[0-9a-fA-F]+|\d+)\s*[,}]/
       );
@@ -2291,7 +2328,10 @@ export class GDBDebugSession extends LoggingDebugSession {
     if (!parentVarname) return false;
     try {
       const regDepth = this.getRegisterVarDepth();
-      const rootName = parentVarname.indexOf(".") !== -1 ? parentVarname.split(".")[0] : parentVarname;
+      const rootName =
+        parentVarname.indexOf(".") !== -1
+          ? parentVarname.split(".")[0]
+          : parentVarname;
       const rootVar = this.gdb.varManager.getVarByName(
         frame.frameId,
         frame.threadId,
@@ -2314,7 +2354,11 @@ export class GDBDebugSession extends LoggingDebugSession {
    * @param threadId The ID of the thread to invalidate.
    * @param stackFrameId The ID of the stack frame to invalidate.
    */
-  private sendInvalidatedEvent(areas: string[] = ["variables"], threadId?: number, stackFrameId?: number): void {
+  private sendInvalidatedEvent(
+    areas: string[] = ["variables"],
+    threadId?: number,
+    stackFrameId?: number
+  ): void {
     const ev = new InvalidatedEvent(areas, threadId, stackFrameId);
     this.sendEvent(ev);
   }
@@ -2568,8 +2612,10 @@ export class GDBDebugSession extends LoggingDebugSession {
         continue;
       }
       const rawFlatVal = flatValuesByReg.get(reg) ?? reg_values[i].value;
-      const flatVal = /^[0-9a-fA-F]+$/.test(rawFlatVal) && !rawFlatVal.startsWith("0x")
-        ? "0x" + rawFlatVal : rawFlatVal;
+      const flatVal =
+        /^[0-9a-fA-F]+$/.test(rawFlatVal) && !rawFlatVal.startsWith("0x")
+          ? "0x" + rawFlatVal
+          : rawFlatVal;
       const settled = varCreateResults[i];
       if (settled.status === "rejected") {
         variables.push({

--- a/src/cdtDebugAdapter/adapter/GDBTargetDebugSession.ts
+++ b/src/cdtDebugAdapter/adapter/GDBTargetDebugSession.ts
@@ -564,36 +564,88 @@ export class GDBTargetDebugSession extends GDBDebugSession {
     _args: DebugProtocol.DisconnectArguments
   ): Promise<void> {
     try {
-      if (this.serialPort !== undefined && this.serialPort.isOpen)
-        this.serialPort.close();
-
-      if (this.targetType === "remote") {
-        if (this.gdb.getAsyncMode() && this.isRunning) {
-          // See #295 - this use of "then" is to try to slightly delay the
-          // call to disconnect. A proper solution that waits for the
-          // interrupt to be successful is needed to avoid future
-          // "Cannot execute this command while the target is running"
-          // errors
-          this.gdb
-            .sendCommand("interrupt")
-            .then(() => this.gdb.sendCommand("disconnect"));
-        } else {
-          await this.gdb.sendCommand("disconnect");
+      if (this.serialPort !== undefined && this.serialPort.isOpen) {
+        try {
+          this.serialPort.close();
+        } catch (err) {
+          this.sendEvent(
+            new OutputEvent(
+              `Failed to close UART serial port: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+              "stderr"
+            )
+          );
         }
       }
 
-      await this.gdb.sendGDBExit();
+      if (this.targetType === "remote") {
+        try {
+          if (this.gdb.getAsyncMode() && this.isRunning) {
+            // See #295 - this use of "then" is to try to slightly delay the
+            // call to disconnect. A proper solution that waits for the
+            // interrupt to be successful is needed to avoid future
+            // "Cannot execute this command while the target is running"
+            // errors
+            await this.gdb
+              .sendCommand("interrupt")
+              .then(() => this.gdb.sendCommand("disconnect"));
+          } else {
+            await this.gdb.sendCommand("disconnect");
+          }
+        } catch (err) {
+          this.sendEvent(
+            new OutputEvent(
+              `Failed to disconnect from remote target: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+              "stderr"
+            )
+          );
+        }
+      }
+
+      try {
+        await this.gdb.sendGDBExit();
+      } catch (err) {
+        this.sendEvent(
+          new OutputEvent(
+            `Failed to exit GDB: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+            "stderr"
+          )
+        );
+      }
+
       if (this.killGdbServer) {
-        await this.stopGDBServer();
-        this.sendEvent(new OutputEvent("gdbserver stopped", "server"));
+        try {
+          await this.stopGDBServer();
+          this.sendEvent(new OutputEvent("gdbserver stopped", "server"));
+        } catch (err) {
+          this.sendEvent(
+            new OutputEvent(
+              `Failed to stop gdbserver: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+              "stderr"
+            )
+          );
+        }
       }
       this.sendResponse(response);
     } catch (err) {
-      this.sendErrorResponse(
-        response,
-        1,
-        err instanceof Error ? err.message : String(err)
+      // Still complete disconnect so VS Code can tear down the session
+      // even if OpenOCD/GDB are already gone.
+      this.sendEvent(
+        new OutputEvent(
+          `Disconnect completed with errors: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+          "stderr"
+        )
       );
+      this.sendResponse(response);
     }
   }
 }

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -139,14 +139,27 @@ export class CDTDebugConfigurationProvider
         }
       }
 
-      const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
-        "CONFIG_APP_REPRODUCIBLE_BUILD",
-        folder.uri
-      );
-      if (isAppReproducibleBuildEnabled === "y" && !prefixMapFound) {
-        window.showInformationMessage(
-          `CONFIG_APP_REPRODUCIBLE_BUILD is enabled but no gdbinit prefix map was found.`
-        );
+      const isPostMortemSession =
+        config.sessionID === "core-dump.debug.session.ws" ||
+        config.sessionID === "gdbstub.debug.session.ws";
+      if (!isPostMortemSession && !prefixMapFound) {
+        try {
+          const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
+            "CONFIG_APP_REPRODUCIBLE_BUILD",
+            folder.uri
+          );
+          if (isAppReproducibleBuildEnabled === "y") {
+            window.showInformationMessage(
+              `CONFIG_APP_REPRODUCIBLE_BUILD is enabled but no gdbinit prefix map was found.`
+            );
+          }
+        } catch (error) {
+          Logger.error(
+            "Failed to read CONFIG_APP_REPRODUCIBLE_BUILD from sdkconfig",
+            error as Error,
+            "CDTDebugConfigurationProvider resolveDebugConfiguration"
+          );
+        }
       }
 
       if (

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -72,15 +72,15 @@ export class CDTDebugConfigurationProvider
       await createNewIdfMonitor(folder.uri, true);
     }
     const openOCDManager = OpenOCDManager.init();
-      if (
-        !openOCDManager.isRunning() &&
-        debugConfiguration.sessionID !== "core-dump.debug.session.ws" &&
-        debugConfiguration.sessionID !== "gdbstub.debug.session.ws" &&
-        debugConfiguration.sessionID !== "qemu.debug.session" &&
-        debugConfiguration.runOpenOCD !== false
-      ) {
-        await openOCDManager.start();
-      }
+    if (
+      !openOCDManager.isRunning() &&
+      debugConfiguration.sessionID !== "core-dump.debug.session.ws" &&
+      debugConfiguration.sessionID !== "gdbstub.debug.session.ws" &&
+      debugConfiguration.sessionID !== "qemu.debug.session" &&
+      debugConfiguration.runOpenOCD !== false
+    ) {
+      await openOCDManager.start();
+    }
     return debugConfiguration;
   }
   public async resolveDebugConfiguration(
@@ -120,10 +120,21 @@ export class CDTDebugConfigurationProvider
       const buildDirPath = readParameter("idf.buildPath", folder) as string;
       const preConnectCommands: string[] = [];
       let prefixMapFound = false;
+      const isPostMortemSession =
+        config.sessionID === "core-dump.debug.session.ws" ||
+        config.sessionID === "gdbstub.debug.session.ws";
       if (buildDirPath) {
-        const gdbinitSymbols = join(buildDirPath, "gdbinit", "symbols");
-        if (await pathExists(gdbinitSymbols)) {
-          preConnectCommands.push(`source ${gdbinitSymbols}`);
+        const gdbinitFromBuild = join(buildDirPath, "gdbinit", "gdbinit");
+        if (await pathExists(gdbinitFromBuild)) {
+          preConnectCommands.push(`source ${gdbinitFromBuild}`);
+        } else if (!isPostMortemSession) {
+          preConnectCommands.push(
+            "set remotetimeout 10",
+            "target remote :3333",
+            "monitor reset halt",
+            "maintenance flush register-cache",
+            "thbreak app_main"
+          );
         }
 
         const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
@@ -139,9 +150,6 @@ export class CDTDebugConfigurationProvider
         }
       }
 
-      const isPostMortemSession =
-        config.sessionID === "core-dump.debug.session.ws" ||
-        config.sessionID === "gdbstub.debug.session.ws";
       if (!isPostMortemSession && !prefixMapFound) {
         try {
           const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
@@ -162,59 +170,11 @@ export class CDTDebugConfigurationProvider
         }
       }
 
-      if (
-        config.sessionID !== "core-dump.debug.session.ws" &&
-        config.sessionID !== "gdbstub.debug.session.ws" &&
-        (!config.initCommands || config.initCommands.length === 0)
-      ) {
-        config.initCommands = [
-          "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
-          "mon reset halt",
-          "maintenance flush register-cache",
-        ];
-        if (typeof config.initialBreakpoint === "undefined") {
-          config.initCommands.push(`thb app_main`);
-        } else if (config.initialBreakpoint) {
-          config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`);
+      if (!isPostMortemSession && config.initialBreakpoint) {
+        if (!Array.isArray(config.initCommands)) {
+          config.initCommands = [];
         }
-      }
-
-      if (config.initCommands && Array.isArray(config.initCommands)) {
-        let watchpointNum = "2";
-        try {
-          const sdkWatchpointNum = await getConfigValueFromSDKConfig(
-            "CONFIG_SOC_CPU_WATCHPOINTS_NUM",
-            folder.uri
-          );
-          if (sdkWatchpointNum) {
-            watchpointNum = sdkWatchpointNum;
-          }
-        } catch (error) {
-          Logger.error(
-            "Failed to read CONFIG_SOC_CPU_WATCHPOINTS_NUM from sdkconfig",
-            error as Error,
-            "CDTDebugConfigurationProvider resolveDebugConfiguration"
-          );
-        }
-        config.initCommands = config.initCommands.map((cmd: string) =>
-          cmd.replace(
-            /\{IDF_TARGET_CPU_WATCHPOINT_NUM\}|IDF_TARGET_CPU_WATCHPOINT_NUM/g,
-            watchpointNum
-          )
-        );
-      }
-
-      if (
-        config.sessionID !== "core-dump.debug.session.ws" &&
-        config.sessionID !== "gdbstub.debug.session.ws" &&
-        !config.target
-      ) {
-        config.target = {
-          connectCommands: [
-            "set remotetimeout 20",
-            "target remote localhost:3333",
-          ],
-        };
+        config.initCommands.push(`thb ${config.initialBreakpoint.trim()}`);
       }
 
       if (preConnectCommands.length > 0) {

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -79,7 +79,7 @@ export class CDTDebugConfigurationProvider
       debugConfiguration.sessionID !== "qemu.debug.session" &&
       debugConfiguration.runOpenOCD !== false
     ) {
-      await openOCDManager.start();
+      await openOCDManager.start({ launchedByDebug: true });
     }
     return debugConfiguration;
   }

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -26,16 +26,201 @@ import {
   workspace,
 } from "vscode";
 import { readParameter } from "../idfConfiguration";
-import { getProjectElfFilePath } from "../workspaceConfig";
-import { join } from "path";
-import { pathExists } from "fs-extra";
+import {
+  getProjectDescriptionJson,
+  getProjectElfFilePath,
+} from "../workspaceConfig";
+import { dirname, join } from "path";
+import { pathExists, readFile } from "fs-extra";
 import { verifyAppBinary } from "../espIdf/debugAdapter/verifyApp";
 import { OpenOCDManager } from "../espIdf/openOcd/openOcdManager";
 import { Logger } from "../logger/logger";
-import { getConfigValueFromSDKConfig, getToolchainPath } from "../utils";
+import {
+  execChildProcess,
+  getConfigValueFromSDKConfig,
+  getToolchainPath,
+} from "../utils";
 import { createNewIdfMonitor } from "../espIdf/monitor/command";
 import { ESP } from "../config";
 import { buildFlashAndMonitor } from "../buildFlashMonitor";
+
+/** ESP-IDF generated gdbinit files, in `idf.py gdb` order. */
+const GDBINIT_FILE_NAMES = [
+  "symbols",
+  "prefix_map",
+  "py_extensions",
+  "connect",
+] as const;
+
+/** Expanded by {@link getConnectCommands} rather than sourced like the other files. */
+const GDBINIT_CONNECT_FILE_NAME = "connect";
+
+/** Some GDB builds stall when their Python runtime is unusable, so the probe is bounded. */
+async function isGdbWithPython(gdbPath: string) {
+  try {
+    await execChildProcess(
+      gdbPath,
+      ["--batch-silent", "--ex", "python import os"],
+      dirname(gdbPath),
+      undefined,
+      { cwd: dirname(gdbPath), timeout: 5000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Locates the ESP-IDF generated gdbinit files, preserving the `idf.py gdb` order.
+ * Keys of `gdbinit_files` carry a sort index (`01_symbols`, `02_prefix_map`, ...).
+ */
+async function resolveGdbinitFilePaths(
+  gdbinitFiles: { [key: string]: string } | undefined,
+  buildDirPath: string
+): Promise<Map<string, string>> {
+  const resolved = new Map<string, string>();
+  if (!gdbinitFiles && !buildDirPath) {
+    return resolved;
+  }
+
+  const candidates = gdbinitFiles
+    ? Object.keys(gdbinitFiles)
+        .sort()
+        .map<[string, string]>((key) => [
+          key.replace(/^\d+_/, ""),
+          gdbinitFiles[key],
+        ])
+    : GDBINIT_FILE_NAMES.map<[string, string]>((name) => [
+        name,
+        join(buildDirPath, "gdbinit", name),
+      ]);
+
+  for (const [name, filePath] of candidates) {
+    if (await pathExists(filePath)) {
+      resolved.set(name, filePath);
+    }
+  }
+  return resolved;
+}
+
+async function getGdbinitSourceCommands(
+  gdbinitPaths: Map<string, string>,
+  buildDirPath: string,
+  gdbPath: string
+): Promise<{ commands: string[]; prefixMapFound: boolean }> {
+  const commands: string[] = [];
+  let prefixMapFound = false;
+
+  for (const [name, filePath] of gdbinitPaths) {
+    if (name === GDBINIT_CONNECT_FILE_NAME) {
+      continue;
+    }
+    if (name === "py_extensions" && !(await isGdbWithPython(gdbPath))) {
+      continue;
+    }
+    commands.push(`source ${filePath}`);
+    if (name === "prefix_map") {
+      prefixMapFound = true;
+    }
+  }
+
+  if (!prefixMapFound && buildDirPath) {
+    const legacyPrefixMap = join(buildDirPath, "prefix_map_gdbinit");
+    if (await pathExists(legacyPrefixMap)) {
+      commands.push(`source ${legacyPrefixMap}`);
+      prefixMapFound = true;
+    }
+  }
+
+  return { commands, prefixMapFound };
+}
+
+function getRemoteTargetAddress(target: { host?: string; port?: string }) {
+  const port = target?.port ?? "3333";
+  return target?.host ? `${target.host}:${port}` : `:${port}`;
+}
+
+/** GDB constructs spanning multiple lines, which this flat-list parser cannot handle. */
+const GDB_SCRIPTING_KEYWORDS = /^(define|document|python|if|while|end|source|shell)\b/;
+const GDB_RESUME_COMMAND = /^(c|continue|r|run|start)$/;
+const GDB_APP_MAIN_BREAKPOINT = /^(thb|thbreak|b|br|break)\s+app_main$/;
+const GDB_TARGET_REMOTE_COMMAND = /^target\s+remote\s+\S+$/;
+
+function getDefaultConnectCommands(config: DebugConfiguration) {
+  const commands = [
+    "set remotetimeout 10",
+    `target remote ${getRemoteTargetAddress(config.target)}`,
+    "monitor reset halt",
+    "maintenance flush register-cache",
+  ];
+  if (typeof config.initialBreakpoint === "undefined") {
+    commands.push("thbreak app_main");
+  }
+  return commands;
+}
+
+/**
+ * Expands ESP-IDF's generated `connect` gdbinit file into individual GDB commands.
+ *
+ * The file is replayed instead of sourced so its trailing `continue` can be dropped: the
+ * adapter runs connect commands before sending `InitializedEvent`, so resuming here would
+ * run past breakpoints the client has not inserted yet and hide the resulting stop.
+ *
+ * Returns `undefined` when the file is missing or has a shape this parser does not
+ * understand, so the caller can fall back to {@link getDefaultConnectCommands}.
+ */
+async function getConnectCommands(
+  connectFilePath: string | undefined,
+  config: DebugConfiguration
+): Promise<string[] | undefined> {
+  if (!connectFilePath) {
+    return undefined;
+  }
+  let fileContent: string;
+  try {
+    fileContent = (await readFile(connectFilePath)).toString();
+  } catch (error) {
+    Logger.error(
+      `Failed to read gdbinit connect file ${connectFilePath}`,
+      error as Error,
+      "CDTDebugConfigurationProvider getConnectCommands"
+    );
+    return undefined;
+  }
+
+  const lines = fileContent
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+  if (lines.some((line) => GDB_SCRIPTING_KEYWORDS.test(line))) {
+    return undefined;
+  }
+
+  const usesInitialBreakpointFromConfig =
+    typeof config.initialBreakpoint !== "undefined";
+  const overridesRemoteAddress = !!(config.target?.host || config.target?.port);
+
+  const commands: string[] = [];
+  for (const line of lines) {
+    if (GDB_RESUME_COMMAND.test(line)) {
+      continue;
+    }
+    if (usesInitialBreakpointFromConfig && GDB_APP_MAIN_BREAKPOINT.test(line)) {
+      continue;
+    }
+    if (overridesRemoteAddress && GDB_TARGET_REMOTE_COMMAND.test(line)) {
+      commands.push(`target remote ${getRemoteTargetAddress(config.target)}`);
+      continue;
+    }
+    commands.push(line);
+  }
+
+  // The `CONFIG_IDF_TARGET_LINUX` variant of this file has no remote to attach to.
+  const connectsToTarget = commands.some((cmd) => /^target\s/.test(cmd));
+  return connectsToTarget ? commands : undefined;
+}
 
 export class CDTDebugConfigurationProvider
   implements DebugConfigurationProvider {
@@ -116,38 +301,32 @@ export class CDTDebugConfigurationProvider
       if (!config.gdb) {
         config.gdb = await getToolchainPath(folder.uri, "gdb");
       }
+      // config.gdb may still hold an unresolved ${command:...} variable at this point.
+      const gdbPath = config.gdb.includes("${")
+        ? await getToolchainPath(folder.uri, "gdb")
+        : config.gdb;
 
       const buildDirPath = readParameter("idf.buildPath", folder) as string;
-      const preConnectCommands: string[] = [];
-      let prefixMapFound = false;
       const isPostMortemSession =
         config.sessionID === "core-dump.debug.session.ws" ||
         config.sessionID === "gdbstub.debug.session.ws";
-      if (buildDirPath) {
-        const gdbinitFromBuild = join(buildDirPath, "gdbinit", "gdbinit");
-        if (await pathExists(gdbinitFromBuild)) {
-          preConnectCommands.push(`source ${gdbinitFromBuild}`);
-        } else if (!isPostMortemSession) {
-          preConnectCommands.push(
-            "set remotetimeout 10",
-            "target remote :3333",
-            "monitor reset halt",
-            "maintenance flush register-cache",
-            "thbreak app_main"
-          );
-        }
+      const projectDescription = await getProjectDescriptionJson(folder.uri);
+      const gdbinitPaths = await resolveGdbinitFilePaths(
+        projectDescription?.gdbinitFiles,
+        buildDirPath
+      );
+      const {
+        commands: preConnectCommands,
+        prefixMapFound,
+      } = await getGdbinitSourceCommands(gdbinitPaths, buildDirPath, gdbPath);
 
-        const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
-        if (await pathExists(gdbinitPrefixMap)) {
-          preConnectCommands.push(`source ${gdbinitPrefixMap}`);
-          prefixMapFound = true;
-        } else {
-          const prefixMapGdbinit = join(buildDirPath, "prefix_map_gdbinit");
-          if (await pathExists(prefixMapGdbinit)) {
-            preConnectCommands.push(`source ${prefixMapGdbinit}`);
-            prefixMapFound = true;
-          }
-        }
+      if (!isPostMortemSession) {
+        const connectCommands =
+          (await getConnectCommands(
+            gdbinitPaths.get(GDBINIT_CONNECT_FILE_NAME),
+            config
+          )) ?? getDefaultConnectCommands(config);
+        preConnectCommands.push(...connectCommands);
       }
 
       if (!isPostMortemSession && !prefixMapFound) {

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -116,6 +116,39 @@ export class CDTDebugConfigurationProvider
       if (!config.gdb) {
         config.gdb = await getToolchainPath(folder.uri, "gdb");
       }
+
+      const buildDirPath = readParameter("idf.buildPath", folder) as string;
+      const preConnectCommands: string[] = [];
+      let prefixMapFound = false;
+      if (buildDirPath) {
+        const gdbinitSymbols = join(buildDirPath, "gdbinit", "symbols");
+        if (await pathExists(gdbinitSymbols)) {
+          preConnectCommands.push(`source ${gdbinitSymbols}`);
+        }
+
+        const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
+        if (await pathExists(gdbinitPrefixMap)) {
+          preConnectCommands.push(`source ${gdbinitPrefixMap}`);
+          prefixMapFound = true;
+        } else {
+          const prefixMapGdbinit = join(buildDirPath, "prefix_map_gdbinit");
+          if (await pathExists(prefixMapGdbinit)) {
+            preConnectCommands.push(`source ${prefixMapGdbinit}`);
+            prefixMapFound = true;
+          }
+        }
+      }
+
+      const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
+        "CONFIG_APP_REPRODUCIBLE_BUILD",
+        folder.uri
+      );
+      if (isAppReproducibleBuildEnabled === "y" && !prefixMapFound) {
+        window.showInformationMessage(
+          `CONFIG_APP_REPRODUCIBLE_BUILD is enabled but no gdbinit prefix map was found.`
+        );
+      }
+
       if (
         config.sessionID !== "core-dump.debug.session.ws" &&
         config.sessionID !== "gdbstub.debug.session.ws" &&
@@ -126,33 +159,6 @@ export class CDTDebugConfigurationProvider
           "mon reset halt",
           "maintenance flush register-cache",
         ];
-        const isAppReproducibleBuildEnabled = await getConfigValueFromSDKConfig(
-          "CONFIG_APP_REPRODUCIBLE_BUILD",
-          folder.uri
-        );
-        if (isAppReproducibleBuildEnabled === "y") {
-          const buildDirPath = readParameter("idf.buildPath", folder) as string;
-          if (!buildDirPath) {
-            throw new Error("Failed to get build directory path.");
-          }
-          const gdbinitPrefixMap = join(buildDirPath, "gdbinit", "prefix_map");
-          const gdbinitPrefixMapExists = await pathExists(gdbinitPrefixMap);
-          if (gdbinitPrefixMapExists) {
-            config.initCommands.push(`source ${gdbinitPrefixMap}`);
-          } else {
-            const prefix_map_gdbinit = join(buildDirPath, "prefix_map_gdbinit");
-            const prefix_map_gdbinitExists = await pathExists(
-              prefix_map_gdbinit
-            );
-            if (prefix_map_gdbinitExists) {
-              config.initCommands.push(`source ${prefix_map_gdbinit}`);
-            } else {
-              window.showInformationMessage(
-                `CONFIG_APP_REPRODUCIBLE_BUILD is enabled but no gdbinit prefix map was found.`
-              );
-            }
-          }
-        }
         if (typeof config.initialBreakpoint === "undefined") {
           config.initCommands.push(`thb app_main`);
         } else if (config.initialBreakpoint) {
@@ -166,32 +172,39 @@ export class CDTDebugConfigurationProvider
           | "esp32"
           | "esp32s2"
           | "esp32s3"
+          | "esp32s31"
           | "esp32c2"
           | "esp32c3"
-          | "esp32c6"
-          | "esp32h2"
-          | "esp32p4"
-          | "esp32c4"
           | "esp32c5"
-          | "esp32c61";
-        // Mapping of idfTarget to corresponding CPU watchpoint numbers
+          | "esp32c6"
+          | "esp32c61"
+          | "esp32h2"
+          | "esp32h21"
+          | "esp32h4"
+          | "esp32p4";
+        // SOC_CPU_WATCHPOINTS_NUM from ESP-IDF components/soc/*/include/soc/soc_caps.h
         const idfTargetWatchpointMap: Record<IdfTarget, number> = {
           esp32: 2,
           esp32s2: 2,
           esp32s3: 2,
+          esp32s31: 4,
           esp32c2: 2,
           esp32c3: 8,
+          esp32c5: 3,
           esp32c6: 4,
+          esp32c61: 3,
           esp32h2: 4,
+          esp32h21: 4,
+          esp32h4: 3,
           esp32p4: 3,
-          esp32c4: 2,
-          esp32c5: 4,
-          esp32c61: 4,
         };
+        const watchpointNum = String(
+          idfTargetWatchpointMap[idfTarget as IdfTarget] || 2
+        );
         config.initCommands = config.initCommands.map((cmd: string) =>
           cmd.replace(
-            "{IDF_TARGET_CPU_WATCHPOINT_NUM}",
-            idfTargetWatchpointMap[idfTarget] || 2
+            /\{IDF_TARGET_CPU_WATCHPOINT_NUM\}|IDF_TARGET_CPU_WATCHPOINT_NUM/g,
+            watchpointNum
           )
         );
       }
@@ -207,6 +220,22 @@ export class CDTDebugConfigurationProvider
             "-target-select extended-remote localhost:3333",
           ],
         };
+      }
+
+      if (preConnectCommands.length > 0) {
+        if (!config.target) {
+          config.target = { connectCommands: [] };
+        }
+        if (!Array.isArray(config.target.connectCommands)) {
+          config.target.connectCommands = [];
+        }
+        const connectCommands = config.target.connectCommands as string[];
+        for (let i = preConnectCommands.length - 1; i >= 0; i--) {
+          const cmd = preConnectCommands[i];
+          if (!connectCommands.includes(cmd)) {
+            connectCommands.unshift(cmd);
+          }
+        }
       }
       if (folder && folder.uri && config.verifyAppBinBeforeDebug) {
         const isSameAppBinary = await verifyAppBinary(folder.uri);

--- a/src/cdtDebugAdapter/debugConfProvider.ts
+++ b/src/cdtDebugAdapter/debugConfProvider.ts
@@ -26,7 +26,7 @@ import {
   workspace,
 } from "vscode";
 import { readParameter } from "../idfConfiguration";
-import { getIdfTargetFromSdkconfig, getProjectElfFilePath } from "../workspaceConfig";
+import { getProjectElfFilePath } from "../workspaceConfig";
 import { join } from "path";
 import { pathExists } from "fs-extra";
 import { verifyAppBinary } from "../espIdf/debugAdapter/verifyApp";
@@ -180,40 +180,22 @@ export class CDTDebugConfigurationProvider
       }
 
       if (config.initCommands && Array.isArray(config.initCommands)) {
-        let idfTarget = await getIdfTargetFromSdkconfig(folder.uri);
-        type IdfTarget =
-          | "esp32"
-          | "esp32s2"
-          | "esp32s3"
-          | "esp32s31"
-          | "esp32c2"
-          | "esp32c3"
-          | "esp32c5"
-          | "esp32c6"
-          | "esp32c61"
-          | "esp32h2"
-          | "esp32h21"
-          | "esp32h4"
-          | "esp32p4";
-        // SOC_CPU_WATCHPOINTS_NUM from ESP-IDF components/soc/*/include/soc/soc_caps.h
-        const idfTargetWatchpointMap: Record<IdfTarget, number> = {
-          esp32: 2,
-          esp32s2: 2,
-          esp32s3: 2,
-          esp32s31: 4,
-          esp32c2: 2,
-          esp32c3: 8,
-          esp32c5: 3,
-          esp32c6: 4,
-          esp32c61: 3,
-          esp32h2: 4,
-          esp32h21: 4,
-          esp32h4: 3,
-          esp32p4: 3,
-        };
-        const watchpointNum = String(
-          idfTargetWatchpointMap[idfTarget as IdfTarget] || 2
-        );
+        let watchpointNum = "2";
+        try {
+          const sdkWatchpointNum = await getConfigValueFromSDKConfig(
+            "CONFIG_SOC_CPU_WATCHPOINTS_NUM",
+            folder.uri
+          );
+          if (sdkWatchpointNum) {
+            watchpointNum = sdkWatchpointNum;
+          }
+        } catch (error) {
+          Logger.error(
+            "Failed to read CONFIG_SOC_CPU_WATCHPOINTS_NUM from sdkconfig",
+            error as Error,
+            "CDTDebugConfigurationProvider resolveDebugConfiguration"
+          );
+        }
         config.initCommands = config.initCommands.map((cmd: string) =>
           cmd.replace(
             /\{IDF_TARGET_CPU_WATCHPOINT_NUM\}|IDF_TARGET_CPU_WATCHPOINT_NUM/g,
@@ -230,7 +212,7 @@ export class CDTDebugConfigurationProvider
         config.target = {
           connectCommands: [
             "set remotetimeout 20",
-            "-target-select extended-remote localhost:3333",
+            "target remote localhost:3333",
           ],
         };
       }

--- a/src/cdtDebugAdapter/runOpenOcdWarning.ts
+++ b/src/cdtDebugAdapter/runOpenOcdWarning.ts
@@ -1,0 +1,173 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Wednesday, 9th September 2026
+ * Copyright 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path";
+import {
+  ConfigurationTarget,
+  DebugAdapterTracker,
+  DebugAdapterTrackerFactory,
+  DebugConfiguration,
+  DebugSession,
+  ProviderResult,
+  Uri,
+  l10n,
+  window,
+  workspace,
+} from "vscode";
+import { readParameter } from "../idfConfiguration";
+import { TCLClient } from "../espIdf/openOcd/tcl/tclClient";
+import { Logger } from "../logger/logger";
+
+/** Sessions that never rely on the extension OpenOCD server. */
+const SESSIONS_WITHOUT_OPENOCD = [
+  "core-dump.debug.session.ws",
+  "gdbstub.debug.session.ws",
+  "qemu.debug.session",
+];
+
+function skipsExtensionOpenOCD(session: DebugSession) {
+  return (
+    session.configuration.runOpenOCD === false &&
+    SESSIONS_WITHOUT_OPENOCD.indexOf(session.configuration.sessionID) === -1
+  );
+}
+
+async function isExternalOpenOCDRunning(workspaceFolder: Uri | undefined) {
+  const host = readParameter("openocd.tcl.host", workspaceFolder) as string;
+  const port = readParameter("openocd.tcl.port", workspaceFolder) as number;
+  const tclClient = new TCLClient({ host, port });
+  return tclClient.isOpenOCDServerRunning();
+}
+
+async function setRunOpenOCDInLaunchJson(session: DebugSession) {
+  const folderUri = session.workspaceFolder?.uri;
+  const launchConfig = workspace.getConfiguration("launch", folderUri);
+  const configurations = launchConfig.get<DebugConfiguration[]>(
+    "configurations"
+  );
+  const matchIndex = (configurations ?? []).findIndex(
+    (conf) =>
+      conf.type === session.configuration.type &&
+      conf.name === session.configuration.name
+  );
+  if (matchIndex === -1) {
+    if (folderUri) {
+      await window.showTextDocument(
+        Uri.file(join(folderUri.fsPath, ".vscode", "launch.json"))
+      );
+    }
+    return;
+  }
+  const updatedConfigurations = configurations.slice();
+  updatedConfigurations[matchIndex] = {
+    ...updatedConfigurations[matchIndex],
+    runOpenOCD: true,
+  };
+  await launchConfig.update(
+    "configurations",
+    updatedConfigurations,
+    ConfigurationTarget.WorkspaceFolder
+  );
+  await window.showInformationMessage(
+    l10n.t(
+      "runOpenOCD is now true for '{0}'. Start the debug session again.",
+      session.configuration.name
+    )
+  );
+}
+
+async function warnAboutRunOpenOCD(session: DebugSession) {
+  try {
+    if (await isExternalOpenOCDRunning(session.workspaceFolder?.uri)) {
+      return;
+    }
+  } catch (error) {
+    Logger.error(
+      "Failed to check for an external OpenOCD server",
+      error as Error,
+      "runOpenOcdWarning warnAboutRunOpenOCD"
+    );
+  }
+  const updateLaunchJson = l10n.t("Update launch.json");
+  const selected = await window.showWarningMessage(
+    l10n.t(
+      "The debug session failed and 'runOpenOCD' is false in your launch.json, so the extension did not start OpenOCD and none is listening. Set 'runOpenOCD' to true to let the extension start it, or start OpenOCD yourself before debugging."
+    ),
+    updateLaunchJson
+  );
+  if (selected !== updateLaunchJson) {
+    return;
+  }
+  try {
+    await setRunOpenOCDInLaunchJson(session);
+  } catch (error) {
+    Logger.errorNotify(
+      l10n.t("Failed to update runOpenOCD in launch.json"),
+      error as Error,
+      "runOpenOcdWarning setRunOpenOCDInLaunchJson"
+    );
+  }
+}
+
+/**
+ * Warns when a session configured with `runOpenOCD: false` fails before it is running,
+ * since the most common cause is that no OpenOCD server was started outside the extension.
+ */
+export class RunOpenOCDWarningTrackerFactory
+  implements DebugAdapterTrackerFactory {
+  public createDebugAdapterTracker(
+    session: DebugSession
+  ): ProviderResult<DebugAdapterTracker> {
+    if (!skipsExtensionOpenOCD(session)) {
+      return undefined;
+    }
+    let isSessionStarted = false;
+    let hasWarned = false;
+    const warnOnce = () => {
+      if (isSessionStarted || hasWarned) {
+        return;
+      }
+      hasWarned = true;
+      void warnAboutRunOpenOCD(session);
+    };
+    return {
+      onDidSendMessage(message) {
+        if (
+          !message ||
+          message.type !== "response" ||
+          (message.command !== "attach" && message.command !== "launch")
+        ) {
+          return;
+        }
+        if (message.success) {
+          isSessionStarted = true;
+        } else {
+          warnOnce();
+        }
+      },
+      onError() {
+        warnOnce();
+      },
+      onExit(code) {
+        if (code) {
+          warnOnce();
+        }
+      },
+    };
+  }
+}

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -368,6 +368,7 @@ export class OpenOCDManager extends EventEmitter {
         );
       }
       this.stop();
+      this.emit("close", { code, signal });
     });
     this.updateStatusText(`❇️ ${vscode.l10n.t("OpenOCD Server (Running)")}`);
     OutputChannel.show();

--- a/src/espIdf/openOcd/openOcdManager.ts
+++ b/src/espIdf/openOcd/openOcdManager.ts
@@ -87,6 +87,7 @@ export class OpenOCDManager extends EventEmitter {
   private statusBar: vscode.StatusBarItem;
   private workspace: vscode.Uri;
   private encounteredErrors: boolean = false;
+  private launchedByDebug: boolean = false;
 
   private constructor() {
     super();
@@ -170,6 +171,10 @@ export class OpenOCDManager extends EventEmitter {
     return this.server && !this.server.killed;
   }
 
+  public isLaunchedByDebug(): boolean {
+    return this.launchedByDebug;
+  }
+
   public async promptUserToLaunchOpenOCDServer(): Promise<boolean> {
     const host = idfConf.readParameter("openocd.tcl.host", this.workspace);
     const port = idfConf.readParameter("openocd.tcl.port", this.workspace);
@@ -191,7 +196,7 @@ export class OpenOCDManager extends EventEmitter {
     return true;
   }
 
-  public async start() {
+  public async start(options?: { launchedByDebug?: boolean }) {
     if (this.isRunning()) {
       return;
     }
@@ -300,6 +305,7 @@ export class OpenOCDManager extends EventEmitter {
       cwd: this.workspace.fsPath,
       env: modifiedEnv,
     });
+    this.launchedByDebug = !!options?.launchedByDebug;
     this.server.stderr.on("data", (data) => {
       this.encounteredErrors = true;
       data = typeof data === "string" ? Buffer.from(data) : data;
@@ -378,6 +384,7 @@ export class OpenOCDManager extends EventEmitter {
     if (this.server && !this.server.killed) {
       this.server.kill("SIGKILL");
       this.server = undefined;
+      this.launchedByDebug = false;
       this.updateStatusText(`❌ ${vscode.l10n.t("OpenOCD Server (Stopped)")}`);
       const endMsg = "[Stopped] : OpenOCD Server";
       OutputChannel.appendLine(endMsg, "OpenOCD");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2632,12 +2632,6 @@ export async function activate(context: vscode.ExtensionContext) {
               request: "attach",
               sessionID: "qemu.debug.session",
               gdb: gdbPath,
-              initCommands: [
-                "set remote hardware-watchpoint-limit {IDF_TARGET_CPU_WATCHPOINT_NUM}",
-                "mon reset halt",
-                "maintenance flush register-cache",
-                "thb app_main",
-              ],
               target: {
                 type: "remote",
                 host: "localhost",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -629,6 +629,24 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   });
 
+  openOCDManager.on("close", () => {
+    const session = vscode.debug.activeDebugSession;
+    if (
+      !session ||
+      session.type !== "gdbtarget" ||
+      session.configuration.sessionID === "core-dump.debug.session.ws" ||
+      session.configuration.sessionID === "gdbstub.debug.session.ws" ||
+      session.configuration.sessionID === "qemu.debug.session" ||
+      session.configuration.runOpenOCD === false
+    ) {
+      return;
+    }
+    vscode.window.showWarningMessage(
+      "OpenOCD has stopped. Ending the debug session."
+    );
+    void vscode.debug.stopDebugging(session);
+  });
+
   const kconfigMenusWatcher = vscode.workspace.createFileSystemWatcher(
     "**/config/kconfig_menus.json",
     true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -191,7 +191,6 @@ let covRenderer: CoverageRenderer;
 // OpenOCD  and Debug Adapter Manager
 
 let openOCDManager: OpenOCDManager;
-let isOpenOCDLaunchedByDebug: boolean = false;
 let isDebugRestarted: boolean = false;
 
 // QEMU
@@ -623,8 +622,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   vscode.debug.onDidTerminateDebugSession((e) => {
-    if (isOpenOCDLaunchedByDebug && !isDebugRestarted) {
-      isOpenOCDLaunchedByDebug = false;
+    if (openOCDManager.isLaunchedByDebug() && !isDebugRestarted) {
       openOCDManager.stop();
     }
   });
@@ -1304,14 +1302,6 @@ export async function activate(context: vscode.ExtensionContext) {
       workspaceRoot
     ) as string;
     peripheralTreeProvider.debugSessionStarted(session, svdFile, 16); // Move svdFile and threshold as conf settings
-    if (
-      openOCDManager.isRunning() &&
-      session.type === "gdbtarget" &&
-      session.configuration.sessionID !== "core-dump.debug.session.ws" &&
-      session.configuration.sessionID !== "gdbstub.debug.session.ws"
-    ) {
-      isOpenOCDLaunchedByDebug = true;
-    }
     isDebugRestarted = false;
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,7 @@ import { createSBOM, installEspSBOM } from "./espBom";
 import { selectIdfSetup } from "./versionSwitcher";
 import { CDTDebugConfigurationProvider } from "./cdtDebugAdapter/debugConfProvider";
 import { CDTDebugAdapterDescriptorFactory } from "./cdtDebugAdapter/server";
+import { RunOpenOCDWarningTrackerFactory } from "./cdtDebugAdapter/runOpenOcdWarning";
 import { IdfReconfigureTask } from "./espIdf/reconfigure/task";
 import { ErrorHintProvider, HintHoverProvider } from "./espIdf/hints/index";
 import { installWebsocketClient } from "./espIdf/monitor/checkWebsocketClient";
@@ -1293,6 +1294,13 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.debug.registerDebugAdapterDescriptorFactory(
       "gdbtarget",
       new CDTDebugAdapterDescriptorFactory()
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterTrackerFactory(
+      "gdbtarget",
+      new RunOpenOCDWarningTrackerFactory()
     )
   );
 


### PR DESCRIPTION
## Description

This pull request introduces several improvements and bug fixes to the ESP-IDF VS Code extension, focusing on enhanced debugging configuration, improved error handling during debug sessions, and better support for additional ESP32 targets. The changes also include updates to documentation and minor code cleanups.

**Debugging and Configuration Improvements:**

* Refactored the logic for setting up GDB initialization commands in `CDTDebugConfigurationProvider`, ensuring that prefix map files are sourced if present and providing user feedback if expected files are missing when reproducible builds are enabled. This improves the reliability and clarity of debug configuration setup. [[1]](diffhunk://#diff-e2fa8de3075b5006c67694fcd088159136af77c6f12fdc3dbecf80de0485d0d1L119-R174) [[2]](diffhunk://#diff-e2fa8de3075b5006c67694fcd088159136af77c6f12fdc3dbecf80de0485d0d1R237-R252)
* Expanded the list of supported ESP32 targets and updated the mapping for CPU watchpoint numbers, ensuring correct GDB configuration per target. The placeholder `{IDF_TARGET_CPU_WATCHPOINT_NUM}` (and its braced form) is now correctly replaced in all relevant commands. [[1]](diffhunk://#diff-e2fa8de3075b5006c67694fcd088159136af77c6f12fdc3dbecf80de0485d0d1R188-R220) [[2]](diffhunk://#diff-e7cd97d844562b85fa216d530b6c17ba5ef1196fa5445ffbc240099a8dc30818L161-R161) [[3]](diffhunk://#diff-d6a5b8e6a52479da7d88eda8b06835cc0fbfb07adcae0910ee48f84db2978930L161-R161)

**Debug Session Error Handling:**

* Enhanced error handling in `GDBTargetDebugSession`'s disconnect logic to gracefully handle failures when closing the serial port, disconnecting from the remote target, exiting GDB, or stopping the GDB server. Errors are now reported to the user via output events, but the disconnect process always completes to avoid hanging the session.
* Added logic to detect when OpenOCD stops unexpectedly and automatically end the associated debug session, notifying the user with a warning. [[1]](diffhunk://#diff-52f3a37c5461f3a9923373871914ea79c5405c2d2f75b504bbf269642186fa53R373) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R626-R643)

**Other Improvements and Cleanups:**

* Improved merging and writing of EIM executable arguments in both the EIM launch and notification flows, ensuring that duplicate or conflicting arguments are filtered out and the configuration is updated correctly. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L4478-R4508) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L4505-R4544)
* Minor code cleanups for clarity and consistency, such as more robust parsing of content-length in downloads and improved path handling in Python environment detection. [[1]](diffhunk://#diff-32bdf151a07d1ec0928b1bbbbe6413a780bbbb5fd0aa4c7890a85f4a38f9b6d9L480-R480) [[2]](diffhunk://#diff-0ccfa2b5ac8958888ebfcbcefc4f4ee7086002952fd91deb743a28470bbff72eL124-R142)

**Documentation Updates:**

* Updated both English and Chinese documentation to clarify that the `IDF_TARGET_CPU_WATCHPOINT_NUM` placeholder (including its braced form) is resolved for both default and user-defined `initCommands`. [[1]](diffhunk://#diff-e7cd97d844562b85fa216d530b6c17ba5ef1196fa5445ffbc240099a8dc30818L161-R161) [[2]](diffhunk://#diff-d6a5b8e6a52479da7d88eda8b06835cc0fbfb07adcae0910ee48f84db2978930L161-R161)

Fixes #1824 

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

1. Press F5 to start a debug session.
2. Check the Debug Console. See that symbols and prefix_map are added to the debug session even before connection.
3. During a debug session, stop the OpenOCD Server from running. The debug session should be terminated as well.
4. Observe results.

- Expected behaviour:

Symbols are added to the debug session automatically.

- Expected output:

## How has this been tested?

Manually using steps above.

**Test Configuration**:
* ESP-IDF Version: 5.5.4
* OS (Windows,Linux and macOS): macOS

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified debugger command execution order and connection behavior.
  - Updated launch and Native Debug examples with simplified configurations and standard remote-target commands.
  - Removed the obsolete `debugPort` setting and clarified initial breakpoint behavior.

- **Bug Fixes**
  - Improved debugger disconnection cleanup and error handling.
  - Prevented unnecessary initial breakpoints when none are configured.
  - Improved handling and reporting when OpenOCD sessions close unexpectedly.
  - Added localized OpenOCD status and message text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->