### PR TITLE
Feature/preserve json comments when saving configuration files under `.vscode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2687,6 +2687,7 @@
     "es6-promisify": "^6.0.0",
     "fs-extra": "^8.1.0",
     "interactjs": "^1.9.18",
+    "jsonc-parser": "^3.3.1",
     "marked": "^4.0.12",
     "maska": "^2.1.10",
     "os-browserify": "^0.3.0",

--- a/src/clang/index.ts
+++ b/src/clang/index.ts
@@ -82,7 +82,9 @@ export async function configureClangSettings(
   }
 
   const errors: ParseError[] = [];
-  settingsJson = parse(settingsContent, errors);
+  settingsJson = parse(settingsContent, errors, {
+    allowTrailingComma: true,
+  });
   if (errors.length > 0) {
     Logger.errorNotify(
       "Failed to parse settings.json. Ensure it has valid JSON syntax.",

--- a/src/clang/index.ts
+++ b/src/clang/index.ts
@@ -16,15 +16,16 @@
  * limitations under the License.
  */
 
-import { l10n, Uri, workspace } from "vscode";
+import { l10n, Uri } from "vscode";
 import { isBinInPath } from "../utils";
-import { pathExists, writeJSON, writeFile } from "fs-extra";
+import { pathExists, readFile, writeFile } from "fs-extra";
 import { readParameter } from "../idfConfiguration";
 import { join } from "path";
 import { Logger } from "../logger/logger";
-import { parse } from "jsonc-parser";
+import { ParseError, parse } from "jsonc-parser";
 import { EOL } from "os";
 import { configureEnvVariables } from "../common/prepareEnv";
+import { updateJsonPreservingComments } from "../jsonc/updateJsonPreservingComments";
 
 export async function validateEspClangExists(workspaceFolder: Uri) {
   const modifiedEnv = await configureEnvVariables(workspaceFolder);
@@ -74,28 +75,26 @@ export async function configureClangSettings(
     "settings.json"
   );
   let settingsJson: any = {};
+  let settingsContent = "{}";
   const settingsPathExists = await pathExists(settingsJsonPath);
   if (settingsPathExists) {
-    try {
-      const settingsContent = await workspace.fs.readFile(
-        Uri.file(settingsJsonPath)
-      );
-      settingsJson = parse(settingsContent.toString());
-    } catch (error) {
-      Logger.errorNotify(
-        "Failed to parse settings.json. Ensure it has valid JSON syntax.",
-        error,
-        "clang index configureClangSettings"
-      );
-      return;
-    }
+    settingsContent = await readFile(settingsJsonPath, "utf8");
+  }
+
+  const errors: ParseError[] = [];
+  settingsJson = parse(settingsContent, errors);
+  if (errors.length > 0) {
+    Logger.errorNotify(
+      "Failed to parse settings.json. Ensure it has valid JSON syntax.",
+      new Error(`settings.json parse errors: ${errors.length}`),
+      "clang index configureClangSettings"
+    );
+    return;
   }
 
   await setClangSettings(settingsJson, workspaceFolder, showError);
 
-  await writeJSON(settingsJsonPath, settingsJson, {
-    spaces: 2,
-  });
+  await updateJsonPreservingComments(settingsJsonPath, settingsJson);
 
   await createClangdFile(workspaceFolder);
 }

--- a/src/jsonc/updateJsonPreservingComments.ts
+++ b/src/jsonc/updateJsonPreservingComments.ts
@@ -1,0 +1,92 @@
+/*
+ * Project: ESP-IDF VSCode Extension
+ * File Created: Sunday, 16th August 2026
+ * Copyright 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { applyEdits, modify, ParseError, parse } from "jsonc-parser";
+import { pathExists, readFile, writeFile } from "fs-extra";
+import { isDeepStrictEqual } from "util";
+
+type JsonPath = Array<string | number>;
+
+export async function updateJsonPreservingComments(
+  filePath: string,
+  json: { [key: string]: any },
+  keysToUpdate?: Array<string | JsonPath>
+) {
+  let content = "{}";
+  if (await pathExists(filePath)) {
+    content = await readFile(filePath, "utf8");
+  }
+
+  const errors: ParseError[] = [];
+  const existingJson = parse(content, errors) as { [key: string]: any };
+  if (errors.length > 0) {
+    throw new Error(`Failed to parse JSON file with ${errors.length} errors`);
+  }
+
+  const keys = keysToUpdate ?? getChangedKeys(existingJson, json);
+
+  for (const key of keys) {
+    const path = Array.isArray(key) ? key : [key];
+    content = updateJsonContent(content, path, getValueAtPath(json, path));
+  }
+
+  await writeFile(filePath, content, { encoding: "utf8" });
+}
+
+function getChangedKeys(
+  existingJson: { [key: string]: any } = {},
+  newJson: { [key: string]: any } = {}
+) {
+  const allKeys = new Set([
+    ...Object.keys(existingJson),
+    ...Object.keys(newJson),
+  ]);
+
+  return Array.from(allKeys).filter((key) => {
+    const existingHasKey = Object.prototype.hasOwnProperty.call(existingJson, key);
+    const newHasKey = Object.prototype.hasOwnProperty.call(newJson, key);
+
+    if (existingHasKey !== newHasKey) {
+      return true;
+    }
+
+    return !isDeepStrictEqual(existingJson[key], newJson[key]);
+  });
+}
+
+function getValueAtPath(json: { [key: string]: any }, path: JsonPath) {
+  let current: any = json;
+  for (const part of path) {
+    if (typeof current === "undefined" || current === null) {
+      return undefined;
+    }
+    current = current[part];
+  }
+  return current;
+}
+
+function updateJsonContent(content: string, path: JsonPath, value: any) {
+  const edits = modify(content, path, value, {
+    formattingOptions: {
+      insertSpaces: true,
+      tabSize: 2,
+      eol: content.includes("\r\n") ? "\r\n" : "\n",
+    },
+  });
+  return applyEdits(content, edits);
+}

--- a/src/jsonc/updateJsonPreservingComments.ts
+++ b/src/jsonc/updateJsonPreservingComments.ts
@@ -33,7 +33,9 @@ export async function updateJsonPreservingComments(
   }
 
   const errors: ParseError[] = [];
-  const existingJson = parse(content, errors) as { [key: string]: any };
+  const existingJson = parse(content, errors, {
+    allowTrailingComma: true,
+  }) as { [key: string]: any };
   if (errors.length > 0) {
     throw new Error(`Failed to parse JSON file with ${errors.length} errors`);
   }

--- a/src/jsonc/updateJsonPreservingComments.ts
+++ b/src/jsonc/updateJsonPreservingComments.ts
@@ -38,35 +38,21 @@ export async function updateJsonPreservingComments(
     throw new Error(`Failed to parse JSON file with ${errors.length} errors`);
   }
 
-  const keys = keysToUpdate ?? getChangedKeys(existingJson, json);
-
-  for (const key of keys) {
-    const path = Array.isArray(key) ? key : [key];
-    content = updateJsonContent(content, path, getValueAtPath(json, path));
+  if (keysToUpdate && keysToUpdate.length > 0) {
+    for (const key of keysToUpdate) {
+      const path = Array.isArray(key) ? key : [key];
+      content = applyValueDiff(
+        content,
+        path,
+        getValueAtPath(existingJson, path),
+        getValueAtPath(json, path)
+      );
+    }
+  } else {
+    content = applyValueDiff(content, [], existingJson, json);
   }
 
   await writeFile(filePath, content, { encoding: "utf8" });
-}
-
-function getChangedKeys(
-  existingJson: { [key: string]: any } = {},
-  newJson: { [key: string]: any } = {}
-) {
-  const allKeys = new Set([
-    ...Object.keys(existingJson),
-    ...Object.keys(newJson),
-  ]);
-
-  return Array.from(allKeys).filter((key) => {
-    const existingHasKey = Object.prototype.hasOwnProperty.call(existingJson, key);
-    const newHasKey = Object.prototype.hasOwnProperty.call(newJson, key);
-
-    if (existingHasKey !== newHasKey) {
-      return true;
-    }
-
-    return !isDeepStrictEqual(existingJson[key], newJson[key]);
-  });
 }
 
 function getValueAtPath(json: { [key: string]: any }, path: JsonPath) {
@@ -78,6 +64,87 @@ function getValueAtPath(json: { [key: string]: any }, path: JsonPath) {
     current = current[part];
   }
   return current;
+}
+
+function applyValueDiff(
+  content: string,
+  path: JsonPath,
+  currentValue: any,
+  nextValue: any
+) {
+  if (isDeepStrictEqual(currentValue, nextValue)) {
+    return content;
+  }
+
+  if (Array.isArray(currentValue) && Array.isArray(nextValue)) {
+    return applyArrayDiff(content, path, currentValue, nextValue);
+  }
+
+  if (isObject(currentValue) && isObject(nextValue)) {
+    return applyObjectDiff(content, path, currentValue, nextValue);
+  }
+
+  return updateJsonContent(content, path, nextValue);
+}
+
+function applyObjectDiff(
+  content: string,
+  path: JsonPath,
+  currentObject: { [key: string]: any },
+  nextObject: { [key: string]: any }
+) {
+  for (const key of Object.keys(currentObject)) {
+    if (!Object.prototype.hasOwnProperty.call(nextObject, key)) {
+      content = updateJsonContent(content, [...path, key], undefined);
+    }
+  }
+
+  for (const key of Object.keys(nextObject)) {
+    if (!Object.prototype.hasOwnProperty.call(currentObject, key)) {
+      content = updateJsonContent(content, [...path, key], nextObject[key]);
+      continue;
+    }
+
+    content = applyValueDiff(
+      content,
+      [...path, key],
+      currentObject[key],
+      nextObject[key]
+    );
+  }
+
+  return content;
+}
+
+function applyArrayDiff(
+  content: string,
+  path: JsonPath,
+  currentArray: any[],
+  nextArray: any[]
+) {
+  const sharedLength = Math.min(currentArray.length, nextArray.length);
+  for (let i = 0; i < sharedLength; i++) {
+    content = applyValueDiff(
+      content,
+      [...path, i],
+      currentArray[i],
+      nextArray[i]
+    );
+  }
+
+  for (let i = currentArray.length - 1; i >= nextArray.length; i--) {
+    content = updateJsonContent(content, [...path, i], undefined);
+  }
+
+  for (let i = currentArray.length; i < nextArray.length; i++) {
+    content = updateJsonContent(content, [...path, i], nextArray[i]);
+  }
+
+  return content;
+}
+
+function isObject(value: any): value is { [key: string]: any } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function updateJsonContent(content: string, path: JsonPath, value: any) {

--- a/src/newProject/newProjectPanel.ts
+++ b/src/newProject/newProjectPanel.ts
@@ -17,12 +17,13 @@ import { Logger } from "../logger/logger";
 import { OutputChannel } from "../logger/outputChannel";
 import { INewProjectArgs } from "./newProjectInit";
 import { IComponent } from "../espIdf/idfComponent/IdfComponent";
-import { copy, ensureDir, readFile, writeFile, writeJSON } from "fs-extra";
+import { copy, ensureDir, readFile, writeFile } from "fs-extra";
 import * as utils from "../utils";
 import { IExample } from "../examples/Example";
 import { setCurrentSettingsInTemplate } from "./utils";
 import { NotificationMode, readParameter } from "../idfConfiguration";
 import { createClangdFile } from "../clang";
+import { updateJsonPreservingComments } from "../jsonc/updateJsonPreservingComments";
 import { IdfSetup } from "../eim/types";
 
 export class NewProjectPanel {
@@ -295,9 +296,7 @@ export class NewProjectPanel {
             openOcdConfigs
           );
           await createClangdFile(vscode.Uri.file(newProjectPath));
-          await writeJSON(settingsJsonPath, settingsJson, {
-            spaces: 2,
-          });
+          await updateJsonPreservingComments(settingsJsonPath, settingsJson);
 
           if (components && components.length > 0) {
             const componentsPath = path.join(newProjectPath, "components");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -378,9 +378,11 @@ export async function updateCCppPropertiesJson(
     cCppPropertiesJson.configurations.length
   ) {
     cCppPropertiesJson.configurations[0][fieldToUpdate] = newFieldValue;
-    await updateJsonPreservingComments(cCppPropertiesJsonPath, cCppPropertiesJson, [
-      ["configurations", 0, fieldToUpdate],
-    ]);
+    await updateJsonPreservingComments(
+      cCppPropertiesJsonPath,
+      cCppPropertiesJson,
+      [["configurations", 0, fieldToUpdate]]
+    );
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -366,7 +366,9 @@ export async function updateCCppPropertiesJson(
   }
   const cCppPropertiesContent = await readFile(cCppPropertiesJsonPath, "utf8");
   const parseErrors: ParseError[] = [];
-  const cCppPropertiesJson = parse(cCppPropertiesContent, parseErrors);
+  const cCppPropertiesJson = parse(cCppPropertiesContent, parseErrors, {
+    allowTrailingComma: true,
+  });
   if (parseErrors.length > 0) {
     throw new Error(
       `Failed to parse c_cpp_properties.json with ${parseErrors.length} errors`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,7 @@ import {
   writeJSON,
 } from "fs-extra";
 import { marked } from "marked";
+import { ParseError, parse } from "jsonc-parser";
 import { EOL, platform } from "os";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -43,6 +44,7 @@ import * as sanitizedHtml from "sanitize-html";
 import { isFlashEncryptionEnabled } from "./flash/verifyFlashEncryption";
 import { configureClangSettings } from "./clang";
 import { configureEnvVariables } from "./common/prepareEnv";
+import { updateJsonPreservingComments } from "./jsonc/updateJsonPreservingComments";
 
 const currentFolderMsg = vscode.l10n.t("ESP-IDF: Current Project");
 
@@ -362,16 +364,23 @@ export async function updateCCppPropertiesJson(
   if (!doesPathExists) {
     return;
   }
-  const cCppPropertiesJson = await readJSON(cCppPropertiesJsonPath);
+  const cCppPropertiesContent = await readFile(cCppPropertiesJsonPath, "utf8");
+  const parseErrors: ParseError[] = [];
+  const cCppPropertiesJson = parse(cCppPropertiesContent, parseErrors);
+  if (parseErrors.length > 0) {
+    throw new Error(
+      `Failed to parse c_cpp_properties.json with ${parseErrors.length} errors`
+    );
+  }
   if (
     cCppPropertiesJson &&
     cCppPropertiesJson.configurations &&
     cCppPropertiesJson.configurations.length
   ) {
     cCppPropertiesJson.configurations[0][fieldToUpdate] = newFieldValue;
-    await writeJSON(cCppPropertiesJsonPath, cCppPropertiesJson, {
-      spaces: 2,
-    });
+    await updateJsonPreservingComments(cCppPropertiesJsonPath, cCppPropertiesJson, [
+      ["configurations", 0, fieldToUpdate],
+    ]);
   }
 }
 


### PR DESCRIPTION
## Description

Preserve JSON comments when saving `.vscode/settings.js`, `.vscode/c_cpp_properties,.json`.

Implements #1927 - [Feature Request]: Preserve comments in JSON files under `.vscode`

## Type of change

Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Steps to test this pull request

Provide a list of steps to test changes in this PR and required output

[ONE TIME SETUP]
1. Choose an ESP-IDF project to work with. Any project created from an ESP-IDF sample works 
2. Open `.vscode/settings.json` and add JSON comments (aka `// This is a comment`) in various places in the file. Do the same for `.vscode/c_cpp_properties.json`
3. Save file(s) with comments added
4. Apply this PR, build and install the extension

[TESTS]
1. Open the ESP-IDF project chosen in step 1 above in VS Code and wait for the ESP-IDF extension to activate
2. Trigger a functionality which writes to `.vscode/settings.json` and/or `.vscode/c_cpp_properties.json`. Example of such commands include `ESP-IDF: Set Espressif Device Target` or `ESP-IDF: Select Current ESP-IDF Version` (works best if you have more than one ESP-IDF version installed) or switching from one `cmake` preset to another (my favorite !)

OBSERVE:
1. Comments added to `.vscode/settings.json` and/or `.vscode/c_cpp_properties.json` during [ONE TIME SETUP] above are preserved
2. Comments in `.vscode/c_cpp_properties.json` no longer trigger an ESP-IDF Extension error about being unable to read `.vscode/c_cpp_properties.json`

## How has this been tested?

- Ran test above
- Use the custom ESP_IDF extension for a few days as my daily driver

**Test Configuration**:
* ESP-IDF Version: v6.0.2, v6.1-beta1
* OS (Windows,Linux and macOS): Windows 11

## Dependent components impacted by this PR:

- Component 1
- Component 2

## Checklist
- [x] PR Self Reviewed
- [x] Applied Code formatting
- [ ] Added Documentation
- [ ] Added Unit Test
- [x] Verified on all platforms - Windows,Linux and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Configuration updates now preserve comments, formatting, and line endings in settings files.
* C/C++ properties can be updated without rewriting unrelated configuration content.
* Invalid JSON or JSONC configuration files now report parse errors clearly and are not applied.

## New Features

* Configuration updates support targeted changes while retaining existing content.
* Trailing commas are supported in configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->