### PR TITLE
fix: improve trace parsing and file opening robustness

### DIFF
--- a/src/espIdf/tracing/appTracePanel.ts
+++ b/src/espIdf/tracing/appTracePanel.ts
@@ -174,8 +174,13 @@ export class AppTracePanel {
   }
   private async openFileAtLineNumber(filePath: string, lineNumber: number) {
     try {
-      const textDocument = await vscode.workspace.openTextDocument(filePath);
-      const selectionRange = textDocument.lineAt(lineNumber - 1).range;
+      const textDocument = await vscode.workspace.openTextDocument(
+        vscode.Uri.file(filePath)
+      );
+      const targetLine = Number.isFinite(lineNumber)
+        ? Math.max(1, Math.min(lineNumber, textDocument.lineCount))
+        : 1;
+      const selectionRange = textDocument.lineAt(targetLine - 1).range;
 
       const column = vscode.window.activeTextEditor
         ? vscode.window.activeTextEditor.viewColumn
@@ -184,7 +189,6 @@ export class AppTracePanel {
         selection: selectionRange,
         viewColumn: column || vscode.ViewColumn.One,
       });
-      // editor.revealRange(selectionRange, vscode.TextEditorRevealType.InCenter);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       Logger.errorNotify(
@@ -238,6 +242,18 @@ export class AppTracePanel {
 
     return funcName;
   }
+  /** Parse addr2line "path:line" without breaking Windows drive letters. */
+  private parseAddr2LineLocation(respStr: string): {
+    filePath: string;
+    lineNumber: string;
+  } {
+    const match = respStr.match(/^(.*?):(\d+)(?::\d+)?(?:\s.*)?$/);
+    if (match) {
+      return { filePath: match[1], lineNumber: match[2] };
+    }
+    return { filePath: respStr, lineNumber: "" };
+  }
+
   private async resolveAddresses({
     addresses,
   }: {
@@ -262,10 +278,8 @@ export class AppTracePanel {
           );
           const resp = await addr2line.run();
           const respStr = resp.toString().trim();
-          const fileSplit = respStr.split(":");
-          const filePath = fileSplit[0];
-          const fileName = filePath.split("/");
-          const lineNumber = fileSplit[1];
+          const { filePath, lineNumber } = this.parseAddr2LineLocation(respStr);
+          const fileName = filePath.split(/[/\\]/);
           const funcName = this.functionNameForAddress(address);
           Object.assign(addresses[address], {
             filePath,
@@ -311,7 +325,8 @@ export class AppTracePanel {
     }
     const sysviewTraceProc = new SysviewTraceProc(
       workspaceRoot,
-      this._traceData.trace.filePath
+      this._traceData.trace.filePath,
+      await getProjectElfFilePath(workspaceRoot)
     );
     const resp = await sysviewTraceProc.parse();
     const respStr = resp.toString();

--- a/src/espIdf/tracing/system-view/parser.ts
+++ b/src/espIdf/tracing/system-view/parser.ts
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-import { AppTraceArchiveItems } from "../tree/appTraceArchiveTreeDataProvider";
-import { window, ProgressLocation } from "vscode";
+import { window, ProgressLocation, workspace } from "vscode";
 import { Logger } from "../../../logger/logger";
 import { SystemViewPanel } from "./panel";
 import { SysviewTraceProc } from "../tools/sysviewTraceProc";
 import { NotificationMode, readParameter } from "../../../idfConfiguration";
+import { getProjectElfFilePath } from "../../../workspaceConfig";
 
 export class SystemViewResultParser {
   public static parseWithProgress(
-    trace: AppTraceArchiveItems,
+    trace: { filePath: string },
     extensionPath: string
   ) {
     const notificationMode = readParameter(
@@ -58,7 +58,11 @@ export class SystemViewResultParser {
     );
   }
   private static async parseSVDATToJSON(filePath: string): Promise<any> {
-    const sysView = new SysviewTraceProc(undefined, filePath);
+    const workspaceRoot = workspace.workspaceFolders?.[0]?.uri;
+    const elfFilePath = workspaceRoot
+      ? await getProjectElfFilePath(workspaceRoot)
+      : undefined;
+    const sysView = new SysviewTraceProc(workspaceRoot, filePath, elfFilePath);
     const resp = await sysView.parse();
     return JSON.parse(resp.toString());
   }

--- a/src/espIdf/tracing/tools/sysviewTraceProc.ts
+++ b/src/espIdf/tracing/tools/sysviewTraceProc.ts
@@ -2,13 +2,13 @@
  * Project: ESP-IDF VSCode Extension
  * File Created: Thursday, 15th August 2019 9:17:30 pm
  * Copyright 2019 Espressif Systems (Shanghai) CO LTD
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,15 +16,46 @@
  * limitations under the License.
  */
 
-import { constants } from "fs";
-import { join } from "path";
+import { constants, existsSync } from "fs";
+import { basename, dirname, join } from "path";
 import * as vscode from "vscode";
 
 import { AbstractTracingToolManager } from "./abstractTracingToolManager";
 
+const CORE_SUFFIX = /^(.+\.svdat)_core\d+$/i;
+
+// Prefer OpenOCD per-core dumps (*.svdat_coreN). Passing them skips the
+// Windows multicore-split path in sysviewtrace_proc.py.
+export function resolveTraceSources(traceFilePath: string): string[] {
+  const directory = dirname(traceFilePath);
+  const baseName = stripCoreSuffix(basename(traceFilePath));
+  const coreSources: string[] = [];
+  for (let core = 0; ; core++) {
+    const coreFile = join(directory, `${baseName}_core${core}`);
+    if (!existsSync(coreFile)) {
+      break;
+    }
+    coreSources.push(toFileUrl(coreFile));
+  }
+  return coreSources.length > 0 ? coreSources : [toFileUrl(traceFilePath)];
+}
+
+function stripCoreSuffix(fileName: string): string {
+  const match = CORE_SUFFIX.exec(fileName);
+  return match ? match[1] : fileName;
+}
+
+function toFileUrl(filePath: string): string {
+  return `file://${filePath.replace(/\\/g, "/")}`;
+}
+
 export class SysviewTraceProc extends AbstractTracingToolManager {
-  constructor(workspaceRoot: vscode.Uri, traceFilePath: string) {
-    super(workspaceRoot, traceFilePath);
+  constructor(
+    workspaceRoot: vscode.Uri,
+    traceFilePath: string,
+    elfFilePath?: string
+  ) {
+    super(workspaceRoot, traceFilePath, elfFilePath);
   }
 
   public async parse(): Promise<Buffer> {
@@ -41,12 +72,14 @@ export class SysviewTraceProc extends AbstractTracingToolManager {
         "sysviewtrace_proc.py tool is not found or not accessible"
       );
     }
-    return await this.parseInternal(
-      "python",
-      ["sysviewtrace_proc.py", "-j", "-b", `file://${this.elfFilePath}`, `file://${this.traceFilePath}`],
-      {
-        cwd: this.appTraceToolsPath(),
-      }
-    );
+    const args = ["sysviewtrace_proc.py", "-j"];
+    if (this.elfFilePath) {
+      // -b expects a filesystem path (not file://), matching IDF / Eclipse usage
+      args.push("-b", this.elfFilePath);
+    }
+    args.push(...resolveTraceSources(this.traceFilePath));
+    return await this.parseInternal("python", args, {
+      cwd: this.appTraceToolsPath(),
+    });
   }
 }

--- a/src/espIdf/tracing/tree/appTraceArchiveTreeDataProvider.ts
+++ b/src/espIdf/tracing/tree/appTraceArchiveTreeDataProvider.ts
@@ -26,6 +26,12 @@ export enum TraceType {
   HeapTrace = 1,
 }
 
+export type AppTraceArchiveReportArgs = {
+  fileName: string;
+  filePath: string;
+  type: TraceType;
+};
+
 export class AppTraceArchiveItems extends vscode.TreeItem {
   public fileName: string;
   public filePath: string;
@@ -122,10 +128,17 @@ export class AppTraceArchiveTreeDataProvider
 
     // Only set command for Heap Trace items - App Trace items will open the file directly
     if (appTraceArchiveNode.type === TraceType.HeapTrace) {
+      // Pass a plain DTO — putting the TreeItem in arguments creates a circular
+      // structure (command.arguments[0] === this) that breaks JSON serialization.
+      const reportArgs: AppTraceArchiveReportArgs = {
+        fileName: appTraceArchiveNode.fileName,
+        filePath: appTraceArchiveNode.filePath,
+        type: appTraceArchiveNode.type,
+      };
       appTraceArchiveNode.command = {
         command: "espIdf.apptrace.archive.showReport",
         title: "Show Report",
-        arguments: [appTraceArchiveNode],
+        arguments: [reportArgs],
       };
       appTraceArchiveNode.iconPath = new vscode.ThemeIcon("pulse");
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { AppTracePanel } from "./espIdf/tracing/appTracePanel";
 import { GdbHeapTraceManager } from "./espIdf/tracing/gdbHeapTraceManager";
 import {
   AppTraceArchiveTreeDataProvider,
-  AppTraceArchiveItems,
+  AppTraceArchiveReportArgs,
   TraceType,
 } from "./espIdf/tracing/tree/appTraceArchiveTreeDataProvider";
 import { AppTraceTreeDataProvider } from "./espIdf/tracing/tree/appTraceTreeDataProvider";
@@ -2949,7 +2949,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand(
     "espIdf.apptrace.archive.showReport",
-    (trace: AppTraceArchiveItems) => {
+    (trace: AppTraceArchiveReportArgs) => {
       if (!trace) {
         Logger.errorNotify(
           vscode.l10n.t(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { AppTracePanel } from "./espIdf/tracing/appTracePanel";
 import { GdbHeapTraceManager } from "./espIdf/tracing/gdbHeapTraceManager";
 import {
   AppTraceArchiveTreeDataProvider,
-  AppTraceArchiveItems,
+  AppTraceArchiveReportArgs,
   TraceType,
 } from "./espIdf/tracing/tree/appTraceArchiveTreeDataProvider";
 import { AppTraceTreeDataProvider } from "./espIdf/tracing/tree/appTraceTreeDataProvider";
@@ -2871,7 +2871,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   registerIDFCommand(
     "espIdf.apptrace.archive.showReport",
-    (trace: AppTraceArchiveItems) => {
+    (trace: AppTraceArchiveReportArgs) => {
       if (!trace) {
         Logger.errorNotify(
           vscode.l10n.t(

--- a/src/views/tracing/components/Calls.vue
+++ b/src/views/tracing/components/Calls.vue
@@ -43,9 +43,9 @@ function percentage() {
   return percentageStr === "(0.00%)" ? "" : percentageStr;
 }
 function openFileAtLine(filePath: string, lineNumber: string) {
-  let lineNumMatches = lineNumber.match(/[0-9]*/);
+  let lineNumMatches = lineNumber.match(/\d+/);
   if (lineNumMatches && lineNumMatches.length) {
-    const lineNumberInt = parseInt(lineNumMatches[0]);
+    const lineNumberInt = parseInt(lineNumMatches[0], 10);
     store.treeOpenFileHandler(filePath, lineNumberInt);
   }
 }

--- a/src/views/tracing/components/Tree.vue
+++ b/src/views/tracing/components/Tree.vue
@@ -14,9 +14,9 @@ function toggle() {
 }
 
 function openFileAtLine(filePath: string, lineNumber: string) {
-  const matches = lineNumber.match(/[0-9]*/);
+  const matches = lineNumber.match(/\d+/);
   if (matches && matches.length) {
-    const lineNumberInt = parseInt(matches[0]);
+    const lineNumberInt = parseInt(matches[0], 10);
     store.treeOpenFileHandler(filePath, lineNumberInt);
   }
 }


### PR DESCRIPTION
## Description

Fix heap tracing on Windows: open archive reports reliably, process multicore *.svdat_coreN dumps, and open leak-table source links with correct Windows paths/line numbers.

Also pass the project ELF as a plain -b path to sysviewtrace_proc.py (instead of file://undefined).

Fixes #XXX

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

1. Build a dual-core ESP32 project with heap tracing enabled and a built ELF.
2. Start OpenOCD, run ESP-IDF: Heap Tracing (start → stop) so files appear under trace/.
3. In ESP-IDF: App Trace Archive, click a Heap Trace item.
4. Confirm the heap tracing report webview opens (Windows: no silent failure / empty panel).
5. If *.svdat_core0 / *_core1 siblings exist, confirm both cores are processed (events/leaks from more than one core).
6. In Possible memory leaks, click a file:line link.
7. Confirm the correct source file opens at the expected line (including Windows C:\… paths).
8. Expected behaviour: report opens from the archive; multicore dumps are merged; leak links navigate correctly.
9. Expected output: valid JSON/report UI without FileNotFoundError / logging noise breaking parse; editor opens at the linked line.

- Expected behaviour:

- everything is working fine, we see table with correct information for 2 cores

## How has this been tested?

use heap tracing feature and click show report

**Test Configuration**:
* ESP-IDF Version:
* OS (Windows,Linux and macOS):

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [ ] PR Self Reviewed
- [ ] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [ ] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from trace results to source files, including accurate line selection and handling of invalid line numbers.
  * Added support for Unix and Windows file paths when resolving source locations.
  * Fixed heap-trace processing by correctly associating project ELF files.
  * Improved OpenOCD trace handling for multi-core trace files, with fallback support when per-core files are unavailable.
  * Improved trace report command reliability and handling of trace metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->